### PR TITLE
Describe commands more accurately in the documentation

### DIFF
--- a/documentation/content/installanduninstall.rst
+++ b/documentation/content/installanduninstall.rst
@@ -85,7 +85,7 @@ Package install
 Update
 ------
 Every time you want to get a new version of `kw`, just pull from this
-repository and install kw again (`./setup -i` removes legacy files and installs
+repository and install kw again (`./setup.sh -i` removes legacy files and installs
 new ones).
 
 Remove

--- a/documentation/content/tests.rst
+++ b/documentation/content/tests.rst
@@ -9,26 +9,26 @@ https://github.com/kward/shunit2).
 
 If you want to run all the tests, try::
 
-  run_tests.sh
+  ./run_tests.sh
 
 List all available test files::
 
-  run_tests.sh list
+  ./run_tests.sh list
 
 Or run individual tests with::
 
-  run_tests.sh test TESTFILE1 ...
+  ./run_tests.sh test TESTFILE1 ...
 
 Tests rely on some external files. These files are automatically downloaded
 when you first try to run a test. You can, however, force `run_tests.sh` to
 prepare the environment for running tests with::
 
-  run_tests.sh prepare
+  ./run_tests.sh prepare
 
 Also, if you already have the test's environment prepared but want to update
 the external files, you can use::
 
-  run_tests.sh prepare -f|--force-update
+  ./run_tests.sh prepare -f|--force-update
 
 .. note::
    `run_tests.sh` script must be run from the directory it is in,


### PR DESCRIPTION
This PR intends to make the commands described in both _documentation/content/installanduninstall.rst_ and  _documentation/content/tests.rst_ to be exactly how they're supposed to be run in the terminal.