### PR TITLE
src: mk: use of ${configurations[arch]} instead of $MAKE_OPTS

### DIFF
--- a/src/mk.sh
+++ b/src/mk.sh
@@ -43,8 +43,8 @@ function mk_build
     PARALLEL_CORES=$(grep -c ^processor /proc/cpuinfo)
   fi
 
-  say "make -j$PARALLEL_CORES $MAKE_OPTS"
-  make -j$PARALLEL_CORES $MAKE_OPTS
+  say "make ARCH="${configurations[arch]}" -j$PARALLEL_CORES"
+  make ARCH="${configurations[arch]}" -j$PARALLEL_CORES
 }
 
 function mk_install


### PR DESCRIPTION
Remove $MAKE_OPTS and replace by ${configurations[arch]}
in mk_build function

Fixes #63 

Signed-off-by: Rodrigo Ribeiro Carvalho <rodrigorsdc@gmail.com>

