### PR TITLE
src: autocomplete: add remaining fish completions

### DIFF
--- a/src/kw.fish
+++ b/src/kw.fish
@@ -28,3 +28,45 @@ complete -c kw -n "__fish_kw_no_commands" -a "codestyle c" -d "Apply checkpatch 
 complete -c kw -n "__fish_kw_no_commands" -a "maintainers m" -d "Return the maintainers and the mailing list"
 complete -c kw -n "__fish_kw_no_commands" -a "explore e" -d "Search for expression on git log or directory"
 complete -c kw -n "__fish_kw_no_commands" -a "help h" -d "Display this help mesage"
+complete -c kw -n "__fish_kw_no_commands" -a "man" -d "Display this help mesage"
+complete -c kw -n "__fish_kw_no_commands" -a "configm g" -d "Config manager"
+
+# disable file completion for commands that doesn't need them
+complete -c kw -n "__fish_seen_subcommand_from build" -f
+complete -c kw -n "__fish_seen_subcommand_from b" -f
+complete -c kw -n "__fish_seen_subcommand_from install" -f
+complete -c kw -n "__fish_seen_subcommand_from i" -f
+complete -c kw -n "__fish_seen_subcommand_from bi" -f
+complete -c kw -n "__fish_seen_subcommand_from prepare" -f
+complete -c kw -n "__fish_seen_subcommand_from p" -f
+complete -c kw -n "__fish_seen_subcommand_from new" -f
+complete -c kw -n "__fish_seen_subcommand_from n" -f
+complete -c kw -n "__fish_seen_subcommand_from mount" -f
+complete -c kw -n "__fish_seen_subcommand_from mo" -f
+complete -c kw -n "__fish_seen_subcommand_from umount" -f
+complete -c kw -n "__fish_seen_subcommand_from um" -f
+complete -c kw -n "__fish_seen_subcommand_from vars" -f
+complete -c kw -n "__fish_seen_subcommand_from v" -f
+complete -c kw -n "__fish_seen_subcommand_from up" -f
+complete -c kw -n "__fish_seen_subcommand_from u" -f
+complete -c kw -n "__fish_seen_subcommand_from help" -f
+complete -c kw -n "__fish_seen_subcommand_from h" -f
+complete -c kw -n "__fish_seen_subcommand_from man" -f
+complete -c kw -n "__fish_seen_subcommand_from g" -f
+complete -c kw -n "__fish_seen_subcommand_from configm" -f
+
+# kw maintainers flags
+complete -c kw -n "__fish_seen_subcommand_from maintainers" -s a -l authors -d "Print file authors"
+complete -c kw -n "__fish_seen_subcommand_from m" -s a -l authors -d "Print file authors"
+
+# kw configm flags
+complete -c kw -n "__fish_seen_subcommand_from configm" -l save -d "Save config file"
+complete -c kw -n "__fish_seen_subcommand_from configm" -l ls -d "List config files under kw management"
+complete -c kw -n "__fish_seen_subcommand_from g" -l save -d "Save config file"
+complete -c kw -n "__fish_seen_subcommand_from g" -l ls -d "List config files under kw management"
+
+# kw ssh flags
+complete -c kw -n "__fish_seen_subcommand_from ssh" -l script -d "List config files under kw management"
+complete -c kw -n "__fish_seen_subcommand_from ssh" -l 'command' -d "List config files under kw management"
+complete -c kw -n "__fish_seen_subcommand_from s" -l script -d "List config files under kw management"
+complete -c kw -n "__fish_seen_subcommand_from s" -l 'command' -d "List config files under kw management"

--- a/tests/fish_completion_test.sh
+++ b/tests/fish_completion_test.sh
@@ -5,6 +5,13 @@
 function suite()
 {
     suite_addTest "testKwCompletion"
+    suite_addTest "testNoCompletion"
+    suite_addTest "testKwMCompletion"
+    suite_addTest "testKwMaintainersCompletion"
+    suite_addTest "testKwConfigmCompletion"
+    suite_addTest "testKwGCompletion"
+    suite_addTest "testKwSSHCompletion"
+    suite_addTest "testKwSCompletion"
 }
 
 function getSortedCompletions()
@@ -16,25 +23,77 @@ function getSortedCompletions()
     local fish_cmd="set PATH $env_path;
                     set fish_complete_path $env_fish_complete_path;
                     source $completion;
-                    complete -C'$1 '"
+                    complete -C'$1'"
 
     fish -c "$fish_cmd" | awk '{print $1}' | sort
 }
 
+function assertCompletion()
+{
+    local command="$1"
+    local expected="$2"
+
+    local sorted_expected="$(echo $expected | awk '{gsub(" ", "\n"); print $0}' | sort)"
+    local sorted_observed="$(getSortedCompletions "$command")"
+
+    if [[ "$sorted_observed" != "$sorted_expected" ]]; then
+    local difference="$(diff <(echo "$sorted_expected") <(echo "$sorted_observed"))"
+    echo $difference > out.out
+    fail "Fish suggestions for '$command' aren't the expected:\n$difference"
+    fi;
+}
+
 function testKwCompletion()
 {
-    local kw_options="explore e build b bi install i prepare p new n ssh s
-                      mount mo umount um vars v up u codestyle c
-                      maintainers m help h"
+    local expected="explore e build b bi install i prepare p new n ssh s mount
+                    mo umount um vars v up u codestyle c maintainers m help h
+                    man g configm"
 
-    local sorted_kw_options="$(echo $kw_options | awk '{gsub(" ", "\n"); print $0}' | sort)"
-    local sorted_kw_fish_completions="$(getSortedCompletions 'kw')"
+    assertCompletion "kw " "$expected"
+}
 
-    if [[ "$sorted_kw_fish_completions" != "$sorted_kw_options" ]]; then
-	local difference="$(diff <(echo "$sorted_kw_options") <(echo "$sorted_kw_fish_completions"))"
-	fail "Fish suggestions and kw commands are not the same:\n$difference"
-    fi;
+function testNoCompletion()
+{
+    local without_file="build b install i bi prepare p new n mount mo umount um
+                       vars v up u help h man configm g ssh s"
 
+    for cmd in $without_file; do assertCompletion "kw $cmd " ""; done
+}
+
+function testKwMCompletion()
+{
+    local expected="-a --authors"
+    assertCompletion "kw m -" "$expected"
+}
+
+function testKwMaintainersCompletion()
+{
+    local expected="-a --authors"
+    assertCompletion "kw maintainers -" "$expected"
+}
+
+function testKwConfigmCompletion
+{
+    local expected="--save --ls"
+    assertCompletion "kw configm -" "$expected"
+}
+
+function testKwGCompletion
+{
+    local expected="--save --ls"
+    assertCompletion "kw g -" "$expected"
+}
+
+function testKwSSHCompletion
+{
+    local expected="--script --command"
+    assertCompletion "kw ssh -" "$expected"
+}
+
+function testKwSCompletion
+{
+    local expected="--script --command"
+    assertCompletion "kw s -" "$expected"
 }
 
 invoke_shunit


### PR DESCRIPTION
In this PR I made the remaining completions. As far as I'm concerned, with this PR `kw` will be totally compatible with `fish`.

Here is a screenshot of a completion for a subcommand:
![image](https://user-images.githubusercontent.com/12701580/58297060-aa81f000-7dac-11e9-83f9-10133d3730c8.png)
