### PR TITLE
setup: Make setup show usage when incorrect number of args given

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -408,6 +408,7 @@ case "$1" in
     ;;
   *)
     complain "Invalid number of arguments"
+    usage
     exit 1
     ;;
 esac


### PR DESCRIPTION
I felt it would be useful especially to new users to give this information
if they try to use setup incorrectly.
Alternatively we could show a different custom message.

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@usp.br>