### PR TITLE
Drop prepare feature

### DIFF
--- a/documentation/content/installanduninstall.rst
+++ b/documentation/content/installanduninstall.rst
@@ -16,7 +16,6 @@ following dependencies:
 
 * libguestfs
 * Qemu
-* Ansible
 * Bash
 * git
 * python-docutils

--- a/documentation/man/kw.rst
+++ b/documentation/man/kw.rst
@@ -69,18 +69,6 @@ specific target, and finally umounts the QEMU image.
 .. note::
   **Only run this command after you turn off your VM**.
 
-p, prepare
-~~~~~~~~~~
-**(EXPERIMENTAL)** Starting from a generic image, *prepare* sets up the
-necessary packages, files, etc. inside the QEMU image so that it is ready for
-development work. For this to work, you have to:
-
-1. Add your public key in the VM in the authorized_keys file.
-
-2. Remove the requirement for password in the VM to become root.
-
-This command (currently) uses Ansible playbooks.
-
 COMMANDS FOR WORKING WITH CODE
 ------------------------------
 Projects that have a similar workflow to the Linux Kernel usually have a set of
@@ -164,8 +152,8 @@ and **install** commands.
 alert=[*vs|sv,v,s,n*]
 ~~~~~~~~~~~~~~~~~~~~~
 Some commands take considerable time to execute. **kw** gives you an option to
-be notified when they finish. The commands *prepare*, *build*, *install*,
-*mount*, *umount*, new and *bi* offer this feature.
+be notified when they finish. The commands *build*, *install*, *mount*,
+*umount*, new and *bi* offer this feature.
 
 1. *v* enables visual notification.
 

--- a/kw
+++ b/kw
@@ -50,16 +50,6 @@ function kw()
         vm_up
       )
       ;;
-    prepare|p)
-      (
-        . "$src_script_path"/vm.sh --source-only
-
-        vm_prepare
-        local ret=$?
-        alert_completion "kw prepare" "$1"
-        return $ret
-      )
-      ;;
     build|b)
       (
         . "$src_script_path"/mk.sh --source-only

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -6,7 +6,7 @@ _kw_autocomplete()
     COMPREPLY=()
     current_command="${COMP_WORDS[COMP_CWORD]}"
     previous_command="${COMP_WORDS[COMP_CWORD-1]}"
-    kw_options="explore e build b bi install i prepare p new n ssh s
+    kw_options="explore e build b bi install i new n ssh s
                 mount mo umount um vars v up u codestyle c configm g
                 maintainers m help h"
 

--- a/src/help.sh
+++ b/src/help.sh
@@ -13,7 +13,6 @@ function kworkflow-help()
     "\tbuild,b - Build Kernel and modules\n" \
     "\tinstall,i - Install modules\n" \
     "\tbi - Build and install modules\n" \
-    "\tprepare,p - Deploy basic environment in the VM\n" \
     "\tnew,n - Install new Kernel image\n" \
     "\tmount,mo - Mount partition with qemu-nbd\n" \
     "\tumount,um - Umount partition created with qemu-nbd\n" \

--- a/src/kw.fish
+++ b/src/kw.fish
@@ -17,7 +17,6 @@ complete -c kw -n __fish_kw_no_commands -f
 complete -c kw -n "__fish_kw_no_commands" -a "build b" -d "Build Kernel and modules"
 complete -c kw -n "__fish_kw_no_commands" -a "install i" -d "Install modules"
 complete -c kw -n "__fish_kw_no_commands" -a "bi" -d "Build and install modules"
-complete -c kw -n "__fish_kw_no_commands" -a "prepare p" -d "Deploy basic environment in the VM"
 complete -c kw -n "__fish_kw_no_commands" -a "new n" -d "Install new Kernel image"
 complete -c kw -n "__fish_kw_no_commands" -a "ssh s" -d "Enter in the vm"
 complete -c kw -n "__fish_kw_no_commands" -a "mount mo" -d "Mount partition with qemu-nbd"

--- a/src/vm.sh
+++ b/src/vm.sh
@@ -98,16 +98,3 @@ function vm_ssh
   say "ssh $port $target $opts"
   eval "ssh $port $target $opts"
 }
-
-function vm_prepare
-{
-  local path_ansible=$HOME/.config/kw/deploy_rules/
-  local current_path=$PWD
-  local ret=0
-  say "Deploying with Ansible, this will take some time"
-  cd $path_ansible
-  ansible-playbook kworkflow.yml --extra-vars "user=$USER"
-  ret=$?
-  cd $current_path
-  return $ret
-}

--- a/tests/fish_completion_test.sh
+++ b/tests/fish_completion_test.sh
@@ -23,7 +23,7 @@ function getSortedCompletions()
 
 function testKwCompletion()
 {
-    local kw_options="explore e build b bi install i prepare p new n ssh s
+    local kw_options="explore e build b bi install i new n ssh s
                       mount mo umount um vars v up u codestyle c
                       maintainers m help h"
 


### PR DESCRIPTION
When we started to develop kw, we want to make the Kernel developer's
life as easy as possible. For this reason, we added a feature named
prepare that uses Ansible scripts to put a VM in a well-known state.
However, after a long time of experiments, we realize that it is hard to
maintain such feature generic, and it also adds much complexity.
Additionally, some people start to package kw for Arch and Debian, which
means that Ansible represents another dependency for kworkflow. For all
of these reasons, we decided to drop this feature because it adds much
complexity, and the final result does not bring many benefits for
end-users.

Signed-off-by: Rodrigo Siqueira <rodrigosiqueiramelo@gmail.com>