### PR TITLE
src: version: Add version output

### DIFF
--- a/documentation/man/kw.rst
+++ b/documentation/man/kw.rst
@@ -232,6 +232,10 @@ h, help
 ~~~~~~~
 Show basic help.
 
+version, --version, -v
+~~~~~~~~~~~~~~~~~~~~~~
+Show kworkflow version.
+
 ABOUT kworflow.config
 =====================
 

--- a/kw
+++ b/kw
@@ -97,7 +97,7 @@ function kw()
         vm_ssh $@
       )
       ;;
-    vars|v)
+    vars)
       (
         . "$src_script_path"/kw_config_loader.sh --source-only
 
@@ -144,6 +144,13 @@ function kw()
         . $src_script_path/help.sh --source-only
 
         kworkflow-man
+      )
+      ;;
+    version|--version|-v)
+      (
+        . "$src_script_path"/help.sh --source-only
+
+        kworkflow_version
       )
       ;;
     *)

--- a/setup.sh
+++ b/setup.sh
@@ -135,12 +135,27 @@ function synchronize_files()
   say "$SEPARATOR"
 }
 
+function update_version()
+{
+  local head_hash=$(git rev-parse --short HEAD)
+  local branch_name=$(git rev-parse --short --abbrev-ref HEAD)
+  local base_version=$(cat "$INSTALLTO/$SRCDIR/VERSION" | head -n 1)
+
+  cat > "$INSTALLTO/$SRCDIR/VERSION" <<EOF
+$base_version
+Branch: $branch_name
+Commit: $head_hash
+EOF
+}
+
 function install_home()
 {
   # First clean old installation
   clean_legacy
-  # Synchronize of vimfiles
+  # Synchronize source files
   synchronize_files
+  # Update version based on the current branch
+  update_version
 }
 
 # Options

--- a/src/VERSION
+++ b/src/VERSION
@@ -1,0 +1,3 @@
+alpha
+Branch: master
+Commit: 8870b67242c

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -7,8 +7,8 @@ _kw_autocomplete()
     current_command="${COMP_WORDS[COMP_CWORD]}"
     previous_command="${COMP_WORDS[COMP_CWORD-1]}"
     kw_options="explore e build b bi init new n ssh s
-                mount mo umount um vars v up u codestyle c configm g
-                maintainers m deploy d help h"
+                mount mo umount um vars up u codestyle c configm g
+                maintainers m deploy d help h version --version -v"
 
     # By default, autocomplete with kw_options
     if [[ ${previous_command} == kw ]] ; then

--- a/src/help.sh
+++ b/src/help.sh
@@ -22,6 +22,7 @@ function kworkflow-help()
     "\t                             the mailing list. \"-a\" also\n" \
     "\t                             prints files authors\n" \
     "\thelp,h - displays this help mesage\n" \
+    "\tversion,--version,-v - show kw version\n" \
     "\tman - Show manual\n"
 
   echo -e "kw explore:\n" \
@@ -64,4 +65,11 @@ function kworkflow-man()
     fi
 
     man kw
+}
+
+function kworkflow_version()
+{
+  local version_path="$src_script_path/VERSION"
+
+  cat "$version_path"
 }


### PR DESCRIPTION
Currently, we don't have a mechanism to show kw version, this commit
introduces this option. Notice that `setup.sh` update the version during
the installation, however, we keep a new file named VERSION with the
generic version info for distro packages.

Closes #163

Signed-off-by: Rodrigo Siqueira <rodrigosiqueiramelo@gmail.com>