### PR TITLE
tests: standardization of test names

### DIFF
--- a/documentation/content/codingstyle.rst
+++ b/documentation/content/codingstyle.rst
@@ -180,6 +180,27 @@ $PATH, you should use 'type ', instead of 'which '.
 The output of 'which' is not machine parsable and its exit code
 is not reliable across platforms.
 
+Test name
+---------
+
+Tests are an important part of kw, we only accept new features with tests, and
+we prefer bug fixes that came with tests. For trying to keep the test
+comprehensible, we adopt the following patter for naming a test::
+
+    target_function_name_[an_option_description]_Test
+
+To better illustrate this definition, see the below example::
+
+    detect_distro_Test
+
+This function name indicates that we are testing `detect_distro` function.
+Another example::
+
+    save_config_file_check_description_Test
+
+The function `save_config_file` is tested with a focus on description
+validation.
+
 Conclusion
 ----------
 

--- a/tests/configm_test.sh
+++ b/tests/configm_test.sh
@@ -24,18 +24,18 @@ readonly LS_NO_FILES="There's no tracked .config file"
 function suite
 {
   suite_addTest "execute_config_manager_SAVE_fails_Test"
-  suite_addTest "save_config_file_CHECK_CONFIG_fails_Test"
-  suite_addTest "save_config_file_CHECK_CONFIGS_DIRECTORY_Test"
-  suite_addTest "save_config_file_CHECK_SAVED_CONFIG_FILE_Test"
-  suite_addTest "save_config_file_CHECK_DESCRIPTION_Test"
-  suite_addTest "save_config_file_CHECK_GIT_SAVE_SCHEMA_Test"
-  suite_addTest "save_config_file_CHECK_FORCE_Test"
-  suite_addTest "list_config_CHECK_NO_CONFIGS_Test"
-  suite_addTest "list_config_OUTPUT_Test"
-  suite_addTest "get_operation_with_force_Test"
-  suite_addTest "get_operation_that_should_fail_Test"
-  suite_addTest "remove_operation_that_should_fail_Test"
-  suite_addTest "remove_operation"
+  suite_addTest "save_config_file_check_save_failures_Test"
+  suite_addTest "save_config_file_check_directories_creation_Test"
+  suite_addTest "save_config_file_check_saved_config_Test"
+  suite_addTest "save_config_file_check_description_Test"
+  suite_addTest "save_config_file_check_git_save_schema_Test"
+  suite_addTest "save_config_file_check_force_Test"
+  suite_addTest "list_config_check_when_there_is_no_config_Test"
+  suite_addTest "list_config_normal_output_Test"
+  suite_addTest "get_config_with_force_Test"
+  suite_addTest "execute_config_manager_get_config_invalid_option_Test"
+  suite_addTest "execute_config_manager_remove_that_should_fail_Test"
+  suite_addTest "remove_config_Test"
 }
 
 function setUp()
@@ -100,7 +100,7 @@ function execute_config_manager_SAVE_fails_Test
   test_expected_string "$msg_prefix -f" "$COMMAND_MSG_INVALID_ARG" "$ret"
 }
 
-function save_config_file_CHECK_CONFIG_fails_Test()
+function save_config_file_check_save_failures_Test()
 {
   local -r test_path="tests/.tmp"
   local current_path="$PWD"
@@ -122,7 +122,7 @@ function save_config_file_CHECK_CONFIG_fails_Test()
   cd "$current_path"
 }
 
-function save_config_file_CHECK_CONFIGS_DIRECTORY_Test()
+function save_config_file_check_directories_creation_Test()
 {
   local -r test_path="tests/.tmp"
   local current_path="$PWD"
@@ -140,7 +140,7 @@ function save_config_file_CHECK_CONFIGS_DIRECTORY_Test()
   assertTrue "The configs dir is not available" '[[ -d $config_files_path/configs/configs ]]'
 }
 
