### PR TITLE
Remove unnecessary variables from kw file

### DIFF
--- a/kw
+++ b/kw
@@ -27,12 +27,6 @@ KW_DATA_DIR=${KW_DATA_DIR:-"$HOME/.kw"}
 KW_PLUGINS_DIR=${KW_PLUGINS_DIR:-"$KW_LIB_DIR/plugins"}
 KW_CACHE_DIR="$HOME/.cache/kw"
 
-# User data
-# TODO: These two variables just introduce more complexity, try to get rid of
-# them.
-config_files_path=${config_files_path:-"$KW_DATA_DIR"}
-statistics_path=${statistics_path:-"$KW_DATA_DIR/statistics"}
-
 # Export external variables required by kworkflow
 export KWORKFLOW
 

--- a/src/config_manager.sh
+++ b/src/config_manager.sh
@@ -29,7 +29,7 @@ function save_config_file()
   local -r name="$2"
   local -r description="$3"
   local -r original_path="$PWD"
-  local -r dot_configs_dir="$config_files_path/configs"
+  local -r dot_configs_dir="$KW_DATA_DIR/configs"
 
   if [[ ! -f "$original_path/.config" ]]; then
     complain "There's no .config file in the current directory"
@@ -75,7 +75,7 @@ function save_config_file()
 
 function list_configs()
 {
-  local -r dot_configs_dir="$config_files_path/configs"
+  local -r dot_configs_dir="$KW_DATA_DIR/configs"
 
   if [[ ! -d "$dot_configs_dir" || ! -d "$dot_configs_dir/$metadata_dir" ]]; then
     say "There's no tracked .config file"
@@ -109,7 +109,7 @@ function basic_config_validations()
   local force="$2"
   local operation="$3" && shift 3
   local message="$@"
-  local -r dot_configs_dir="$config_files_path/configs/configs"
+  local -r dot_configs_dir="$KW_DATA_DIR/configs/configs"
 
   if [[ ! -f "$dot_configs_dir/$target" ]]; then
     complain "No such file or directory: $target"
@@ -141,7 +141,7 @@ function get_config()
 {
   local target="$1"
   local force="$2"
-  local -r dot_configs_dir="$config_files_path/configs/configs"
+  local -r dot_configs_dir="$KW_DATA_DIR/configs/configs"
   local -r msg="This operation will override the current .config file"
 
   force=${force:-0}
@@ -167,7 +167,7 @@ function remove_config()
   local target="$1"
   local force="$2"
   local original_path="$PWD"
-  local -r dot_configs_dir="$config_files_path/configs"
+  local -r dot_configs_dir="$KW_DATA_DIR/configs"
   local -r msg="This operation will remove $target from kw management"
 
   basic_config_validations "$target" "$force" "Remove" "$msg"

--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -271,7 +271,7 @@ function statistics_manager
   local value="$2"
   local day=$(date +%d)
   local year_month_dir=$(date +%Y/%m)
-  local day_path="$statistics_path/$year_month_dir/$day"
+  local day_path="$KW_DATA_DIR/statistics/$year_month_dir/$day"
 
   elapsed_time=$(date -d@$value -u +%H:%M:%S)
   say "-> Execution time: $elapsed_time"
@@ -294,8 +294,8 @@ function update_statistics_database
 
   [[ -z "$day" || -z "$year_month_path" ]] && return 22 # EINVAL
 
-  mkdir -p "$statistics_path/$year_month_path"
-  touch "$statistics_path/$year_month_path/$day"
+  mkdir -p "$KW_DATA_DIR/statistics/$year_month_path"
+  touch "$KW_DATA_DIR/statistics/$year_month_path/$day"
 }
 
 # This function save the information directly to a file.

--- a/src/statistics.sh
+++ b/src/statistics.sh
@@ -48,9 +48,9 @@ function statistics()
   case "$info_request" in
     --day)
       if [[ -z "$date_param" ]]; then
-        target_day="$statistics_path/$year_month_dir/$day"
+        target_day="$KW_DATA_DIR/statistics/$year_month_dir/$day"
       else
-        target_day="$statistics_path/$(date_to_format "$date_param")"
+        target_day="$KW_DATA_DIR/statistics/$(date_to_format "$date_param")"
         if [[ "$?" != 0 ]]; then
           complain "Invalid parameter: $date_param"
           return 22 # EINVAL
@@ -271,9 +271,9 @@ function week_statistics()
   # 7 -> week days
   for (( i=0 ; i < 7 ; i++ )); do
     day=$(date --date="${first} +${i} day" +%Y/%m/%d)
-    [[ ! -f "$statistics_path/$day" ]] && continue
+    [[ ! -f "$KW_DATA_DIR/statistics/$day" ]] && continue
 
-    all_file_data=$(cat "$statistics_path/$day")
+    all_file_data=$(cat "$KW_DATA_DIR/statistics/$day")
     [[ -z "$all_file_data" ]] && continue
 
     all_data="${all_data}${all_file_data}\n"
