### PR TITLE
Some small fixes to use the newly created organization in links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ firefox build/index.html
 
 We are happy that you want to help us! If you are looking for a good starting
 point, check
-[those issues](https://github.com/rodrigosiqueira/kworkflow/labels/good%20first%20issue)
+[those issues](https://github.com/kworkflow/kworkflow/labels/good%20first%20issue)
 and don't forget to read our
 [Contribuitor's Guide](https://siqueira.tech/doc/kw/content/howtocontribute.html)
 (or [howtocontribute file](documentation/content/howtocontribute.rst)).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ We are happy that you want to help us! If you are looking for a good starting
 point, check
 [those issues](https://github.com/kworkflow/kworkflow/labels/good%20first%20issue)
 and don't forget to read our
-[Contribuitor's Guide](https://siqueira.tech/doc/kw/content/howtocontribute.html)
+[Contribuitor's Guide](https://flusp.ime.usp.br/doc/kw/content/howtocontribute.html)
 (or [howtocontribute file](documentation/content/howtocontribute.rst)).
 
 # License

--- a/documentation/content/howtocontribute.rst
+++ b/documentation/content/howtocontribute.rst
@@ -20,7 +20,9 @@ please check https://git-scm.com/docs/SubmittingPatches/
 
 Development Cycle and Branches
 ------------------------------
-Our development cycle relies on two different branches:
+Kw's development happens in GitHub. The official repository can be found at
+https://github.com/kworkflow/kworkflow/. Our development cycle relies on two
+different branches:
 
 1. **master**: We maintain the kw stable version in the master branch, and we
 try our best to keep master working well for final users. If you only want to
@@ -45,7 +47,7 @@ development cycle.
 .. note::
     One of our main goals is to keep kw stable. In this sense, **if you send a
     new patch do not forget to add tests**. You might also want to fork `kw at
-    github <https://github.com/rodrigosiqueira/kworkflow/>`_ and allow
+    github <https://github.com/kworkflow/kworkflow/>`_ and allow
     `travis-ci <https://travis-ci.org/>`_ builds for it, to automatically run
     the test in the cloud. If you want to know more about tests, take a look at
     `About Tests` page.


### PR DESCRIPTION
We now have https://github.com/kworkflow/kworkflow/, let's use it in links instead of the old repo location. Also use FLUSP's hosting of the docs when linking to online docs.