### PR TITLE
tests: kwlib_test: use help builtin to test pwd

### DIFF
--- a/tests/kwlib_test.sh
+++ b/tests/kwlib_test.sh
@@ -101,7 +101,7 @@ function cmd_manager_check_silent_option_Test
   assertTrue "We expected to find scripts" '[[ $ret =~ scripts ]]'
 
   # Test command with parameters
-  ret=$(cmd_manager SILENT pwd --help)
+  ret=$(cmd_manager SILENT help pwd)
   assertTrue "We expected to find -P" '[[ $ret =~ -P ]]'
   assertTrue "We expected to find -L" '[[ $ret =~ -L ]]'
 
@@ -123,8 +123,7 @@ function cmdManagerSAY_COMPLAIN_WARNING_SUCCESS_Test
   assertTrue "We expected to find scripts" '[[ $ret =~ scripts ]]'
 
   # TODO: There's an alternative to discover the color?
-  ret=$(cmd_manager COMPLAIN pwd --help)
-  assertTrue "We expected to find the ls command" '[[ $ret =~ --help ]]'
+  ret=$(cmd_manager COMPLAIN help pwd)
   assertTrue "We expected to find -P" '[[ $ret =~ -P ]]'
   assertTrue "We expected to find -L" '[[ $ret =~ -L ]]'
 


### PR DESCRIPTION
Testing kw's command manager with `pwd --help` would break in older
versions of bash, since this option was not available. Using `help pwd`
instead gives consistency to the test.

Closes: #126

Signed-off-by: João Seckler <jseckler@riseup.net>