### PR TITLE
Fix 'kw statistics' output

### DIFF
--- a/src/statistics.sh
+++ b/src/statistics.sh
@@ -6,7 +6,7 @@
 
 # This is a data struct that describes the main type of data collected. We use
 # this in some internal loops.
-declare -A statistics_opt=( ["deploy"]=1 ["build"]=2 ["list"]=3 ["uninstall"]=4 ["build_failure"]=5  ["Modules_deploy"]=5 )
+declare -a statistics_opt=( "deploy" "build" "list" "uninstall" "build_failure" "Modules_deploy" )
 
 # ATTENTION:
 # This variable is shared between function, for this reason, it is NOT SAFE to
@@ -195,14 +195,14 @@ function sec_to_formatted_date()
 # Note: This function relies on a global variable named shared_data.
 function print_basic_data()
 {
-  local line=" Total Max Min Average\n"
-  for option in "${!statistics_opt[@]}"; do
+  local header_format="%20s %4s %8s %12s\n"
+  local row_format="%-14s %5d %s %s %s\n"
+
+  printf "$header_format" Total Max Min Average
+  for option in "${statistics_opt[@]}"; do
     [[ -z "${shared_data[$option]}" ]] && continue
-
-    line="${line}${option^} ${shared_data[$option]}\n"
+    printf "$row_format" "${option^}" ${shared_data[$option]}
   done
-
-  column -t -s' ' <<< $(echo -e "$line")
 }
 
 # This function expect a list of values organized as "<LABEL> <VALUE>", it will
@@ -225,7 +225,7 @@ function basic_data_process()
   local max
   local min
 
-  for option in "${!statistics_opt[@]}"; do
+  for option in "${statistics_opt[@]}"; do
     values=$(echo -e "$all_data" | grep "$option" | cut -d' ' -f2-)
     [[ -z "$values" ]] && continue
 

--- a/tests/statistics_test.sh
+++ b/tests/statistics_test.sh
@@ -201,8 +201,8 @@ function year_statistics_Test
   local line
 
   declare -a expected_cmd=(
-    'Build   19   00:03:40  00:00:06  00:00:23'
-    'Deploy  8    00:01:13  00:00:31  00:01:04'
+    'Deploy             8 00:01:13 00:00:31 00:01:04'
+    'Build             19 00:03:40 00:00:06 00:00:23'
   )
 
   year_data=$(year_statistics "$target_year")
@@ -212,11 +212,11 @@ function year_statistics_Test
   compare_command_sequence expected_cmd[@] "$year_data" "$LINENO"
 
   declare -a expected_cmd=(
-    'Uninstall      3    00:00:03  00:00:02  00:00:02'
-    'Build_failure  1    00:00:01  00:00:01  00:00:01'
-    'Build          3    00:00:55  00:00:01  00:00:19'
-    'Deploy         1    00:00:21  00:00:21  00:00:21'
-    'List           2    00:00:08  00:00:00  00:00:04'
+    'Deploy             1 00:00:21 00:00:21 00:00:21'
+    'Build              3 00:00:55 00:00:01 00:00:19'
+    'List               2 00:00:08 00:00:00 00:00:04'
+    'Uninstall          3 00:00:03 00:00:02 00:00:02'
+    'Build_failure      1 00:00:01 00:00:01 00:00:01'
   )
 
   year_data=$(year_statistics 2021 | tail -n 5)

--- a/tests/statistics_test.sh
+++ b/tests/statistics_test.sh
@@ -10,6 +10,7 @@
 # Max: 9433
 function suite
 {
+  suite_addTest "statistics_Test"
   suite_addTest "calculate_average_Test"
   suite_addTest "calculate_total_of_data_Test"
   suite_addTest "max_value_Test"
@@ -49,81 +50,78 @@ function setUp
   pre_formated_sec='00:30:46'
 }
 
