### PR TITLE
tests/get_maintainer_wrapper_test: improve

### DIFF
--- a/tests/get_maintainer_wrapper_test.sh
+++ b/tests/get_maintainer_wrapper_test.sh
@@ -57,12 +57,19 @@ function oneTimeSetUp
   # dir is also created inside tests/.tmp so that get_maintainer.pl thinks
   # it is a git repo. This is done in order to avoid some warnings that
   # get_maintainer.pl prints when no .git is found.
+  local original_dir="$PWD"
   mk_fake_kernel_root "$FAKE_KERNEL"
-  mkdir -p "$FAKE_KERNEL/.git"
   cp -f tests/samples/MAINTAINERS "$FAKE_KERNEL"/MAINTAINERS
   cp -f tests/external/get_maintainer.pl "$FAKE_KERNEL"/scripts/
   cp -f tests/samples/update_patch_test{_model,}{,2}.patch "$FAKE_KERNEL"/
+  cd "$FAKE_KERNEL"
+  touch fs/some_file
+  git init --quiet
+  git add fs/some_file
+  git commit --quiet -m "Test message"
+  cd "$original_dir"
 }
+
 
 function oneTimeTearDown
 {

--- a/tests/utils
+++ b/tests/utils
@@ -28,6 +28,47 @@ function prefix_multiline
   echo "$@" | sed -E "s/^/> /g"
 }
 
+# Compare strings with multiple lines and prefix them with "> "
+function multilineAssertEquals
+{
+  local message
+  local left
+  local right
+
+  if [ $# -ge 3 ]; then
+    message="$1"
+    shift
+  fi
+
+  left=$'\n'"$(echo "$1" | sed -E "s/^/> /g" )"$'\n'
+  right=$'\n'"$(echo "$2" | sed -E "s/^/> /g" )"$'\n'
+
+  if [ -n "$message" ]; then
+    assertEquals "$message" "$left" "$right"
+  else
+    assertEquals "$left" "$right"
+  fi
+}
+
+# Assert that two files are byte by byte the same
+function assertFileEquals()
+{
+  local message
+  local ret
+
+  if [ $# -ge 3 ]; then
+    message="$1"
+    shift
+  else
+    message="Files $1 and $2 differ"
+  fi
+
+  cmp -s "$1" "$2"
+  ret="$?"
+
+  assertTrue "$message" "$ret"
+}
+
 # Receives a path and creates a fake kernel root in it. The goal is to make this
 # path recognizable by src/kwlib.sh:is_kernel_root().
 function mk_fake_kernel_root


### PR DESCRIPTION
This PR makes two improvements to the `get_maintainer_wrapper_test` file: i) some refactoring and reduction of code duplication and ii) introduction of a fake `.git` folder to avoid some warnings by the `get_maintainer.pl` kernel script.

Fixes #224