### PR TITLE
src: signal_manager: Implement signal manager

### DIFF
--- a/documentation/content/codingstyle.rst
+++ b/documentation/content/codingstyle.rst
@@ -263,6 +263,17 @@ ideally, we want it in the same file. For example, you should find details on
 using the `build` option in the mk.sh, and for `configm` in the file
 config_manager.sh.
 
+Handling Signals
+----------------
+It is natural for commands to set global variables or to create temporary files
+during their execution. However, all commands should expect to receive signals
+and be able to properly handle them. If you implement a new feature, take some
+time to check if it pollutes the environment. If it does, make sure to handle
+it's de-pollution upon receiving a SIGINT or a SIGTERM: an interrupted command
+should always leave the environment in the same state as it was prior to its
+invocation. Convenience functions for this purpose (setting and resetting
+handlers for arbitrary signals) are implemented in `src/signal_manager`.
+
 Conclusion
 ----------
 

--- a/kw
+++ b/kw
@@ -33,10 +33,14 @@ export KWORKFLOW
 # The include function (sourced from this file) should always be used for file sourcing.
 . "$KW_LIB_DIR/kw_include.sh" --source-only
 
+include "$KW_LIB_DIR"/signal_manager.sh
+
 function kw()
 {
   action="$1"
   shift
+
+  signal_manager || warning 'Was not able to set signal handler'
 
   mkdir -p "$KW_CACHE_DIR"
 

--- a/src/signal_manager.sh
+++ b/src/signal_manager.sh
@@ -1,0 +1,71 @@
+include "$KW_LIB_DIR/kwio.sh"
+
+function get_valid_signals()
+{
+  local -r signal_list="$(trap -l | grep -oE 'SIG\S+')"
+  declare -gA SIGNAL_MANAGER_VALID_SIGNALS
+
+  for s in $signal_list; do
+    SIGNAL_MANAGER_VALID_SIGNALS["$s"]='1'
+  done
+}
+
+get_valid_signals
+
+# This functions prints the default message when interrupting kw
+function default_interrupt_handler()
+{
+  say $'\n'Oh no! An interruption! See ya...
+}
+
+# This function adds a new signal handler to an arbitrary signal
+#
+# @command The handler to be called when a signal is catched. This
+#          must be a single command
+# @signals The list of signals to attach to this handler
+#
+# If command is empty, use the default handler
+# If the signal is empty, use the default signals
+
+# shellcheck disable=2120
+function signal_manager()
+{
+  local command="$1"
+  shift
+  local -a signals=("$@")
+
+  if [[ -z "$command" ]]; then
+    command='default_interrupt_handler'
+  elif ! type "$command" > /dev/null 2>&1; then
+    return 22 # EINVAL
+  fi
+
+  if [[ "${#signals}" == 0 ]]; then
+    signals=(SIGINT SIGTERM)
+  else
+    for s in "${signals[@]}"; do
+      if [[ ! -v SIGNAL_MANAGER_VALID_SIGNALS["$s"] &&
+        ! -v SIGNAL_MANAGER_VALID_SIGNALS[SIG"$s"] ]]; then
+        return 22 # EINVAL
+      fi
+    done
+  fi
+
+  # shellcheck disable=2064
+  trap "$command" "${signals[@]}" 2> /dev/null
+}
+
+# This function resets all signal handlers to their system defaults and
+# sets kw's default signal handler for SIGINT and SIGTERM
+function signal_manager_reset()
+{
+  local traps
+
+  traps=$(trap -p | grep -o '[^ ]*$')
+
+  while read -r sig; do
+    trap - "$sig"
+  done <<< "$traps"
+
+  signal_manager
+}

--- a/tests/signal_manager_test.sh
+++ b/tests/signal_manager_test.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+include './src/signal_manager.sh'
+include './tests/utils.sh'
+
+function oneTimeSetUp()
+{
+  declare -gr test_phrase="This is a phrase."
+  declare -gr file_name="out.tmp"
+  declare -gr original_dir="$PWD"
+}
+
+function setUp()
+{
+  cd "$SHUNIT_TMPDIR" || fail "($LINENO): Was not able to cd into temporary directory"
+}
+
+function write_to_file()
+{
+  echo "$test_phrase" > "$file_name"
+}
+
+function test_default_handler()
+{
+  local -r expected=$'\n'"Oh no! An interruption! See ya..."
+
+  trap 'kill -s SIGTERM $!' SIGUSR1
+  {
+    signal_manager default_interrupt_handler SIGINT SIGTERM
+    sleep infinity &
+    echo $! > sleep_pid
+    kill -s SIGUSR1 $$ # Send SIGUSR1 to parent process
+    wait $!            # wait for SIGTERM
+  } > out.tmp &
+
+  wait $! # wait for SIGUSR1
+  kill "$(cat sleep_pid)"
+  assertEquals "($LINENO)" "$expected" "$(cat "$file_name")"
+
+  rm -f out.tmp
+
+  trap 'kill -s SIGINT $!' SIGUSR1
+  {
+    signal_manager default_interrupt_handler SIGINT SIGTERM
+    sleep infinity &
+    echo $! > sleep_pid
+    kill -s SIGUSR1 $$ # Send SIGUSR1 to parent process
+    wait $!            # wait for SIGINT
+  } > out.tmp &
+
+  wait $!
+  kill "$(cat sleep_pid)"
+  assertEquals "($LINENO)" "$expected" "$(cat "$file_name")"
+}
+
+function test_non_signal()
+{
+  local ret
+
+  signal_manager echo SIGNONEXISTENT
+  ret="$?"
+  assertFalse "($LINENO) Should have received an error." "$ret"
+
+  signal_manager echo 'HUP SIG'
+  ret="$?"
+  assertFalse "($LINENO) Should have received an error." "$ret"
+}
+
+function test_new_signal()
+{
+  # Enable job control. This allows us to send a SIGINT signal to this
+  # very process without it being interrupted. The special parameter $$,
+  # used below, is used to get the current process's PID
+  set -m
+
+  signal_manager write_to_file SIGINT
+  kill -s SIGINT $$
+  assertEquals "($LINENO)" "$test_phrase" "$(cat "$file_name")"
+
+  signal_manager write_to_file SIGTERM
+  kill -s SIGTERM $$
+  assertEquals "($LINENO)" "$test_phrase" "$(cat "$file_name")"
+
+  set +m
+}
+
+function test_signal_reset()
+{
+  local ret
+  local output
+
+  signal_manager write_to_file SIGINT SIGTERM
+  signal_manager_reset
+  output="$(trap -p)"
+
+  echo "$output" | grep -q "trap -- 'default_interrupt_handler' SIGINT"
+  ret="$?"
+  assertTrue "($LINENO) Default handler not set." "$ret"
+
+  echo "$output" | grep -q "trap -- 'default_interrupt_handler' SIGTERM"
+  ret="$?"
+  assertTrue "($LINENO) Default handler not set." "$ret"
+}
+
+function test_add_two_signals()
+{
+  signal_manager write_to_file SIGINT SIGTERM
+  local -r output="$(trap)"
+  local ret
+
+  echo "$output" | grep -q "trap -- 'write_to_file' SIGINT"
+  ret="$?"
+  assertTrue "($LINENO) Trap not set" "$ret"
+
+  echo "$output" | grep -q "trap -- 'write_to_file' SIGTERM"
+  ret="$?"
+  assertTrue "($LINENO) Trap not set" "$ret"
+}
+
+function test_compound_signal()
+{
+  signal_manager 'echo something; ls'
+  ret="$?"
+  assertFalse "($LINENO) Compound command accepted" "$ret"
+}
+
+invoke_shunit


### PR DESCRIPTION
Currently, kw does not handle signals. If you pass it a SIGINT, for
example, the subprocess that happens to be executing at that particular
moment is the one who will receive and treat it. This results in a poor
user interface, where the standard Ctrl-C doesn’t have a meaningful
outcome. Worse than that, a simple SIGINT could leave the environment
polluted by unremoved temporary files. This patch:

 - Implements functions for adding and resetting handlers
 - Implements default handler for SIGINT and SIGTERM
 - Describes a use policy of signal handling in
   documentation/content/howtocontribute.rst

closes: #270

Signed-off-by: João Seckler <jseckler@riseup.net>