+function statistics_Test
+{
+  local msg
+
+  declare -a expected_cmd=(
+    "You have disable_statistics_data_track marked as 'yes'"
+    "If you want to see the statistics, change this option to 'no'"
+  )
+
+  configurations[disable_statistics_data_track]='yes'
+  output=$(statistics --)
+  compare_command_sequence expected_cmd[@] "$output" "$LINENO"
+
+  configurations[disable_statistics_data_track]='no'
+
+  output=$(statistics --invalid-option)
+  msg="Invalid parameter: --invalid-option"
+  assertEquals "($LINENO)" "$msg" "$output"
+}
+
 function calculate_average_Test
 {
-  local ID
-
-  ID=1
   avg=$(calculate_average "10")
-  assertEquals "($ID)" "10" "$avg"
+  assertEquals "($LINENO)" "10" "$avg"
 
-  ID=2
   avg=$(calculate_average "$pre_values")
-  assertEquals "($ID)" "$pre_avg" "$avg"
+  assertEquals "($LINENO)" "$pre_avg" "$avg"
 }
 
 function calculate_total_of_data_Test
 {
-  local ID
-
-  ID=1
   total=$(calculate_total_of_data "1")
-  assertEquals "($ID)" "1" "$total"
+  assertEquals "($LINENO)" "1" "$total"
 
-  ID=2
   total=$(calculate_total_of_data "")
-  assertEquals "($ID)" "0" "$total"
+  assertEquals "($LINENO)" "0" "$total"
 
-  ID=3
   total=$(calculate_total_of_data "$pre_values")
-  assertEquals "($ID)" "$pre_total" "$total"
+  assertEquals "($LINENO)" "$pre_total" "$total"
 }
 
 function max_value_Test
 {
-  local ID
-
-  ID=1
   max=$(max_value "0")
-  assertEquals "($ID)" "$max" "0"
+  assertEquals "($LINENO)" "$max" "0"
 
-  ID=2
   max=$(max_value "")
-  assertEquals "($ID)" "$max" "0"
+  assertEquals "($LINENO)" "$max" "0"
 
-  ID=3
   max=$(max_value "$pre_values")
-  assertEquals "($ID)" "$pre_max" "$max"
+  assertEquals "($LINENO)" "$pre_max" "$max"
 }
 
 function min_value_Test
 {
-  local ID
-
-  ID=1
   min=$(min_value "0" "0")
-  assertEquals "($ID)" "$min" "0"
+  assertEquals "($LINENO)" "$min" "0"
 
-  ID=1
   min=$(min_value "" "")
-  assertEquals "($ID)" "$min" ""
+  assertEquals "($LINENO)" "$min" ""
 
-  ID=2
   min=$(min_value "$pre_values" "$pre_max")
-  assertEquals "($ID)" "$min" "$pre_min"
+  assertEquals "($LINENO)" "$min" "$pre_min"
 }
 
 function sec_to_formatted_date_Test
 {
-  local ID
-
-  ID=1
   formatted_time=$(sec_to_formatted_date "$pre_total_sec")
-  assertEquals "($ID)" "$formatted_time" "$pre_formated_sec"
+  assertEquals "($LINENO)" "$formatted_time" "$pre_formated_sec"
 
-  ID=2
   formatted_time=$(sec_to_formatted_date "")
-  assertEquals "($ID)" "$formatted_time" "00:00:00"
+  assertEquals "($LINENO)" "$formatted_time" "00:00:00"
 }
 
 # Note: The weekly, monthly, and yearly calculation uses `basic_data_process`.
@@ -132,26 +130,22 @@ function sec_to_formatted_date_Test
 # operation in the weekly, monthly, and yearly tests.
 function basic_data_process_Test
 {
-  local ID
   local data
   local day_path="$base_statistics/05/27"
 
   data=$(cat "$day_path")
 
-  ID=1
   basic_data_process "$data"
   build="${shared_data["build"]}"
-  assertEquals "($ID)" "$build_output" "$build"
+  assertEquals "($LINENO)" "$build_output" "$build"
 
-  ID=2
   basic_data_process "$data"
   deploy="${shared_data["deploy"]}"
-  assertEquals "($ID)" "$deploy_output" "$deploy"
+  assertEquals "($LINENO)" "$deploy_output" "$deploy"
 
-  ID=3
   basic_data_process "$data"
   deploy="${shared_data["list"]}"
-  assertEquals "($ID)" "" "$deploy"
+  assertEquals "($LINENO)" "" "$deploy"
 }
 
 function day_statistics_Test
@@ -161,13 +155,11 @@ function day_statistics_Test
   local msg1='Currently, kw does not have any data for the present date.'
   local msg2='There is no data in the kw records'
 
-  ID=1
   day_data=$(day_statistics "an/invalid/path")
-  assertEquals "($ID)" "$msg1" "$day_data"
+  assertEquals "($LINENO)" "$msg1" "$day_data"
 
-  ID=2
   day_data=$(day_statistics "$base_statistics/05/28")
-  assertEquals "($ID)" "$msg2" "$day_data"
+  assertEquals "($LINENO)" "$msg2" "$day_data"
 }
 
 function week_statistics_Test
@@ -178,9 +170,8 @@ function week_statistics_Test
   local end_target_week='2019/05/11'
   local msg="Sorry, kw does not have any data from $start_target_week to $end_target_week"
 
-  ID=1
   week_data=$(week_statistics "$start_target_week" "$end_target_week")
-  assertEquals "($ID)" "$msg" "$week_data"
+  assertEquals "($LINENO)" "$msg" "$week_data"
 }
 
 function month_statistics_Test
@@ -188,9 +179,8 @@ function month_statistics_Test
   local target_month='2019/05'
   local msg='Currently, kw does not have any data for the present month.'
 
-  ID=1
   month_data=$(month_statistics "$target_month")
-  assertEquals "($ID)" "$msg" "$month_data"
+  assertEquals "($LINENO)" "$msg" "$month_data"
 }
 
 function year_statistics_Test


### PR DESCRIPTION
The output of kw statistics was presented differently depending on the versions of Bash and the column command.
Instead of using the column utility, which can have different formatting options depending on where it comes from (util-linux, or bsdmanutils, or bsdextrautils), I chose to use `printf`, instead.
Another change was the type of variable of `statistics_opt`: it was an associative array, and I chose to let it be a normal array, since this type keeps the ordering.

This PR closes issues #267 and #280, which are pretty much relatable, and also addresses issue #276.