### PR TITLE
src: add grep utility to explore feature

### DIFF
--- a/documentation/man/kw.rst
+++ b/documentation/man/kw.rst
@@ -149,15 +149,27 @@ This command is a wrapper for **checkpatch**, with the goal of simplifying the
 use of this tool; notice that you can specify a single file or an entire
 directory.
 
-e, explore [--log] [*EXPRESSION*] [-p] [*DIRECTORY|FILE*]
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The *explore* command is a wrapper to git grep. It can search for string
-matches in either the git repository contents or in the git log messages. For
-example, you can use **kw e functionName** to find *functionName* in the source
-directory; If you want to search for a composed string, you have to quote your
-search (e.g., **kw e "str1 str2"**). You can also search the git log history by
-using *--log* after the *e*; for instance, **kw e --log STRING_MATCH**.
-Additionally, you can use *-p* to see the diff in the search.
+e, explore [--log, -l | --grep, -g | --all, -a] [*EXPRESSION*] [-p] [*DIRECTORY|FILE*]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The *explore* command is, by default, a wrapper to git grep, searching for
+string matches in files under git control or in the git log messages.
+Additional parameters extended its behavior to cover all files in a directory
+(whether or not controlled by git) and also to replace the search tool with the
+GNU grep utility. Default usage: you can use **kw e functionName** to find
+*functionName* in the source directory; If you want to search for a composed
+string, you have to quote your search (e.g., **kw e "str1 str2"**).
+
+1. --log: Search the git log history by using *--log* after the *e*; for
+   instance, **kw e --log STRING_MATCH**.  Additionally, you can use *-p* to
+   see the diff in the search.
+
+2. --grep | -g: Search for string matches in directory contents using GNU grep
+   tool. For instance, **kw e --grep STRING_MATCH**. It also covers files
+   inside .git directory.
+
+3. --all | -a: Search for string matches in directory contents using Git grep
+   tool. For instance, **kw e --all STRING_MATCH**. With this, the search
+   ignores files inside .git, except if it is called inside .git directory. 
 
 m, maintainers [*-a|--authors*] [*DIRECTORY|FILE*]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/explore.sh
+++ b/src/explore.sh
@@ -19,7 +19,15 @@ function explore()
       shift 1 # Remove 'log' string
       explore_git_log "$@"
     ;;
-    2) # Search in a git repository
+    2) # Use GNU GREP
+      shift 1 # Remove 'grep' string
+      explore_files_gnu_grep "$@"
+    ;;
+    3) # Search in directories controlled or not by git
+      shift 1
+      explore_all_files_git "$@"
+    ;; 
+    4) # Search in files under git control
       explore_files_under_git "$@"
     ;;
     *)
@@ -35,20 +43,37 @@ function explore()
 # Returns:
 # This function returns the following values:
 #   1 if --log is passed
-#   2 for something different from --log
+#   2 if --grep is passed
+#   3 if --all is passed
+#   4 for something different from --log or --grep
 #   22 for invalid operation
 function explore_parser()
 {
+  local option="$1"
+
   if [[ "$#" -eq 0 ]]; then
-    complain "Expected string or 'log'"
+    complain "Expected string or parameter. See man for detail."
     exit 22 # EINVAL
   fi
 
-  if [[ "$1" =~ ^--log$ && ! -z "$2" ]]; then
-    return 1
+  if [[ -z "$2" ]]; then
+    return 4
   fi
 
-  return 2
+  case "$option" in
+    --log|-l)
+      return 1
+    ;;
+    --grep|-g)
+      return 2
+    ;;
+    --all|-a)
+      return 3
+    ;;
+    *)
+      return 4
+    ;;
+  esac
 }
 
 # This function is responsible for handling the search in the log history.
@@ -69,8 +94,7 @@ function explore_git_log()
   cmd_manager "$flag" "git log --grep=\"$search_string\" $path"
 }
 
-# This function manages the search inside files and under the git repository
-# control.
+# This function searches string in files under git control.
 #
 # @regex Specifies the regex that we want to search in the files
 # @path Narrow down the search
@@ -89,4 +113,49 @@ function explore_files_under_git()
   path=${path:-"."}
 
   cmd_manager "$flag" "git grep -e \"$regex\" -nI $path"
+}
+
+# This function uses git grep tool to search string in files under or not git
+# control. This only covers files into .git if the user runs the command
+# inside the directory
+#
+# @regex Specifies the regex that we want to search in the files
+# @path Narrow down the search
+# @flag How to display a command, the default value is "SILENT". For more
+#       options see `src/kwlib.sh` function `cmd_manager`
+function explore_all_files_git()
+{
+  local regex="$1"
+  local path="$2"
+  local flag="$3"
+
+  # Silent by default
+  flag=${flag:-"SILENT"}
+
+  # If user only set regex value
+  path=${path:-"."}
+
+  cmd_manager "$flag" "git grep --no-index -e \"$regex\" -nI $path"
+}
+
+# This function allows the use of gnu grep utility to manages the search for
+# regex regardless if the files is or not under git control.
+#
+# @regex Specifies the regex that we want to search in the files
+# @path Narrow down the search
+# @flag How to display a command, the default value is "SILENT". For more
+#       options see `src/kwlib.sh` function `cmd_manager`
+function explore_files_gnu_grep()
+{
+  local regex="$1"
+  local path="$2"
+  local flag="$3"
+
+  # Silent by default
+  flag=${flag:-"SILENT"}
+
+  # If user only set regex value
+  path=${path:-"."}
+
+  cmd_manager "$flag" "grep --color -nrI $path -e \"$regex\""
 }

--- a/src/help.sh
+++ b/src/help.sh
@@ -28,8 +28,10 @@ function kworkflow-help()
 
   echo -e "kw explore:\n" \
     "\texplore,e STRING [PATH] - Search for STRING based in PATH (./ by default) \n" \
-    "\texplore,e \"STR SRT\" [PATH] - Search for strings\n" \
-    "\texplore,e --log STRING - Search for STRING on git log\n" \
+    "\texplore,e \"STR SRT\" [PATH] - Search for strings only in files under git control\n" \
+    "\texplore,e --log,-l STRING - Search for STRING on git log\n" \
+    "\texplore,e --grep,-g STRING - Search for STRING using the GNU grep tool\n" \
+    "\texplore,e --all,-a STRING - Search for STRING using the git grep tool\n" \
 
   echo -e "kw config manager:\n" \
     "\tconfigm,g --save NAME [-d 'DESCRIPTION']\n" \

--- a/tests/samples/grep_check.c
+++ b/tests/samples/grep_check.c
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * grep_check.c
+ *
+ * Copyright (C) 2018 John Doe
+ *
+ * This file is used for GNU grep checking.
+ *
+ */
+
+#include <stdio.h>
+
+void camelCase(void)
+{
+	puts("One should avoid camel case.");
+}
+
+int main(int argc, char *args[])
+{
+	int i;
+
+	printf("%d\n", argc);
+	for (i = 0; i < argc; ++i)
+		printf("%s ", args[i]);
+	return 0;
+}


### PR DESCRIPTION
This patch expands the feature -explore- adding the grep utility
for searching plain-text data in files that are not under git.
Related to #61 

Signed-off-by: Melissa Wen <melissa.srw@gmail.com>