### PR TITLE
src: config_manager: Update list and remove API

### DIFF
--- a/documentation/man/kw.rst
+++ b/documentation/man/kw.rst
@@ -72,8 +72,8 @@ notice that this approach is the most generic one because you can use it for
   **Currently, we don't support the Kernel image update in the --vm option.
   However, you can use the remote option for a workaround this issue**.
 
-d, deploy [--remote [REMOTE:PORT]|--local|--vm] [--reboot|-r] [--modules|-m] [--ls-line|-s] [--ls|-l] [--uninstall|-u KERNEL_NAME]
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+d, deploy [--remote [REMOTE:PORT]|--local|--vm] [--reboot|-r] [--modules|-m] [--ls-line|-s] [--list|-l] [--uninstall|-u KERNEL_NAME]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If you are in a kernel directory, this command will try to install the current
 kernel version in your target machine (remote, host, and VM). If you want to
 install a kernel version in a remote machine, the following steps will be
@@ -117,7 +117,7 @@ need root access.
 
 5. --modules: Only install/update modules.
 
-6. --ls: List available kernels in a single column the target.
+6. --list: List available kernels in a single column the target.
 
 7. --ls-line: List available kernels separated by comma.
 
@@ -502,7 +502,7 @@ In case you want that kw saves your current .config file, you can use::
 
 You can see the config's file maintained by kw with::
 
-  kw g --ls
+  kw g --list
 
 You can turn on your VM with::
 

--- a/documentation/man/kw.rst
+++ b/documentation/man/kw.rst
@@ -250,8 +250,8 @@ expects a bash script as a parameter to evaluate it in the target machine. The
 *--command* parameter expects a command to be executed inside of target
 machine.
 
-g, configm [--save *NAME* [-d *DESCRIPTION*][-f]]|[--ls]|[--get *NAME* [-f]]|[--rm *NAME* [-f]]
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+g, configm [--save *NAME* [-d *DESCRIPTION*][-f]]|[--list|-l]|[--get *NAME* [-f]]|[--remove|-rm *NAME* [-f]]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The 'configm' command manages different versions of the project's '.config'
 file.  It provides the save, load, remove, and list operations of such files.
@@ -263,15 +263,15 @@ can add a description by using *-d* flag. Finally, if the user tries to add the
 same name twice, **kw** will issue a warning; the '-f' will suppress this
 message.
 
-2. --ls lists all the .config file versions available.
+2. --list|-l lists all the .config file versions available.
 
 3. --get *NAME* [-f]: Get a config file based on the *NAME* and paste it in the
 current directory. It pop-up a warning message because this operation override
 the current .config file. The user can suppress this warning by using -f flag.
 
-4. --rm *NAME* [-f]: Remove config labeled with *NAME*. It pop-up a warning
-message because it will remove the config file from kw management. The user can
-suppress this warning by using -f.
+4. --remove|-rm *NAME* [-f]: Remove config labeled with *NAME*. It pop-up a
+warning message because it will remove the config file from kw management. The
+user can suppress this warning by using -f.
 
 v, vars
 ~~~~~~~

--- a/src/config_manager.sh
+++ b/src/config_manager.sh
@@ -204,7 +204,7 @@ function execute_config_manager()
       shift 2 && description_config=$@
       save_config_file $force $name_config "$description_config"
       ;;
-    --ls)
+    --list|-l)
       list_configs
       ;;
     --get)
@@ -216,7 +216,7 @@ function execute_config_manager()
 
       get_config $1 $force
       ;;
-    --rm)
+    --remove|-rm)
       shift # Skip '--rm' option
       if [[ -z "$1" ]]; then
         complain "Invalid argument"

--- a/src/help.sh
+++ b/src/help.sh
@@ -44,9 +44,9 @@ function kworkflow-help()
 
   echo -e "kw config manager:\n" \
     "\tconfigm,g --save NAME [-d 'DESCRIPTION']\n" \
-    "\tconfigm,g --ls - List config files under kw management\n" \
+    "\tconfigm,g --list|-l - List config files under kw management\n" \
     "\tconfigm,g --get NAME - Get a config file based named *NAME*\n" \
-    "\tconfigm,g --rm - Remove config labeled with *NAME*\n" \
+    "\tconfigm,g --remove|-rm - Remove config labeled with *NAME*\n" \
 
   echo -e "kw ssh|s options:\n" \
     "\tssh|s [--script|-s="SCRIPT PATH"]\n" \

--- a/src/help.sh
+++ b/src/help.sh
@@ -55,7 +55,7 @@ function kworkflow-help()
   echo -e "kw deploy|d installs kernel and modules:\n" \
     "\tdeploy,d [--remote [REMOTE:PORT]|--local|--vm] [--reboot|-r] [--modules|-m]\n" \
     "\tdeploy,d [--remote [REMOTE:PORT]|--local|--vm] [--uninstall|-u KERNEL_NAME]\n" \
-    "\tdeploy,d [--remote [REMOTE:PORT]|--local|--vm] [--ls-line|-s] [--ls|-l]"
+    "\tdeploy,d [--remote [REMOTE:PORT]|--local|--vm] [--ls-line|-s] [--list|-l]"
 }
 
 # Display the man documentation using rst2man, or man kw if it is already

--- a/src/mk.sh
+++ b/src/mk.sh
@@ -669,7 +669,7 @@ function deploy_parser_options()
           options_values["MODULES"]=1
           continue
           ;;
-        --ls|-l)
+        --list|-l)
           options_values["LS"]=1
           continue
           ;;

--- a/tests/configm_test.sh
+++ b/tests/configm_test.sh
@@ -304,15 +304,15 @@ function get_operation_with_force_Test()
 
 function remove_operation_that_should_fail_Test()
 {
-  local msg_prefix=" --rm"
-
-  ret=$(execute_config_manager --rm)
-  test_expected_string "$msg_prefix" "$COMMAND_MSG_INVALID_ARG" "$ret"
+  local msg_prefix=" -rm"
 
   ret=$(execute_config_manager -rm)
+  test_expected_string "$msg_prefix" "$COMMAND_MSG_INVALID_ARG" "$ret"
+
+  ret=$(execute_config_manager --rm)
   test_expected_string "$msg_prefix" "$COMMAND_MSG_UNKNOWN" "$ret"
 
-  ret=$(execute_config_manager --rm something_wrong)
+  ret=$(execute_config_manager -rm something_wrong)
   test_expected_string "$msg_prefix" "$COMMAND_NO_SUCH_FILE: something_wrong" "$ret"
 }
 


### PR DESCRIPTION
Currently, we use `--ls` and `--rm`, which does not make sense when
compared with other kw commands. This commit replaces `--ls` for
`--list` or `-l` and `--rm` for `--remove` or `-rm`.

Signed-off-by: Rodrigo Siqueira <rodrigosiqueiramelo@gmail.com>