-function save_config_file_CHECK_SAVED_CONFIG_FILE_Test()
+function save_config_file_check_saved_config_Test()
 {
   local -r test_path="tests/.tmp"
   local current_path="$PWD"
@@ -166,7 +166,7 @@ function save_config_file_CHECK_SAVED_CONFIG_FILE_Test()
   assertTrue "Content in the file does not match" '[[ $tmp = $CONTENT ]]'
 }
 
-function save_config_file_CHECK_DESCRIPTION_Test()
+function save_config_file_check_description_Test()
 {
   local -r test_path="tests/.tmp"
   local current_path="$PWD"
@@ -189,7 +189,7 @@ function save_config_file_CHECK_DESCRIPTION_Test()
   assertTrue "The description content for $NAME_2 does not match" '[[ $tmp = $DESCRIPTION_2 ]]'
 }
 
-function save_config_file_CHECK_GIT_SAVE_SCHEMA_Test()
+function save_config_file_check_git_save_schema_Test()
 {
   local -r test_path="tests/.tmp"
   local current_path="$PWD"
@@ -207,7 +207,7 @@ function save_config_file_CHECK_GIT_SAVE_SCHEMA_Test()
   assertTrue "We expected 2 commits, but we got $ret" '[[ $ret = "2" ]]'
 }
 
-function save_config_file_CHECK_FORCE_Test()
+function save_config_file_check_force_Test()
 {
   local -r test_path="tests/.tmp"
   local current_path="$PWD"
@@ -222,7 +222,7 @@ function save_config_file_CHECK_FORCE_Test()
   assertTrue "We expected no changes" '[[ $ret =~ Warning ]]'
 }
 
-function list_config_CHECK_NO_CONFIGS_Test()
+function list_config_check_when_there_is_no_config_Test()
 {
   local -r test_path="tests/.tmp"
   local current_path="$PWD"
@@ -234,7 +234,7 @@ function list_config_CHECK_NO_CONFIGS_Test()
   assertTrue "We expected no changes" '[[ $ret =~ $LS_NO_FILES ]]'
 }
 
-function list_config_OUTPUT_Test()
+function list_config_normal_output_Test()
 {
   local -r test_path="tests/.tmp"
   local current_path="$PWD"
@@ -257,7 +257,7 @@ function list_config_OUTPUT_Test()
   assertTrue "We expected $DESCRIPTION_2 in the output, but we got $ret" '[[ $ret =~ $DESCRIPTION_2 ]]'
 }
 
-function get_operation_that_should_fail_Test()
+function execute_config_manager_get_config_invalid_option_Test()
 {
   local msg_prefix=" --get"
 
@@ -271,7 +271,7 @@ function get_operation_that_should_fail_Test()
   test_expected_string "$msg_prefix" "$COMMAND_NO_SUCH_FILE: something_wrong" "$ret"
 }
 
-function get_operation_with_force_Test()
+function get_config_with_force_Test()
 {
   local -r test_path="tests/.tmp"
   local current_path="$PWD"
@@ -302,7 +302,7 @@ function get_operation_with_force_Test()
   assertTrue "We expected $CONTENT, but we got $ret" '[[ $ret =~ $CONTENT ]]'
 }
 
-function remove_operation_that_should_fail_Test()
+function execute_config_manager_remove_that_should_fail_Test()
 {
   local msg_prefix=" --rm"
 
@@ -316,7 +316,7 @@ function remove_operation_that_should_fail_Test()
   test_expected_string "$msg_prefix" "$COMMAND_NO_SUCH_FILE: something_wrong" "$ret"
 }
 
