### PR TITLE
src: bash_autocomplete: remove unnecessary hashbang

### DIFF
--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 _kw_autocomplete()
 {
     local current_command previous_command kw_options


### PR DESCRIPTION
Warned by lintian while packaging kw for debian.