### PR TITLE
Implement include guards

### DIFF
--- a/documentation/content/codingstyle.rst
+++ b/documentation/content/codingstyle.rst
@@ -180,6 +180,14 @@ $PATH, you should use 'type ', instead of 'which '.
 The output of 'which' is not machine parsable and its exit code
 is not reliable across platforms.
 
+Sourcing files
+---------------
+Every file that may be sourced must have an import guard of the form:  
+`[ -n "$FILENAME_IMPORTED" ] && return || readonly FILENAME_IMPORTED=1`.
+This guarantees that no file may be imported twice.
+
+
+
 Test name
 ---------
 

--- a/src/help.sh
+++ b/src/help.sh
@@ -1,3 +1,5 @@
+[ -n "$HELP_IMPORTED" ] && return || readonly HELP_IMPORTED=1
+
 . "$KW_LIB_DIR/kwio.sh" --source-only
 
 function kworkflow-help()

--- a/src/kw_config_loader.sh
+++ b/src/kw_config_loader.sh
@@ -1,3 +1,5 @@
+[ -n "$KW_CONFIGLOADER_IMPORTED" ] && return || readonly KW_CONFIGLOADER_IMPORTED=1
+
 . "$KW_LIB_DIR/kwio.sh" --source-only
 
 CONFIG_FILENAME=kworkflow.config

--- a/src/kwio.sh
+++ b/src/kwio.sh
@@ -1,5 +1,8 @@
 # NOTE: src/kw_config_loader.sh must be included before this file
 
+[ -n "$KWIO_IMPORTED" ] && return || readonly KWIO_IMPORTED=1
+
+
 declare -r BLUECOLOR="\033[1;34;49m%s\033[m"
 declare -r REDCOLOR="\033[1;31;49m%s\033[m"
 declare -r YELLOWCOLOR="\033[1;33;49m%s\033[m"

--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -1,5 +1,7 @@
 # NOTE: src/kw_config_loader.sh must be included before this file
 
+[ -n "$KWLIB_IMPORTED" ] && return || readonly KWLIB_IMPORTED=1
+
 # A common task used inside kw is a string separation based on a delimiter, for
 # this reason, this function tries to handle this scenario by getting a
 # delimiter character followed by the position that the users want to retrieve.

--- a/src/remote.sh
+++ b/src/remote.sh
@@ -2,6 +2,10 @@
 
 # NOTE: It is recommended that src/kw_config_loader.sh be included before this
 # file
+if [[ -z "$KW_CONFIGLOADER_IMPORTED" ]]; then
+  . "$KW_LIB_DIR/kw_config_loader.sh" --source-only
+fi
+
 
 # We now have a kw directory visible for users in the home directory, which is
 # used for saving temporary files to be deployed in the target machine.

--- a/src/remote.sh
+++ b/src/remote.sh
@@ -1,3 +1,5 @@
+[ -n "$REMOTE_IMPORTED" ] && return || readonly REMOTE_IMPORTED=1
+
 # NOTE: It is recommended that src/kw_config_loader.sh be included before this
 # file
 

--- a/src/vm.sh
+++ b/src/vm.sh
@@ -1,3 +1,6 @@
+[ -n "$VM_IMPORTED" ] && return || readonly VM_IMPORTED=1
+
+
 . "$KW_LIB_DIR/kw_config_loader.sh" --source-only
 . "$KW_LIB_DIR/kwlib.sh" --source-only
 


### PR DESCRIPTION
This PR creates an include guard for all files being sourced in the project, thus preventing them from being sourced twice. This PR also uses the same strategy to prevent remote.sh from being sourced before kw_config_loader.sh.

I suggest including this strategy into the codestyle of the project, this PR also includes a suggestion for a section in codingstyle.rst about include guards.



Closes #197 