-function remove_operation
+function remove_config_Test
 {
   local -r test_path="tests/.tmp"
   local current_path="$PWD"

--- a/tests/get_maintainer_wrapper_test.sh
+++ b/tests/get_maintainer_wrapper_test.sh
@@ -7,9 +7,9 @@
 
 function suite
 {
-  suite_addTest "testPrintFileAuthorForFile"
-  suite_addTest "testPrintFileAuthorForDir"
-  suite_addTest "testGetMaintainers"
+  suite_addTest "print_files_authors_Test"
+  suite_addTest "print_files_authors_from_dir_Test"
+  suite_addTest "execute_get_maintainer_Tesg"
 }
 
 # The following variables hold the the lines print_files_authors should
@@ -52,7 +52,7 @@ function tearDownGetMainteiners
   rm -rf "$FAKE_KERNEL"
 }
 
-function testPrintFileAuthorForFile
+function print_files_authors_Test
 {
   local -r ret=$(print_files_authors "tests/samples/print_file_author_test_dir/code1.c")
   if [[ "$ret" != "$CORRECT_FILE_MSG" ]]; then
@@ -63,7 +63,7 @@ function testPrintFileAuthorForFile
   true # Reset return value
 }
 
-function testPrintFileAuthorForDir
+function print_files_authors_from_dir_Test
 {
   local -r ret=$(print_files_authors "tests/samples/print_file_author_test_dir")
   if [[ "$ret" != "$CORRECT_DIR_MSG" ]]; then
@@ -74,7 +74,7 @@ function testPrintFileAuthorForDir
   true # Reset return value
 }
 
