### PR TITLE
src: mk: warn user if 'kw d' is executed as root

### DIFF
--- a/documentation/man/kw.rst
+++ b/documentation/man/kw.rst
@@ -109,7 +109,7 @@ Follows the summary of the options:
 the network.
 
 2. --local: Deploy the Kernel image and modules in the host machine, you will
-need root access.
+need root access. 'kw deploy –local' should not be executed with sudo or root.
 
 3. --vm: Deploy the Kernel image and modules to QEMU vm.
 

--- a/src/mk.sh
+++ b/src/mk.sh
@@ -307,6 +307,11 @@ function kernel_install
       fi
 
       # Local Deploy
+      if [[ $(id -u) == 0 ]]; then
+        complain "kw deploy --local should not be run as root"
+        exit 1 # EPERM
+      fi
+
       . "$KW_PLUGINS_DIR/kernel_install/utils.sh" --source-only
       . "$KW_PLUGINS_DIR/kernel_install/$distro.sh" --source-only
       install_kernel "$name" "$distro" "$kernel_img_name" "$reboot" "$arch_target" 'local' "$flag"

--- a/tests/mk_test.sh
+++ b/tests/mk_test.sh
@@ -39,6 +39,11 @@ function get_kernel_version_mock()
   echo '5.4.0-rc7'
 }
 
+function root_id_mock()
+{
+  echo "0"
+}
+
 function setUp
 {
   local create_mkinitcpio="$1"
@@ -521,6 +526,12 @@ function kernel_install_local_Test
 
   output=$(kernel_install "1" "test" "TEST_MODE" "2")
   compare_command_sequence expected_cmd[@] "$output" "$LINENO"
+
+  ID=2
+  alias "id"="root_id_mock;true"
+  output=$(kernel_install "1" "test" "TEST_MODE" "2")
+  ret="$?"
+  assertEquals "1" "$ret"
 
   cd "$original"
 }


### PR DESCRIPTION
Executing 'kw deploy' as root leads to undefined commands. This PR adds a warning for it in kernel_deploy. This is to display the warning even if other commands invoking kernel_deploy are run as root/sudo, for example `kw bd`. 

Closes #164 