### PR TITLE
kwlib: Rework get_from_colon to make it generic

### DIFF
--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -1,33 +1,44 @@
 # NOTE: src/kw_config_loader.sh must be included before this file
 
+# A common task used inside kw is a string separation based on a delimiter, for
+# this reason, this function tries to handle this scenario by getting a
+# delimiter character followed by the position that the users want to retrieve.
+# For example:
 # In the kw code, we use the pattern "<STRING1>:<STRING2>" for handling IP and
-# port, this function is a helper that expects a string with ':' and positional
-# value. It returns the value represented by position.
+# port, we can use get_based_on_delimiter() helper to handle the ':' delimiter
+# and based on the positional value the user can get the <STRING1> or
+# <STRING2>.
 #
 # @string: String formated as <STRING1>:<STRING2>
-# @position: We use 1 for specifying the string before ':' and 2 for the string
-#            after ':'
+# @delimiter: A delimiter character
+# @position: The string position we want after @delimiter
 #
 # Returns:
 # Return a "string" corresponding to the position number and a code value that
-# specify the result (useful for checking if something went wrong). Probably,
-# you want to execute this function is a subshell and save the output in a
-# variable.
-function get_from_colon()
+# specify the result (useful for checking if something went wrong). In case of
+# error, "string" is displayed in the echo command and EINVAL code is
+# returned.Probably, you want to execute this function is a subshell and save
+# the output in a variable.
+function get_based_on_delimiter()
 {
   local string="$1"
-  local position="$2"
+  local delimiter="$2"
+  local position="$3"
   local output=""
   local ret=0
 
-  output=$(echo "$string" | grep -i ":")
+  delimiter=${delimiter:-":"}
+
+  output=$(echo "$string" | grep -i "$delimiter")
   if [[ "$?" != 0 ]]; then
-    return 22 # EINNVAL
+    echo "$string"
+    return 22 # EINVAL
   fi
 
-  output=$(echo "$string" | cut -d : -f"$position")
+  output=$(echo "$string" | cut -d "$delimiter" -f"$position")
   if [[ -z "$output" ]]; then
-    ret=22 # EINNVAL
+    output="$string"
+    ret=22 # EINVAL
   fi
   echo "$output"
   return "$ret"

--- a/tests/kwlib_test.sh
+++ b/tests/kwlib_test.sh
@@ -14,7 +14,7 @@ function suite
   suite_addTest "joinPathTest"
   suite_addTest "findKernelRootTest"
   suite_addTest "isAPatchTest"
-  suite_addTest "get_from_colon_Test"
+  suite_addTest "get_based_on_delimiter_Test"
 }
 
 function setupFakeOSInfo
@@ -201,32 +201,63 @@ function isAPatchTest
   true # Reset return value
 }
 
-function get_from_colon_Test
+function get_based_on_delimiter_Test
 {
-  local correct_str="IP:PORT"
+  local ID
+  local ip_port_str="IP:PORT"
+  local hostname="kw@remote-machine"
+  local a_weird_pattern="IP:PORT:kw@remote-machine"
   local incorrect_str="IPPORT"
 
-  output=$(get_from_colon "$correct_str" 1)
+  ID=1
+  output=$(get_based_on_delimiter "$ip_port_str" ":" 1)
   ret="$?"
 
-  assertEquals "We should find IP" "IP" "$output"
-  assertEquals "We expected 0 as a return" 0 "$ret"
+  assertEquals "$ID - We should find IP" "IP" "$output"
+  assertEquals "$ID - We expected 0 as a return" 0 "$ret"
 
-  output=$(get_from_colon "$correct_str" 2)
+  ID=2
+  output=$(get_based_on_delimiter "$ip_port_str" ":" 2)
   ret="$?"
 
-  assertEquals "We should find PORT" "PORT" "$output"
-  assertEquals "We expected 0 as a return" 0 "$ret"
+  assertEquals "$ID - We should find PORT" "PORT" "$output"
+  assertEquals "$ID - We expected 0 as a return" 0 "$ret"
 
-  output=$(get_from_colon "$correct_str" 3)
+  ID=3
+  output=$(get_based_on_delimiter "$ip_port_str" ":" 3)
   ret="$?"
-  assertEquals "We expected an empty string" "" "$output"
-  assertEquals "We expected 22 as a return" 22 "$ret"
+  assertEquals "$ID - We expected the same string" "$ip_port_str" "$output"
+  assertEquals "$ID - We expected 22 as a return" 22 "$ret"
 
-  output=$(get_from_colon "$incorrect_str" 1)
+  ID=4
+  output=$(get_based_on_delimiter "$incorrect_str" ":" 1)
   ret="$?"
-  assertEquals "We expected an empty string" "" "$output"
-  assertEquals "We expected 22 as a return" 22 "$ret"
+  assertEquals "$ID - We expected the same string" "$incorrect_str" "$output"
+  assertEquals "$ID - We expected 22 as a return" 22 "$ret"
+
+  ID=5
+  output=$(get_based_on_delimiter "$hostname" "@" 1)
+  ret="$?"
+  assertEquals "$ID - We used $hostname, @, and 1 args; we should see kw" "kw" "$output"
+  assertEquals "$ID - We expected 0 as a return" 0 "$ret"
+
+  ID=6
+  output=$(get_based_on_delimiter "$hostname" "@" 2)
+  ret="$?"
+  assertEquals "$ID - We used $hostname, @, and 2 args; we should see remote-machine" "remote-machine" "$output"
+  assertEquals "$ID - We expected 0 as a return" 0 "$ret"
+
+  ID=7
+  output=$(get_based_on_delimiter "$a_weird_pattern" "@" 2)
+  ret="$?"
+  assertEquals "$ID - We used $a_weird_pattern, @, and 2 args; we should see remote-machine" "remote-machine" "$output"
+  assertEquals "$ID - We expected 0 as a return" 0 "$ret"
+
+  output=$(get_based_on_delimiter "$a_weird_pattern" ":" 2)
+  ret="$?"
+  assertEquals "$ID - We used $a_weird_pattern, :, and 2 args; we should see PORT" "PORT" "$output"
+  assertEquals "$ID - We expected 0 as a return" 0 "$ret"
+
 }
 
 invoke_shunit


### PR DESCRIPTION
We have the function get_from_colon() which is intended to handle
strings that have ':' character, this is useful for handling IP:PORT
format. However, the nature of this function could be easily promoted to
something more generic in order to make it more powerful; for this
reason, this commit rename get_from_colon() to get_based_on_delimiter()
and adds a new parameter that indicates the character delimiter that
should be used. Rework this function also solve the issue of handling
hostname in the parameter `ssh_ip` on `kworkflow.config`, after this
change users can finally use `ssh_ip=username@hotname`.

Signed-off-by: Rodrigo Siqueira <rodrigosiqueiramelo@gmail.com>