### PR TITLE
Implement system-wide installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+PREFIX = ${DESTDIR}/usr
+STDDIR = ${PREFIX}/share/kw
+MANDIR = ${PREFIX}/share/man
+ACDIR = ${PREFIX}/share/bash-completion/completions
+
+all:
+	@echo "kworkflow is a shell script program. Try \"make install\""
+
+bash-autocomplete:
+	@install -v -d ${ACDIR}
+	@install -v -m 0755 -T src/bash_autocomplete.sh ${ACDIR}/kw
+
+install: bash-autocomplete
+	@install -v -d ${MANDIR}/man1
+	rst2man < documentation/man/kw.rst > ${MANDIR}/man1/kw.1
+	@install -v -d ${STDDIR}/src
+	@install -v -d ${STDDIR}/sounds
+	@install -v -d ${STDDIR}/etc
+	@install -v -d ${STDDIR}/deploy_rules
+	@install -v -m 0644 src/* ${STDDIR}/src
+	@chmod 755 ${STDDIR}/src/kw.fish
+	@rm -v ${STDDIR}/src/bash_autocomplete.sh
+	@install -v -m 0644 sounds/* ${STDDIR}/sounds
+	@install -v -m 0644 etc/* ${STDDIR}/etc
+	@cp -vr deploy_rules ${STDDIR}/deploy_rules
+	@install -v kw ${STDDIR}
+	@ln -s ${STDDIR}/kw ${PREFIX}/bin/kw
+
+remove-bash-autocomplete:
+	@rm -vrf \
+		${ACDIR}/kw
+
+uninstall: remove-bash-autocomplete
+	@rm -vrf \
+		${STDDIR} \
+		${MANDIR}/man1/kw.1 \
+		${PREFIX}/bin/kw
+clean:
+	@rm -vrf \
+		build/
+
+.PHONY: build-man install uninstall

--- a/etc/kworkflow.config
+++ b/etc/kworkflow.config
@@ -38,7 +38,7 @@ alert=n
 
 # Command to run for sound completion alert (This command will be executed in
 # the background)
-sound_alert_command=paplay INSTALLPATH/sounds/complete.wav
+sound_alert_command=paplay /usr/share/kw/sounds/complete.wav &
 
 # Command to run for visual completion alert (This command will be executed in
 # the background)

--- a/kw
+++ b/kw
@@ -1,10 +1,14 @@
 #!/bin/bash
 
 # Set required variables
+CURDIR=$(dirname $(realpath "$0"))
+
+export CURDIR
+
 EASY_KERNEL_WORKFLOW=${EASY_KERNEL_WORKFLOW:-"kw"}
-src_script_path=${src_script_path:-"$HOME/.config/$EASY_KERNEL_WORKFLOW/src"}
+src_script_path=${src_script_path:-"$CURDIR/src"}
 external_script_path=${external_script_path:-"$HOME/.config/$EASY_KERNEL_WORKFLOW/external"}
-etc_files_path=${etc_files_path:-"$HOME/.config/$EASY_KERNEL_WORKFLOW/etc"}
+etc_files_path=${etc_files_path:-"$CURDIR/etc"}
 config_files_path=${config_files_path:-"$HOME/.config/$EASY_KERNEL_WORKFLOW"}
 
 # Export external variables required by kworkflow
@@ -167,5 +171,12 @@ function kw()
       ;;
   esac
 }
+
+# If user home doesn't contain config files
+if [ ! -d "$HOME/.config/kw" ]; then
+    install -d "$HOME/.config/kw"
+    cp -a "${CURDIR}/etc/." "${config_files_path}"
+    sed -i "s/USERKW/$USER/g" "${config_files_path}/kworkflow.config"
+fi
 
 kw "$@"

--- a/src/commons.sh
+++ b/src/commons.sh
@@ -59,7 +59,7 @@ function load_configuration()
   local local_config_path=$PWD/kworkflow.config
 
   # First, load the global configuration
-  parse_configuration $etc_files_path/kworkflow.config
+  parse_configuration $config_files_path/kworkflow.config
 
   # Second, check if has a local file and override values
   if [ -f $local_config_path ] ; then

--- a/src/vm.sh
+++ b/src/vm.sh
@@ -101,7 +101,7 @@ function vm_ssh
 
 function vm_prepare
 {
-  local path_ansible=$HOME/.config/kw/deploy_rules/
+  local path_ansible=$CURDIR/deploy_rules/
   local current_path=$PWD
   local ret=0
   say "Deploying with Ansible, this will take some time"

--- a/tests/commons_test.sh
+++ b/tests/commons_test.sh
@@ -52,7 +52,7 @@ function testDefaultConfigFile
       [ssh_port]="2222"
       [mount_point]="/home/USERKW/p/mount"
       [alert]="n"
-      [sound_alert_command]="paplay INSTALLPATH/sounds/complete.wav"
+      [sound_alert_command]="paplay /usr/share/kw/sounds/complete.wav &"
       [visual_alert_command]="notify-send -i checkbox -t 10000 \"kw\" \"Command: \\\\\"\$COMMAND\\\\\" completed!\""
     )
 


### PR DESCRIPTION
This patch add a Makefile with a few targets in order to add
a system-wide installation.

Because of the new install destination, we modify several files
to ensure a correct files paths and correctness of tests.

Now every call of 'kw' will trigger a verification whether user's HOME
has a .config/kw directory. If not, that dir will be create with
kworkflow.config file.

Fixes #50