### PR TITLE
Add error message for wrong commands set in the alert variables

### DIFF
--- a/src/kwio.sh
+++ b/src/kwio.sh
@@ -28,9 +28,23 @@ function alert_completion()
 
   grep -o . <<< "$opts" | while read option;  do
     if [ "$option" == "v" ]; then
-      eval "${configurations[visual_alert_command]} &"
+      if command_exists "${configurations[visual_alert_command]} &"; then
+        eval "${configurations[visual_alert_command]} &"
+      else
+        warning "The following command set in the visual_alert_command variable" \
+        "couldn't be run:"
+        warning "${configurations[visual_alert_command]}"
+        warning "Check if the necessary packages are installed."
+      fi
     elif [ "$option" == "s" ]; then
-      eval "${configurations[sound_alert_command]} &"
+      if command_exists "${configurations[sound_alert_command]} &"; then
+        eval "${configurations[sound_alert_command]} &"
+      else
+        warning "The following command set in the sound_alert_command variable" \
+        "couldn't be run:"
+        warning  "${configurations[sound_alert_command]}"
+        warning "Check if the necessary packages are installed."
+      fi
     fi
   done
 }

--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -313,3 +313,17 @@ function store_statistics_data
 
   echo "$label $value" >> "$day_path"
 }
+
+# This function checks if a certain command can be run
+#
+# @command The whole command that is meant to be executed
+function command_exists()
+{
+  local command="$1"
+  local package=( $command )
+
+  if [[ -x "$(command -v $package)" ]]; then
+    return 0
+  fi
+  return 22 # EINVAL
+}

--- a/tests/kwio_test.sh
+++ b/tests/kwio_test.sh
@@ -2,6 +2,7 @@
 
 . ./tests/utils --source-only
 . ./src/kwio.sh --source-only
+. ./src/kwlib.sh --source-only
 
 # NOTE: All executions off 'alert_completion' in this test file must be done
 # inside a subshell (i.e. "$(alert_completion ...)"), because this function
@@ -17,6 +18,7 @@ function suite
   suite_addTest "alert_completion_options_Test"
   suite_addTest "alert_completition_validate_config_file_options_Test"
   suite_addTest "alert_completion_visual_alert_Test"
+  suite_addTest "alert_completion_sound_alert_Test"
 }
 
 function setUp
@@ -103,11 +105,22 @@ function alert_completition_validate_config_file_options_Test
 
 function alert_completion_visual_alert_Test
 {
+  local output
   local expected="TESTING COMMAND"
-  configurations["visual_alert_command"]="echo \$COMMAND"
-  ret="$(alert_completion "$expected" "--alert=v")"
-  assertEquals "Variable $v should exist." "$ret" "$expected"
-  true
+
+  configurations["visual_alert_command"]="/bin/echo \$COMMAND"
+  output="$(alert_completion "$expected" "--alert=v")"
+  assertEquals "Variable v should exist." "$output" "$expected"
+}
+
+function alert_completion_sound_alert_Test
+{
+  local output
+  local expected="TESTING COMMAND"
+
+  configurations["sound_alert_command"]="/bin/echo \$COMMAND"
+  output="$(alert_completion "$expected" "--alert=s")"
+  assertEquals "Variable s should exist." "$output" "$expected"
 }
 
 invoke_shunit

--- a/tests/kwlib_test.sh
+++ b/tests/kwlib_test.sh
@@ -18,6 +18,7 @@ function suite
   suite_addTest "store_statistics_data_Test"
   suite_addTest "update_statistics_database_Test"
   suite_addTest "statistics_manager_Test"
+  suite_addTest "command_exists_Test"
 }
 
 TARGET_YEAR_MONTH="2020/05"
@@ -353,6 +354,20 @@ function statistics_manager_Test
   ID=4
   configurations['disable_statistics_data_track']='yes'
   assertTrue "($ID) Database day" '[[ ! -f "$statistics_path/$this_year_and_month/$today" ]]'
+}
+
+function command_exists_Test
+{
+  local fake_command="a-non-existent-command -p"
+  local real_command="mkdir"
+
+  output=$(command_exists "$fake_command")
+  ret="$?"
+  assertEquals "$LINENO - We expected 22 as a return" 22 "$ret"
+
+  output=$(command_exists "$real_command")
+  ret="$?"
+  assertEquals "$LINENO - We expected 0 as a return" 0 "$ret"
 }
 
 invoke_shunit


### PR DESCRIPTION
This PR adds a message in case the commands assigned to the alert variables 'sound_alert_command' and 'visual_alert_command' in the kworkflow.config file don't work.

I changed the testing command from "echo" to "/bin/echo", since the latter isn't a built-in, but a file in fact. This was done, so that the command_exists function returns 0 to the testing command. I don't know if this is the best approach, though.



Closes #219