### PR TITLE
run_tests: remove warning when running ./run_tests.sh list

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -176,7 +176,7 @@ if [[ "$#" -eq 0 ]]; then
   strip_path $files_list
   run_tests
 elif [[ "$1" == "list" ]]; then
-  local index=0
+  index=0
   files_list=$(find ./tests/ -name "*_test.sh")
   strip_path $files_list
   for test_name in "${TESTS[@]}"; do


### PR DESCRIPTION
When `./run_tests.sh list` is run, the following warning appears:
`./run_tests.sh: line 179: local: can only be used in a function`
This PR fixes the warning by declaring the 'index' variable globally.