### PR TITLE
plugins: arch: fix the misuse of mkinitcpio on vm deployment

### DIFF
--- a/src/plugins/kernel_install/arch.sh
+++ b/src/plugins/kernel_install/arch.sh
@@ -150,7 +150,7 @@ function install_kernel()
     cp -v "$name.preset" $path_prefix/etc/mkinitcpio.d/
   fi
 
-  if [[ "$target" != 'local' ]]; then
+  if [[ "$target" == 'remote' ]]; then
     # Update mkinitcpio
     cmd="$sudo_cmd mkinitcpio -p $name"
     cmd_manager "$flag" "$cmd"


### PR DESCRIPTION
The mkinitcpio is only used for remote deployment and vm does not
require this operation.

Fixes: 5d75cfa3 ("Add support for VM deploy")
Signed-off-by: Melissa Wen <melissa.srw@gmail.com>