### PR TITLE
.travis.yml: re-enable email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,8 @@ script:
   - ./setup.sh --html
   - ./setup.sh -i
 
-# Disable notifications by email for now are there're some issues to be solved
-# (#126 and #127) that still makes the tests fail at travis-ci (and we don't
-# want emails for them). TODO: remove this once the issues are solved.
-notifications:
-  email: false
+notifications:  
+  email:   
+    on_success: never  
+    on_failure: always
 


### PR DESCRIPTION
We previously disabled them because of issues #126 and #127, which would
make travis-ci always fail with the state of the codebase at that time.
Since the problem was already solved (even though #126 is still to be
solved), let's revoke the email notification prohibition.

Note: we should also consider whether we want email notifications on failures. I personally quite like it, but what do you think, @rodrigosiqueira ?