### PR TITLE
src: mk: Remove unnecessary sound notification

### DIFF
--- a/src/mk.sh
+++ b/src/mk.sh
@@ -404,7 +404,7 @@ function kernel_deploy
   deploy_parser_options "$@"
   if [[ "$?" -gt 0 ]]; then
     complain "Invalid option: ${options_values['ERROR']}"
-    return 22
+    exit 22
   fi
 
   target="${options_values['TARGET']}"


### PR DESCRIPTION
I noticed that when we run 'kw deploy --unknown-option' (and 'unknown-option' can be any invalid option name), we still get a notification when this command finished running. I believe this is an unexpected behaviour, as it doesn't happen with other commands that make use of the 'alert_completion' function.
To reproduce this, you have to be inside a kernel repository and run the command as described above.