### PR TITLE
kw: small issue on u/mount alert message

### DIFF
--- a/kw
+++ b/kw
@@ -34,7 +34,7 @@ function kw()
 
         vm_mount
         local ret=$?
-        alert_completion "kw build" "$1"
+        alert_completion "kw mount" "$1"
         return $ret
       )
       ;;
@@ -44,7 +44,7 @@ function kw()
 
         vm_umount
         local ret=$?
-        alert_completion "kw build" "$1"
+        alert_completion "kw umount" "$1"
         return $ret
       )
       ;;


### PR DESCRIPTION
After u/mount command an alert is exibited, however the alert
showed a message of -build (sic) completion-. This patch solve this
small issue.

Signed-off-by: Melissa Wen <melissa.srw@gmail.com>