-function testGetMaintainers
+function execute_get_maintainer_Tesg
 {
   local ret
   local got_prefixed

--- a/tests/help_test.sh
+++ b/tests/help_test.sh
@@ -5,10 +5,10 @@
 
 function suite
 {
-  suite_addTest "testHelp"
+  suite_addTest "kworkflow-help_Test"
 }
 
-function testHelp
+function kworkflow-help_Test
 {
   HELP_OUTPUT=$(kworkflow-help | head -n 1)
   [[ $HELP_OUTPUT =~ Usage:\ kw.* ]]; assertTrue "Help text not displaying correctly." $?

--- a/tests/kw_config_loader_test.sh
+++ b/tests/kw_config_loader_test.sh
@@ -7,11 +7,11 @@ TMP_DIR=tests/.tmp_kw_config_loader_test
 
 function suite
 {
-  suite_addTest "parser_success_exit_code_Test"
-  suite_addTest "parser_failed_exit_code_Test"
-  suite_addTest "parser_output_Test"
-  suite_addTest "default_config_file_Test"
-  suite_addTest "config_files_loading_order_Test"
+  suite_addTest "parse_configuration_success_exit_code_Test"
+  suite_addTest "parser_configuration_failed_exit_code_Test"
+  suite_addTest "parse_configuration_output_Test"
+  suite_addTest "parse_configuration_standard_config_Test"
+  suite_addTest "parse_configuration_files_loading_order_Test"
 }
 
 function setUp
@@ -26,13 +26,13 @@ function tearDown
   rm -rf "$TMP_DIR"
 }
 
-function parser_success_exit_code_Test
+function parse_configuration_success_exit_code_Test
 {
   parse_configuration tests/samples/kworkflow.config
   assertTrue "Kw failed to load a regular config file" "[ 0 -eq $? ]"
 }
 
-function parser_failed_exit_code_Test
+function parser_configuration_failed_exit_code_Test
 {
   parse_configuration tests/kw_config_loader_test.sh
   assertTrue "kw loaded an unsupported file" "[ 22 -eq $? ]"
@@ -61,7 +61,7 @@ function assertConfigurations
 }
 
 # Test if parse_configuration correctly parses all settings in a file
-function parser_output_Test
+function parse_configuration_output_Test
 {
   declare -A expected_configurations=(
     [arch]="arm64"
@@ -90,7 +90,7 @@ function parser_output_Test
 }
 
 # Test if etc/kworkflow_template.config contains all the expected settings
-function default_config_file_Test
+function parse_configuration_standard_config_Test
 {
   local path_repo=$PWD
 
@@ -119,7 +119,7 @@ function default_config_file_Test
   true # Reset return value
 }
 
-function config_files_loading_order_Test
+function parse_configuration_files_loading_order_Test
 {
   expected="$KW_ETC_DIR/$CONFIG_FILENAME
 $HOME/.kw/$CONFIG_FILENAME

--- a/tests/kw_dash.sh
+++ b/tests/kw_dash.sh
@@ -4,10 +4,10 @@
 
 function suite
 {
-  suite_addTest "testDash"
+  suite_addTest "check_dash_integration_with_kw_Test"
 }
 
-function testDash
+function check_dash_integration_with_kw_Test
 {
   ./tests/_kw_dash.dsh
   if [ $? -ne 0 ]; then

--- a/tests/kw_test.sh
+++ b/tests/kw_test.sh
@@ -5,11 +5,11 @@
 
 function suite
 {
-  suite_addTest "testVariables"
-  suite_addTest "testExported"
+  suite_addTest "validate_global_variables_Test"
+  suite_addTest "check_kworkflow_global_variable_Test"
 }
 
-function testVariables
+function validate_global_variables_Test
 {
   VARS=( KWORKFLOW KW_LIB_DIR )
   for v in "${VARS[@]}"; do
@@ -17,7 +17,7 @@ function testVariables
   done
 }
 
-function testExported
+function check_kworkflow_global_variable_Test
 {
   VARS=( KWORKFLOW )
   for v in "${VARS[@]}"; do

--- a/tests/kwio_test.sh
+++ b/tests/kwio_test.sh
@@ -14,9 +14,9 @@ visual_file="$PWD/tests/.kwio_test_aux/visual.file"
 
 function suite
 {
-  suite_addTest "testAlertOptions"
-  suite_addTest "testAlertDefaultOptions"
-  suite_addTest "testAlertCommandPrinting"
+  suite_addTest "alert_completion_options_Test"
+  suite_addTest "alert_completition_validate_config_file_options_Test"
+  suite_addTest "alert_completion_visual_alert_Test"
 }
 
 function setUp
@@ -32,7 +32,7 @@ function tearDown
 }
 
 
-function testAlertOptions
+function alert_completion_options_Test
 {
   configurations["alert"]="n"
 
@@ -64,7 +64,7 @@ function testAlertOptions
   true
 }
 
-function testAlertDefaultOptions
+function alert_completition_validate_config_file_options_Test
 {
   mkdir -p tests/.kwio_test_aux
 
@@ -101,7 +101,7 @@ function testAlertDefaultOptions
   true
 }
 
-function testAlertCommandPrinting
+function alert_completion_visual_alert_Test
 {
   local expected="TESTING COMMAND"
   configurations["visual_alert_command"]="echo \$COMMAND"

--- a/tests/kwlib_test.sh
+++ b/tests/kwlib_test.sh
@@ -6,14 +6,14 @@
 
 function suite
 {
-  suite_addTest "linuxRootCheckTest"
-  suite_addTest "cmdManagerTESTMODETest"
-  suite_addTest "cmdManagerSILENTTest"
+  suite_addTest "is_kernel_root_Test"
+  suite_addTest "cmd_manager_check_test_mode_option_Test"
+  suite_addTest "cmd_manager_check_silent_option_Test"
   suite_addTest "cmdManagerSAY_COMPLAIN_WARNING_SUCCESS_Test"
-  suite_addTest "detect_distro_family_test"
-  suite_addTest "joinPathTest"
-  suite_addTest "findKernelRootTest"
-  suite_addTest "isAPatchTest"
+  suite_addTest "detect_distro_Test"
+  suite_addTest "join_path_Test"
+  suite_addTest "find_kernel_root_Test"
+  suite_addTest "is_a_patch_Test"
   suite_addTest "get_based_on_delimiter_Test"
   suite_addTest "store_statistics_data_Test"
   suite_addTest "update_statistics_database_Test"
@@ -77,7 +77,7 @@ function tearDownSetup
   rm -rf "$FAKE_STATISTICS_PATH"
 }
 
-function linuxRootCheckTest
+function is_kernel_root_Test
 {
   setupFakeKernelRepo
   is_kernel_root "tests/.tmp"
@@ -86,7 +86,7 @@ function linuxRootCheckTest
   true # Reset return value
 }
 
-function cmdManagerSILENTTest
+function cmd_manager_check_silent_option_Test
 {
   setupFakeKernelRepo
   cd "tests/.tmp"
@@ -143,7 +143,7 @@ function cmdManagerSAY_COMPLAIN_WARNING_SUCCESS_Test
   tearDownSetup
 }
 
-function cmdManagerTESTMODETest
+function cmd_manager_check_test_mode_option_Test
 {
   ret=$(cmd_manager TEST_MODE pwd)
   assertEquals "Expected pwd, but we got $ret" "$ret" "pwd"
@@ -152,7 +152,7 @@ function cmdManagerTESTMODETest
   assertEquals "Expected ls -lah, but we got $ret" "$ret" "ls -lah"
 }
 
-function detect_distro_family_test
+function detect_distro_Test
 {
   setupFakeOSInfo
   local root_path="tests/.tmp/detect_distro/arch"
@@ -177,7 +177,7 @@ function detect_distro_family_test
   assertEquals "We got $ret." "$ret" "none"
 }
 
-function joinPathTest
+function join_path_Test
 {
   local base="/lala/xpto"
   local ret=$(join_path "/lala" "///xpto")
@@ -194,7 +194,7 @@ function joinPathTest
   assertEquals "Expect /lala/" "$ret" "/lala/"
 }
 
-function findKernelRootTest
+function find_kernel_root_Test
 {
   setupFakeKernelRepo
 
@@ -213,7 +213,7 @@ function findKernelRootTest
   tearDownSetup
 }
 
-function isAPatchTest
+function is_a_patch_Test
 {
   setupPatch
   is_a_patch "tests/.tmp/test.patch"

--- a/tests/ssh_test.sh
+++ b/tests/ssh_test.sh
@@ -15,10 +15,10 @@ SSH_OK="ssh -p 3333 127.0.0.1"
 
 function suite
 {
-  suite_addTest "vmSshFailsTest"
-  suite_addTest "vmSshTest"
-  suite_addTest "vmSshCommandTest"
-  suite_addTest "vmSshScriptTest"
+  suite_addTest "vm_ssh_check_fail_cases_Test"
+  suite_addTest "vm_ssh_basic_Test"
+  suite_addTest "vm_ssh_command_Test"
+  suite_addTest "vm_ssh_script_Test"
 }
 
 function setupSsh
@@ -42,7 +42,7 @@ function tearDownSsh
   rm -rf $TEST_PATH
 }
 
-function vmSshFailsTest
+function vm_ssh_check_fail_cases_Test
 {
   setupSsh
 
@@ -78,7 +78,7 @@ function vmSshFailsTest
   tearDownSsh
 }
 
-function vmSshTest
+function vm_ssh_basic_Test
 {
   setupSsh
 
@@ -89,7 +89,7 @@ function vmSshTest
   tearDownSsh
 }
 
-function vmSshCommandTest
+function vm_ssh_command_Test
 {
   setupSsh
 
@@ -104,7 +104,7 @@ function vmSshCommandTest
   tearDownSsh
 }
 
-function vmSshScriptTest
+function vm_ssh_script_Test
 {
   setupSsh
 


### PR DESCRIPTION
Our tests name are not well-formatted for historical reasons; for this
reason, this commits alleviate this issue by applying a similar pattern
for all test names. Additionally, we also update the documentation to
describe this new pattern better.

Closes #152

Signed-off-by: Rodrigo Siqueira <rodrigosiqueiramelo@gmail.com>