### PR TITLE
src: etc: update network setup for QEMU

### DIFF
--- a/documentation/man/kw.rst
+++ b/documentation/man/kw.rst
@@ -424,7 +424,7 @@ Sets QEMU options. By default, **kw** uses
 qemu_net_options=OPTIONS
 ------------------------
 Defines the network configuration. By default, **kw** uses
-**-net nic -net user,hostfwd=tcp::2222-:22,smb=/home/USER**
+**-nic user,hostfwd=tcp::2222-:22,smb=/home/USERKW**
 
 qemu_path_image=PATH
 --------------------

--- a/etc/kworkflow_template.config
+++ b/etc/kworkflow_template.config
@@ -38,7 +38,7 @@ mount_point=/home/USERKW/p/mount
 qemu_hw_options=-enable-kvm -daemonize -smp 2 -m 1024
 
 # Defines the network configuration
-qemu_net_options=-net nic -net user,hostfwd=tcp::2222-:22,smb=/home/USERKW
+qemu_net_options=-nic user,hostfwd=tcp::2222-:22,smb=/home/USERKW
 
 # Specify the VM image path
 qemu_path_image=/home/USERKW/p/virty.qcow2

--- a/tests/kw_config_loader_test.sh
+++ b/tests/kw_config_loader_test.sh
@@ -102,7 +102,7 @@ function parse_configuration_standard_config_Test
     [virtualizer]="qemu-system-x86_64"
     [qemu_path_image]="/home/USERKW/p/virty.qcow2"
     [qemu_hw_options]="-enable-kvm -daemonize -smp 2 -m 1024"
-    [qemu_net_options]="-net nic -net user,hostfwd=tcp::2222-:22,smb=/home/USERKW"
+    [qemu_net_options]="-nic user,hostfwd=tcp::2222-:22,smb=/home/USERKW"
     [ssh_ip]="localhost"
     [ssh_port]="22"
     [mount_point]="/home/USERKW/p/mount"

--- a/tests/samples/etc/kworkflow.config
+++ b/tests/samples/etc/kworkflow.config
@@ -27,7 +27,7 @@ mount_point=/home/USERKW/p/mount
 qemu_hw_options=-enable-kvm -daemonize -smp 2 -m 1024
 
 # Defines the network configuration
-qemu_net_options=-net nic -net user,hostfwd=tcp::2222-:22,smb=/home/USERKW
+qemu_net_options=-nic user,hostfwd=tcp::2222-:22,smb=/home/USERKW
 
 # Specify the VM image path
 qemu_path_image=/home/USERKW/p/virty.qcow2

--- a/tests/samples/kworkflow_template.config
+++ b/tests/samples/kworkflow_template.config
@@ -27,7 +27,7 @@ mount_point=/home/USERKW/p/mount
 qemu_hw_options=-enable-kvm -daemonize -smp 2 -m 1024
 
 # Defines the network configuration
-qemu_net_options=-net nic -net user,hostfwd=tcp::2222-:22,smb=/home/USERKW
+qemu_net_options=-nic user,hostfwd=tcp::2222-:22,smb=/home/USERKW
 
 # Specify the VM image path
 qemu_path_image=/home/USERKW/p/virty.qcow2

--- a/tests/samples/kworkflow_x86.config
+++ b/tests/samples/kworkflow_x86.config
@@ -6,7 +6,7 @@ menu_config=nconfig
 virtualizer=qemu-system-x86_64
 mount_point=/home/USERKW/p/mount
 qemu_hw_options=-enable-kvm -daemonize -smp 2 -m 1024
-qemu_net_options=-net nic -net user,hostfwd=tcp::2222-:22,smb=/home/USERKW
+qemu_net_options=-nic user,hostfwd=tcp::2222-:22,smb=/home/USERKW
 qemu_path_image=/home/USERKW/p/virty.qcow2
 alert=n
 sound_alert_command=paplay SOUNDPATH/complete.wav


### PR DESCRIPTION
The previous default network options for QEMU used a legacy option `-net`.
This commit updates the default to use the newer `-nic`.
More specific network configurations could be set using `-netdev`, but this
is somewhat dependent on the individual setup, and I believe the solution used
is more general.

Closes #257

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@usp.br>