### PR TITLE
Add github bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Which commands were invoked
+2. Where the error appears
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. Debian Bullseye]
+ - Version [e.g. 0.4]
+ - Bash Version [e.g. 5.1.4]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Add a bug report template for kw's github page, to make such issues
easier to open and to encourage them to be more complete and precise.

Signed-off-by: João Seckler <jseckler@riseup.net>