@@ -291,7 +291,7 @@ function week_statistics()
 
 function month_statistics()
 {
-  local month_path="$statistics_path/$1"
+  local month_path="$KW_DATA_DIR/statistics/$1"
   local all_data=""
 
   if [[ ! -d "$month_path" ]]; then
@@ -320,13 +320,12 @@ function month_statistics()
 function year_statistics()
 {
   local year="$1"
-
-  if [[ ! -d "$statistics_path/$year" ]]; then
+  if [[ ! -d "$KW_DATA_DIR/statistics/$year" ]]; then
     say "Currently, kw does not have any data for the requested year."
     return 0
   fi
 
-  all_year_file=$(find "$statistics_path/$year" -follow)
+  all_year_file=$(find "$KW_DATA_DIR/statistics/$year" -follow)
 
   # We did not add "" around all_year_file on purpose
   for day_full_path in $all_year_file; do

--- a/tests/configm_test.sh
+++ b/tests/configm_test.sh
@@ -50,6 +50,8 @@ function setUp()
   touch .config
   echo "$CONTENT" > .config
   cd "$current_path"
+  KW_DATA_DIR="$current_path/$TMP_TEST_DIR"
+  configs_path="$KW_DATA_DIR/configs"
 }
 
 function tearDown()
@@ -113,8 +115,6 @@ function save_config_file_check_save_failures_Test()
 function save_config_file_check_directories_creation_Test()
 {
   local current_path="$PWD"
-  local config_files_path="$current_path/$TMP_TEST_DIR"
-  local configs_path="$config_files_path/configs"
 
   # There's no configs yet, initialize it
   cd "$TMP_TEST_DIR"
@@ -131,8 +131,6 @@ function save_config_file_check_directories_creation_Test()
 function save_config_file_check_saved_config_Test()
 {
   local current_path="$PWD"
-  local config_files_path="$current_path/$TMP_TEST_DIR"
-  local configs_path="$config_files_path/configs"
   local ret=0
   local msg
 
@@ -163,8 +161,6 @@ function save_config_file_check_saved_config_Test()
 function save_config_file_check_description_Test()
 {
   local current_path="$PWD"
-  local config_files_path="$current_path/$TMP_TEST_DIR"
-  local configs_path="$config_files_path/configs"
   local ret=0
   local msg
 

--- a/tests/kwlib_test.sh
+++ b/tests/kwlib_test.sh
@@ -21,8 +21,9 @@ function suite
   suite_addTest "command_exists_Test"
 }
 
+KW_DATA_DIR="tests/.tmp"
 TARGET_YEAR_MONTH="2020/05"
-FAKE_STATISTICS_PATH="tests/.tmp"
+FAKE_STATISTICS_PATH="$KW_DATA_DIR/statistics"
 FAKE_STATISTICS_MONTH_PATH="$FAKE_STATISTICS_PATH/$TARGET_YEAR_MONTH"
 FAKE_STATISTICS_DAY_PATH="$FAKE_STATISTICS_MONTH_PATH/03"
 
@@ -37,8 +38,6 @@ function setupFakeOSInfo
 
 function setupPatch
 {
-  export statistics_path="$FAKE_STATISTICS_PATH"
-
   mkdir -p "$FAKE_STATISTICS_MONTH_PATH"
   touch "$FAKE_STATISTICS_DAY_PATH"
   cp -f tests/samples/test.patch tests/.tmp/
@@ -339,20 +338,20 @@ function statistics_manager_Test
 
   ID=1
   output=$(statistics_manager "values" "33")
-  assertTrue "($ID) Database folders failures" '[[ -d "$statistics_path/$this_year_and_month" ]]'
+  assertTrue "($ID) Database folders failures" '[[ -d "$FAKE_STATISTICS_PATH/$this_year_and_month" ]]'
 
   ID=2
-  assertTrue "($ID) Database day" '[[ -f "$statistics_path/$this_year_and_month/$today" ]]'
+  assertTrue "($ID) Database day" '[[ -f "$FAKE_STATISTICS_PATH/$this_year_and_month/$today" ]]'
 
   ID=3
-  stored_value=$(cat "$statistics_path/$this_year_and_month/$today")
+  stored_value=$(cat "$FAKE_STATISTICS_PATH/$this_year_and_month/$today")
   assertEquals "($ID) - " "values 33" "$stored_value"
 
   tearDownSetup
 
   ID=4
   configurations['disable_statistics_data_track']='yes'
-  assertTrue "($ID) Database day" '[[ ! -f "$statistics_path/$this_year_and_month/$today" ]]'
+  assertTrue "($ID) Database day" '[[ ! -f "$FAKE_STATISTICS_PATH/$this_year_and_month/$today" ]]'
 }
 
 function command_exists_Test

--- a/tests/statistics_test.sh
+++ b/tests/statistics_test.sh
@@ -24,10 +24,10 @@ function suite
 
 function setUp
 {
-  export statistics_path='tests/samples/statistics'
+  export KW_DATA_DIR="tests/samples"
 
   # Samples file data
-  base_statistics="$statistics_path/2020"
+  base_statistics="tests/samples/statistics/2020"
   sample_total='19'
   sample_build_avg='00:00:23' #23
   sample_build_min='00:00:06' #6


### PR DESCRIPTION
This PR removes the config_files_path and statistics_path variables set in the kw file, as well as makes the necessary adjustments for it.

Closes #287