### PR TITLE
codestyle: fix formatting of our codebase

### DIFF
--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -1,0 +1,19 @@
+name: formatter-shfmt
+on:
+  [push, pull_request]
+jobs:
+  sh-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run the sh-checker
+        uses: luizm/action-sh-checker@v0.3.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHFMT_OPTS: -i=2 -ln=bash -fn -ci -sr # arguments to shfmt.
+        with:
+          sh_checker_comment: true
+          sh_checker_exclude: "documentation images sounds etc"
+          sh_checker_shfmt_disable: false
+          sh_checker_shellcheck_disable: true
+          sh_checker_checkbashisms_enable: false

--- a/documentation/content/codingstyle.rst
+++ b/documentation/content/codingstyle.rst
@@ -19,6 +19,23 @@ style, for this reason, we copied-and-pasted many pieces from both projects.
 .. _Git: https://github.com/git/git/blob/master/Documentation/CodingGuidelines#L41
 .. _Linux: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst
 
+
+shfmt
+_____
+
+To help us enforce our codestyle decisions we utilize the
+`shfmt <https://github.com/mvdan/sh>`_ code formatter in our CI pipeline.
+Please refer to the shfmt repository for instructions on how to install it
+on your specific linux distribution, it is available as a package for most
+distributions and as a plugin for most IDEs and text editors.
+To format a file using shfmt::
+
+  shfmt -w -i=2 -ln=bash -fn -ci -sr FILE
+
+To check a file and error with a diff when the formatting differs::
+
+  shfmt -d -i=2 -ln=bash -fn -ci -sr FILE
+
 Indentation
 -----------
 

--- a/kw
+++ b/kw
@@ -33,7 +33,6 @@ export KWORKFLOW
 # The include function (sourced from this file) should always be used for file sourcing.
 . "$KW_LIB_DIR/kw_include.sh" --source-only
 
-
 function kw()
 {
   action="$1"
@@ -50,7 +49,7 @@ function kw()
         return "$?"
       )
       ;;
-    mount|mo)
+    mount | mo)
       (
         include "$KW_LIB_DIR/vm.sh"
 
@@ -60,7 +59,7 @@ function kw()
         return "$ret"
       )
       ;;
-    umount|um)
+    umount | um)
       (
         include "$KW_LIB_DIR/vm.sh"
 
@@ -70,14 +69,14 @@ function kw()
         return "$ret"
       )
       ;;
-    up|u)
+    up | u)
       (
         include "$KW_LIB_DIR/vm.sh"
 
         vm_up
       )
       ;;
-    build|b)
+    build | b)
       (
         include "$KW_LIB_DIR/mk.sh"
 
@@ -87,7 +86,7 @@ function kw()
         return "$ret"
       )
       ;;
-    deploy|d)
+    deploy | d)
       (
         include "$KW_LIB_DIR/mk.sh"
 
@@ -107,12 +106,12 @@ function kw()
         return "$ret"
       )
       ;;
-    diff|df)
-        include "$KW_LIB_DIR/diff.sh"
+    diff | df)
+      include "$KW_LIB_DIR/diff.sh"
 
-        diff_manager "$@"
+      diff_manager "$@"
       ;;
-    ssh|s)
+    ssh | s)
       (
         include "$KW_LIB_DIR/kw_config_loader.sh"
         include "$KW_LIB_DIR/remote.sh"
@@ -127,35 +126,35 @@ function kw()
         show_variables
       )
       ;;
-    codestyle|c)
+    codestyle | c)
       (
         include "$KW_LIB_DIR/checkpatch_wrapper.sh"
 
         execute_checkpatch "$@"
       )
       ;;
-    maintainers|m)
+    maintainers | m)
       (
         include "$KW_LIB_DIR/get_maintainer_wrapper.sh"
 
         execute_get_maintainer $@
       )
       ;;
-    configm|g)
+    configm | g)
       (
         include "$KW_LIB_DIR/config_manager.sh"
 
         execute_config_manager "$@"
       )
       ;;
-    help|h)
+    help | h)
       (
         include "$KW_LIB_DIR/help.sh"
 
         kworkflow_help
       )
       ;;
-    explore|e)
+    explore | e)
       (
         include "$KW_LIB_DIR/explore.sh"
 
@@ -169,7 +168,7 @@ function kw()
         kworkflow_man
       )
       ;;
-    version|--version|-v)
+    version | --version | -v)
       (
         include "$KW_LIB_DIR/help.sh"
 
@@ -183,7 +182,7 @@ function kw()
         statistics "$@"
       )
       ;;
-    pomodoro|p)
+    pomodoro | p)
       (
         . "$KW_LIB_DIR/pomodoro.sh" --source-only
 
@@ -192,9 +191,9 @@ function kw()
       ;;
 
     clear-cache)
-        include "$KW_LIB_DIR/mk.sh"
+      include "$KW_LIB_DIR/mk.sh"
 
-        cleanup
+      cleanup
       ;;
     # Subsystems support
     drm)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,7 +6,7 @@ include './src/kwio.sh'
 
 declare -r PATH_TO_TESTS_EXTERNALS="tests/external"
 
-function show_help
+function show_help()
 {
   echo "Usage: $0 [help] [list] [test tfile1 tfile2 ... tfilen] [prepare [-f|--force-update]]"
   echo "Run tests for kworkflow."
@@ -24,9 +24,9 @@ function download_stuff()
   local OVERWRITE="$3"
 
   if "$OVERWRITE"; then
-      ret=$(wget -N "$URL" -P "$PATH_TO")
+    ret=$(wget -N "$URL" -P "$PATH_TO")
   else
-      ret=$(wget -nc "$URL" -P "$PATH_TO")
+    ret=$(wget -nc "$URL" -P "$PATH_TO")
   fi
 
   if [[ "$?" != 0 ]]; then
@@ -42,11 +42,11 @@ function get_external_scripts()
   local -r MAINTAINER_URL="https://raw.githubusercontent.com/torvalds/linux/master/scripts/get_maintainer.pl"
   local -r CHECKPATCH_CONST_STRUCTS="https://raw.githubusercontent.com/torvalds/linux/master/scripts/const_structs.checkpatch"
   local -r CHECKPATCH_SPELLING="https://raw.githubusercontent.com/torvalds/linux/master/scripts/spelling.txt"
-  local DOWNLOAD_URLS=( \
-        CHECKPATCH_URL \
-        CHECKPATCH_CONST_STRUCTS \
-        CHECKPATCH_SPELLING \
-        MAINTAINER_URL )
+  local DOWNLOAD_URLS=(
+    CHECKPATCH_URL
+    CHECKPATCH_CONST_STRUCTS
+    CHECKPATCH_SPELLING
+    MAINTAINER_URL)
 
   say "Downloading external scripts..."
   echo
@@ -55,7 +55,7 @@ function get_external_scripts()
   for url in ${DOWNLOAD_URLS[@]}; do
     download_stuff "${!url}" "$PATH_TO_TESTS_EXTERNALS" "$OVERWRITE"
     if [[ "$?" -eq 113 ]]; then
-     return 113 # Host unreachable errno
+      return 113 # Host unreachable errno
     fi
   done
 }
@@ -71,62 +71,62 @@ function check_required_files()
   force_update=${force_update:-'false'}
 
   if [[ "$force_update" == 'false' &&
-           -f "$PATH_TO_TESTS_EXTERNALS/checkpatch.pl" &&
-           -f "$PATH_TO_TESTS_EXTERNALS/const_structs.checkpatch" &&
-           -f "$PATH_TO_TESTS_EXTERNALS/spelling.txt" &&
-           -f "$PATH_TO_TESTS_EXTERNALS/get_maintainer.pl" ]]; then
-       # Errno code for File exist
-       return 17
+    -f "$PATH_TO_TESTS_EXTERNALS/checkpatch.pl" &&
+    -f "$PATH_TO_TESTS_EXTERNALS/const_structs.checkpatch" &&
+    -f "$PATH_TO_TESTS_EXTERNALS/spelling.txt" &&
+    -f "$PATH_TO_TESTS_EXTERNALS/get_maintainer.pl" ]]; then
+    # Errno code for File exist
+    return 17
   else
-        say "--> Preparing unit test"
-        get_external_scripts "$force_update"
-        if [[ "$?" -eq 113 ]]; then
-            complain "Failed to download external scripts. Check your connection."
-            complain "Cannot run kw tests"
-            exit 1
-        fi
+    say "--> Preparing unit test"
+    get_external_scripts "$force_update"
+    if [[ "$?" -eq 113 ]]; then
+      complain "Failed to download external scripts. Check your connection."
+      complain "Cannot run kw tests"
+      exit 1
+    fi
   fi
 }
 
 # Reports tests results.
 # Arguments are: $1: # of tests, $2: # of succeeded tests, $3: # of notfound tests and
 # $4: # of failed tests
-function report_results
+function report_results()
 {
-    local -i total="$1"
-    local -i success="$2"
-    local -i notfound="$3"
-    local -i fail="$4"
-    local test_failure_list="$5"
+  local -i total="$1"
+  local -i success="$2"
+  local -i notfound="$3"
+  local -i fail="$4"
+  local test_failure_list="$5"
 
-    if [[ "$total" -eq 0 ]]; then
-        echo 'No test files.'
-    elif [[ "$success" -eq "$total" ]]; then
-      success "$SEPARATOR"
-      success "Total: $total test file(s)"
-      success "Test file(s) SUCCEEDED"
-    else
-      complain "$SEPARATOR"
-      complain "Total: $total test file(s)"
-      if [[ "$fail" -gt 0 ]]; then
-        complain "$fail test file(s) FAILED"
-      fi
-      if [[ "$notfound" -gt 0 ]]; then
-        complain "$notfound test file(s) NOT FOUND"
-      fi
-
-      echo
-      complain "Take a look at:"
-      IF=' ' read -r -a test_failure_array <<< "$test_failure_list"
-      for failed in "${test_failure_array[@]}"; do
-        complain "-> $failed"
-      done
-
-      return 1
+  if [[ "$total" -eq 0 ]]; then
+    echo 'No test files.'
+  elif [[ "$success" -eq "$total" ]]; then
+    success "$SEPARATOR"
+    success "Total: $total test file(s)"
+    success "Test file(s) SUCCEEDED"
+  else
+    complain "$SEPARATOR"
+    complain "Total: $total test file(s)"
+    if [[ "$fail" -gt 0 ]]; then
+      complain "$fail test file(s) FAILED"
     fi
+    if [[ "$notfound" -gt 0 ]]; then
+      complain "$notfound test file(s) NOT FOUND"
+    fi
+
+    echo
+    complain "Take a look at:"
+    IF=' ' read -r -a test_failure_array <<< "$test_failure_list"
+    for failed in "${test_failure_array[@]}"; do
+      complain "-> $failed"
+    done
+
+    return 1
+  fi
 }
 
-function run_tests
+function run_tests()
 {
   local -i total=${#TESTS[@]}
   local -i success=0
@@ -158,9 +158,9 @@ function run_tests
 }
 
 declare -a TESTS
-function strip_path
+function strip_path()
 {
-  TESTS=( )
+  TESTS=()
   for file in "$@"; do
     local base=$(basename ${file})
     TESTS+=("${base%.*}")
@@ -171,7 +171,7 @@ check_required_files
 check_files="$?"
 if [[ "$#" -eq 0 ]]; then
   check_required_files
-  files_list=$(find ./tests -name "*_test.sh" | grep --invert-match "/shunit2/" )
+  files_list=$(find ./tests -name "*_test.sh" | grep --invert-match "/shunit2/")
   # Note: Usually we want to use double-quotes on bash variables, however,
   # in this case we want a set of parameters instead of a single one.
   strip_path $files_list
@@ -181,16 +181,16 @@ elif [[ "$1" == "list" ]]; then
   files_list=$(find ./tests/ -name "*_test.sh")
   strip_path $files_list
   for test_name in "${TESTS[@]}"; do
-    (( index++ ))
+    ((index++))
     say "$index) ${test_name}"
   done
 elif [[ "$1" == "test" ]]; then
   strip_path ${@:2}
   run_tests
 elif [[ "$1" == "prepare" ]]; then
-  if [[ "$#" -gt  1 && ("$2" == "--force-update" || "$2" == "-f") ]]; then
-      check_required_files true
-      check_files="$?"
+  if [[ "$#" -gt 1 && ("$2" == "--force-update" || "$2" == "-f") ]]; then
+    check_required_files true
+    check_files="$?"
   fi
 
   if [[ "$check_files" -eq 17 ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -59,7 +59,7 @@ function check_dependencies()
     cmd="pacman -S $package_list"
   elif [[ "$distro" =~ "debian" ]]; then
     for package in "${debian_packages[@]}"; do
-      installed=$(dpkg-query -W --showformat='${Status}\n' "$package" 2>/dev/null | grep -c "ok installed")
+      installed=$(dpkg-query -W --showformat='${Status}\n' "$package" 2> /dev/null | grep -c "ok installed")
       [[ "$installed" -eq 0 ]] && package_list="$package $package_list"
     done
     cmd="apt install $package_list"
@@ -69,7 +69,7 @@ function check_dependencies()
     return 0
   fi
 
-  if [[ ! -z "$package_list"  ]]; then
+  if [[ ! -z "$package_list" ]]; then
     if [[ "$FORCE" == 0 ]]; then
       if [[ $(ask_yN "Can we install the following dependencies $package_list ?") =~ "0" ]]; then
         return 0
@@ -213,7 +213,7 @@ function setup_config_file()
   if [[ -f "$config_file_template" ]]; then
     cp "$config_file_template" "$config_files_path/$global_config_name"
     sed -i -e "s/USERKW/$USER/g" -e "s,SOUNDPATH,$sharesounddir,g" \
-           -e "/^#?.*/d" "$config_files_path/$global_config_name"
+      -e "/^#?.*/d" "$config_files_path/$global_config_name"
     ret="$?"
     if [[ "$ret" != 0 ]]; then
       return "$ret"
@@ -285,7 +285,7 @@ function synchronize_files()
 
   if command_exists "bash"; then
     # Add tabcompletion to bashrc
-    if [[ -f "$HOME/.bashrc"  ||  -h "$HOME/.bashrc" ]]; then
+    if [[ -f "$HOME/.bashrc" || -L "$HOME/.bashrc" ]]; then
       append_bashcompletion ".bashrc"
       update_path
     else
@@ -295,7 +295,7 @@ function synchronize_files()
 
   if command_exists "zsh"; then
     # Add tabcompletion to zshrc
-    if [[ -f "$HOME/.zshrc" ||  -h "$HOME/.zshrc" ]]; then
+    if [[ -f "$HOME/.zshrc" || -L "$HOME/.zshrc" ]]; then
       echo "# Enable bash completion for zsh" >> "$HOME/.zshrc"
       echo "autoload bashcompinit && bashcompinit" >> "$HOME/.zshrc"
       append_bashcompletion ".zshrc"
@@ -325,7 +325,7 @@ function update_version()
   local branch_name=$(git rev-parse --short --abbrev-ref HEAD)
   local base_version=$(cat "$libdir/VERSION" | head -n 1)
 
-  cat > "$libdir/VERSION" <<EOF
+  cat > "$libdir/VERSION" << EOF
 $base_version
 Branch: $branch_name
 Commit: $head_hash
@@ -347,7 +347,7 @@ function install_home()
 }
 
 # Options
-for arg do
+for arg; do
   shift
   if [ "$arg" = "--verbose" ]; then
     VERBOSE=1

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -1,30 +1,30 @@
-_kw_autocomplete()
+function _kw_autocomplete()
 {
-    local current_command previous_command kw_options
-    COMPREPLY=()
-    current_command="${COMP_WORDS[COMP_CWORD]}"
-    previous_command="${COMP_WORDS[COMP_CWORD-1]}"
-    kw_options="explore e build b bi init new n ssh s clear-cache
+  local current_command previous_command kw_options
+  COMPREPLY=()
+  current_command="${COMP_WORDS[COMP_CWORD]}"
+  previous_command="${COMP_WORDS[COMP_CWORD - 1]}"
+  kw_options="explore e build b bi init new n ssh s clear-cache
                 mount mo umount um vars up u codestyle c configm g
                 maintainers m deploy d help h version statistics
                 pomodoro p drm diff --version -v"
 
-    # By default, autocomplete with kw_options
-    if [[ ${previous_command} == kw ]] ; then
-        COMPREPLY=( $(compgen -W "${kw_options}" -- ${current_command}) )
-        return 0
-    fi
+  # By default, autocomplete with kw_options
+  if [[ ${previous_command} == kw ]]; then
+    COMPREPLY=($(compgen -W "${kw_options}" -- ${current_command}))
+    return 0
+  fi
 
-    # TODO:
-    # Autocomplete in the bash terminal is a powerful tool which allows us to
-    # make many interesting things. In the future, we could add an
-    # autocompletion for subcommands, the code below illustrates an example
-    # that tries to add this feature for the ‘maintainers’ options.
-    #
-    # For maintainers and m options, autocomplete with folder
-    # if [ ${previous_command} == maintainers ] || [ ${previous_command} == m ] ; then
-    #   COMPREPLY=( $(compgen -d -- ${current_command}) )
-    #   return 0
-    # fi
+  # TODO:
+  # Autocomplete in the bash terminal is a powerful tool which allows us to
+  # make many interesting things. In the future, we could add an
+  # autocompletion for subcommands, the code below illustrates an example
+  # that tries to add this feature for the ‘maintainers’ options.
+  #
+  # For maintainers and m options, autocomplete with folder
+  # if [ ${previous_command} == maintainers ] || [ ${previous_command} == m ] ; then
+  #   COMPREPLY=( $(compgen -d -- ${current_command}) )
+  #   return 0
+  # fi
 }
 complete -o default -F _kw_autocomplete kw

--- a/src/config_manager.sh
+++ b/src/config_manager.sh
@@ -209,7 +209,7 @@ function execute_config_manager()
       shift # Skip '--save' option
       name_config="$1"
       # Validate string name
-      if [[ "$name_config" =~ ^- || -z "${name_config// }" ]]; then
+      if [[ "$name_config" =~ ^- || -z "${name_config// /}" ]]; then
         complain "Invalid argument"
         exit 22 # EINVAL
       fi
@@ -217,7 +217,7 @@ function execute_config_manager()
       shift 2 && description_config="$@"
       save_config_file "$force" "$name_config" "$description_config"
       ;;
-    --list|-l)
+    --list | -l)
       list_configs
       ;;
     --get)
@@ -229,7 +229,7 @@ function execute_config_manager()
 
       get_config "$1" "$force"
       ;;
-    --remove|-rm)
+    --remove | -rm)
       shift # Skip '--rm' option
       if [[ -z "$1" ]]; then
         complain "Invalid argument"

--- a/src/diff.sh
+++ b/src/diff.sh
@@ -69,23 +69,23 @@ function diff_parser_options()
 
   IFS=' ' read -r -a options <<< "$raw_options"
   for option in "${options[@]}"; do
-      case "$option" in
-        --no-interactive)
-          diff_options['INTERACTIVE']=0
-          continue
+    case "$option" in
+      --no-interactive)
+        diff_options['INTERACTIVE']=0
+        continue
         ;;
-        --help|-h|help)
-          diff_options['HELP']=1
-          continue
+      --help | -h | help)
+        diff_options['HELP']=1
+        continue
         ;;
-        test_mode)
-          diff_options['TEST_MODE']='TEST_MODE'
+      test_mode)
+        diff_options['TEST_MODE']='TEST_MODE'
         ;;
-        *)
-          diff_options['ERROR']="$option"
-          return 22
-          ;;
-      esac
+      *)
+        diff_options['ERROR']="$option"
+        return 22
+        ;;
+    esac
   done
 
 }

--- a/src/explore.sh
+++ b/src/explore.sh
@@ -15,25 +15,25 @@ function explore()
   ret="$?"
 
   case "$ret" in
-    1) # LOG
+    1)        # LOG
       shift 1 # Remove 'log' string
       explore_git_log "$@"
-    ;;
-    2) # Use GNU GREP
+      ;;
+    2)        # Use GNU GREP
       shift 1 # Remove 'grep' string
       explore_files_gnu_grep "$@"
-    ;;
+      ;;
     3) # Search in directories controlled or not by git
       shift 1
       explore_all_files_git "$@"
-    ;;
+      ;;
     4) # Search in files under git control
       explore_files_under_git "$@"
-    ;;
+      ;;
     *)
       complain "Invalid parameter"
       exit 22 # EINVAL
-    ;;
+      ;;
   esac
 }
 
@@ -66,18 +66,18 @@ function explore_parser()
   fi
 
   case "$option" in
-    --log|-l)
+    --log | -l)
       return 1
-    ;;
-    --grep|-g)
+      ;;
+    --grep | -g)
       return 2
-    ;;
-    --all|-a)
+      ;;
+    --all | -a)
       return 3
-    ;;
+      ;;
     *)
       return 4
-    ;;
+      ;;
   esac
 }
 

--- a/src/get_maintainer_wrapper.sh
+++ b/src/get_maintainer_wrapper.sh
@@ -7,7 +7,7 @@ include "$KW_LIB_DIR/kwlib.sh"
 function print_files_authors()
 {
   local FILE_OR_DIR=$1
-  local files=( )
+  local files=()
   if [[ -d $FILE_OR_DIR ]]; then
     for file in $FILE_OR_DIR/*; do
       if [[ -f $file ]]; then
@@ -22,8 +22,8 @@ function print_files_authors()
 
   for file in ${files[@]}; do
     authors=$(grep -oE "MODULE_AUTHOR *\(.*\)" $file |
-              sed -E "s/(MODULE_AUTHOR *\( *\"|\" *\))//g" |
-              sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/, /g' )
+      sed -E "s/(MODULE_AUTHOR *\( *\"|\" *\))//g" |
+      sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/, /g')
     if [[ ! -z $authors ]]; then
       if [[ $printed_authors_separator = false ]]; then
         say $SEPARATOR
@@ -79,16 +79,16 @@ function execute_get_maintainer()
   for option in "${options[@]}"; do
     if [[ "$option" =~ ^(--.*|-.*) ]]; then
       case "$option" in
-        -au|-ua)
+        -au | -ua)
           print_authors=true
           update_patch=true
           continue
           ;;
-        --authors|-a)
+        --authors | -a)
           print_authors=true
           continue
           ;;
-        --update-patch|-u)
+        --update-patch | -u)
           update_patch=true
           continue
           ;;
@@ -101,7 +101,6 @@ function execute_get_maintainer()
       FILE_OR_DIR=${FILE_OR_DIR:-$option}
     fi
   done
-
 
   # If no file is given, assume "."
   if [[ -z $FILE_OR_DIR ]]; then

--- a/src/help.sh
+++ b/src/help.sh
@@ -37,21 +37,21 @@ function kworkflow_help()
 # installed to the system
 function kworkflow_man()
 {
-    doc="$KW_SHARE_MAN_DIR"
-    ret=0
+  doc="$KW_SHARE_MAN_DIR"
+  ret=0
 
-    if ! man kw > /dev/null 2>&1; then
-      if [ -x "$(command -v rst2man)" ]; then
-        rst2man < "$doc/kw.rst" | man -l -
-        ret="$?"
-      else
-        complain "There's no man support"
-        ret=1
-      fi
-      exit "$ret"
+  if ! man kw > /dev/null 2>&1; then
+    if [ -x "$(command -v rst2man)" ]; then
+      rst2man < "$doc/kw.rst" | man -l -
+      ret="$?"
+    else
+      complain "There's no man support"
+      ret=1
     fi
+    exit "$ret"
+  fi
 
-    man kw
+  man kw
 }
 
 function kworkflow_version()

--- a/src/init.sh
+++ b/src/init.sh
@@ -16,7 +16,7 @@ function init_kw()
   if [[ -f "$config_file_template" ]]; then
     cp "$config_file_template" "$PWD/$name"
     sed -i -e "s/USERKW/$USER/g" -e "s,SOUNDPATH,$KW_SHARE_SOUND_DIR,g" -e "/^#?.*/d" \
-              "$PWD/$name"
+      "$PWD/$name"
   else
     complain "No such: $config_file_template or $kw_path"
     exit 2 # ENOENT

--- a/src/kw_config_loader.sh
+++ b/src/kw_config_loader.sh
@@ -14,14 +14,14 @@ TARGET="$VM_TARGET"
 declare -gA configurations
 
 # Default target option from kworkflow.config
-declare -gA deploy_target_opt=( ['vm']=1 ['local']=2 ['remote']=3 )
+declare -gA deploy_target_opt=(['vm']=1 ['local']=2 ['remote']=3)
 
 # This function is used to show the current set up used by kworkflow.
 function show_variables()
 {
   local has_local_config_path="No"
 
-  if [ -f "$PWD/kworkflow.config" ] ; then
+  if [ -f "$PWD/kworkflow.config" ]; then
     has_local_config_path="Yes"
   else
     has_local_config_path="No"
@@ -46,17 +46,15 @@ function parse_configuration()
   local config_path="$1"
   local filename="$(basename "$config_path")"
 
-  if [ ! -f "$config_path" ] || [ "$filename" != kworkflow.config ] ; then
+  if [ ! -f "$config_path" ] || [ "$filename" != kworkflow.config ]; then
     return 22 # 22 means Invalid argument - EINVAL
   fi
 
-  while read line
-  do
+  while read line; do
     # Line started with # should be ignored
     [[ "$line" =~ ^# ]] && continue
 
-    if echo "$line" | grep -F = &>/dev/null
-    then
+    if echo "$line" | grep -F = &> /dev/null; then
       varname="$(echo "$line" | cut -d '=' -f 1 | tr -d '[:space:]')"
       configurations["$varname"]="$(echo "$line" | cut -d '=' -f 2-)"
     fi

--- a/src/kwio.sh
+++ b/src/kwio.sh
@@ -21,18 +21,18 @@ function alert_completion()
   local opts
 
   if [[ $# -gt 1 && "$ALERT_OPT" =~ ^--alert= ]]; then
-    opts="$(echo $ALERT_OPT | sed s/--alert=// )"
+    opts="$(echo $ALERT_OPT | sed s/--alert=//)"
   else
     opts="${configurations[alert]}"
   fi
 
-  grep -o . <<< "$opts" | while read option;  do
+  grep -o . <<< "$opts" | while read option; do
     if [ "$option" == "v" ]; then
       if command_exists "${configurations[visual_alert_command]} &"; then
         eval "${configurations[visual_alert_command]} &"
       else
         warning "The following command set in the visual_alert_command variable" \
-        "couldn't be run:"
+          "couldn't be run:"
         warning "${configurations[visual_alert_command]}"
         warning "Check if the necessary packages are installed."
       fi
@@ -41,8 +41,8 @@ function alert_completion()
         eval "${configurations[sound_alert_command]} &"
       else
         warning "The following command set in the sound_alert_command variable" \
-        "couldn't be run:"
-        warning  "${configurations[sound_alert_command]}"
+          "couldn't be run:"
+        warning "${configurations[sound_alert_command]}"
         warning "Check if the necessary packages are installed."
       fi
     fi
@@ -59,46 +59,46 @@ function alert_completion()
 #
 function colored_print()
 {
-    local message="${@:2}"
+  local message="${@:2}"
 
-    if [[ $# -ge 2 && $2 = "-n" ]]; then
-        message="${@:3}"
-        if [ -t 1 ]; then
-            printf ${!1} "$message"
-        else
-            echo -n "$message"
-        fi
+  if [[ $# -ge 2 && $2 = "-n" ]]; then
+    message="${@:3}"
+    if [ -t 1 ]; then
+      printf ${!1} "$message"
     else
-        if [ -t 1 ]; then
-            printf "${!1}\n" "$message"
-        else
-            echo "$message"
-        fi
+      echo -n "$message"
     fi
+  else
+    if [ -t 1 ]; then
+      printf "${!1}\n" "$message"
+    else
+      echo "$message"
+    fi
+  fi
 }
 
 # Print normal message (e.g info messages).
 function say()
 {
-    colored_print BLUECOLOR "$@"
+  colored_print BLUECOLOR "$@"
 }
 
 # Print error message.
 function complain()
 {
-    colored_print REDCOLOR "$@"
+  colored_print REDCOLOR "$@"
 }
 
 # Warning error message.
 function warning()
 {
-    colored_print YELLOWCOLOR "$@"
+  colored_print YELLOWCOLOR "$@"
 }
 
 # Print success message.
 function success()
 {
-    colored_print GREENCOLOR "$@"
+  colored_print GREENCOLOR "$@"
 }
 
 # Ask for yes or no

--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -108,21 +108,21 @@ function is_kernel_root()
   # is used to tell if a directory is a linux tree root or not. (They
   # are the same ones used by get_maintainer.pl)
   if [[ -f "${DIR}/COPYING" &&
-        -f "${DIR}/CREDITS" &&
-        -f "${DIR}/Kbuild" &&
-        -e "${DIR}/MAINTAINERS" &&
-        -f "${DIR}/Makefile" &&
-        -f "${DIR}/README" &&
-        -d "${DIR}/Documentation" &&
-        -d "${DIR}/arch" &&
-        -d "${DIR}/include" &&
-        -d "${DIR}/drivers" &&
-        -d "${DIR}/fs" &&
-        -d "${DIR}/init" &&
-        -d "${DIR}/ipc" &&
-        -d "${DIR}/kernel" &&
-        -d "${DIR}/lib" &&
-        -d "${DIR}/scripts" ]]; then
+    -f "${DIR}/CREDITS" &&
+    -f "${DIR}/Kbuild" &&
+    -e "${DIR}/MAINTAINERS" &&
+    -f "${DIR}/Makefile" &&
+    -f "${DIR}/README" &&
+    -d "${DIR}/Documentation" &&
+    -d "${DIR}/arch" &&
+    -d "${DIR}/include" &&
+    -d "${DIR}/drivers" &&
+    -d "${DIR}/fs" &&
+    -d "${DIR}/init" &&
+    -d "${DIR}/ipc" &&
+    -d "${DIR}/kernel" &&
+    -d "${DIR}/lib" &&
+    -d "${DIR}/scripts" ]]; then
     return 0
   fi
   return 1
@@ -135,7 +135,7 @@ function is_kernel_root()
 # Returns:
 # The path of the kernel tree root (string) which the file or dir belongs to, or
 # an empty string if no root was found.
-function find_kernel_root
+function find_kernel_root()
 {
   local -r FILE_OR_DIR="$@"
   local current_dir
@@ -168,7 +168,7 @@ function find_kernel_root
 #
 # Returns:
 # True if given path is a patch file and false otherwise.
-function is_a_patch
+function is_a_patch()
 {
   local -r FILE_PATH="$@"
 
@@ -176,7 +176,7 @@ function is_a_patch
     return 1
   fi
 
-  local file_content=`cat "$FILE_PATH"`
+  local file_content=$(cat "$FILE_PATH")
 
   # The following array stores strings that are expected to be present
   # in a patch file. The absence of any of these strings makes the
@@ -265,7 +265,7 @@ function detect_distro()
 #
 # Return:
 # Print a execution time info
-function statistics_manager
+function statistics_manager()
 {
   local label="$1"
   local value="$2"
@@ -287,7 +287,7 @@ function statistics_manager
 #
 # @year_month_dir Current year
 # @day Current day of the week
-function update_statistics_database
+function update_statistics_database()
 {
   local year_month_path="$1"
   local day="$2"
@@ -303,7 +303,7 @@ function update_statistics_database
 # @day_path Current day
 # @label Label used to identify a value
 # @value An integer number associated to a label
-function store_statistics_data
+function store_statistics_data()
 {
   local day_path="$1"
   local label="$2"
@@ -320,7 +320,7 @@ function store_statistics_data
 function command_exists()
 {
   local command="$1"
-  local package=( $command )
+  local package=($command)
 
   if [[ -x "$(command -v $package)" ]]; then
     return 0

--- a/src/mk.sh
+++ b/src/mk.sh
@@ -54,7 +54,7 @@ function modules_install_to()
 #
 # Note: Make sure that you called is_kernel_root before try to execute this
 # function.
-function get_kernel_release
+function get_kernel_release()
 {
   local flag="$1"
   local cmd='make kernelrelease'
@@ -71,7 +71,7 @@ function get_kernel_release
 #
 # Note: Make sure that you called is_kernel_root before try to execute this
 # function.
-function get_kernel_version
+function get_kernel_version()
 {
   local flag="$1"
   local cmd='make kernelversion'
@@ -83,7 +83,7 @@ function get_kernel_version
 
 # This function goal is to perform a global clean up, it basically calls other
 # specialized cleanup functions.
-function cleanup
+function cleanup()
 {
   say "Cleanup deploy files"
   cleanup_after_deploy
@@ -96,12 +96,12 @@ function cleanup
 #
 # @flag How to display a command, the default value is
 #   "SILENT". For more options see `src/kwlib.sh` function `cmd_manager`
-function cleanup_after_deploy
+function cleanup_after_deploy()
 {
   local flag="$1"
 
   if [[ -d "$KW_CACHE_DIR/$LOCAL_REMOTE_DIR" ]]; then
-    cmd_manager "$flag"  "rm -rf $KW_CACHE_DIR/$LOCAL_REMOTE_DIR/*"
+    cmd_manager "$flag" "rm -rf $KW_CACHE_DIR/$LOCAL_REMOTE_DIR/*"
   fi
 
   if [[ -d "$KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR" ]]; then
@@ -114,7 +114,7 @@ function cleanup_after_deploy
 # machine.
 #
 # @target Target machine
-function modules_install
+function modules_install()
 {
   local flag="$1"
   local target="$2"
@@ -163,7 +163,7 @@ function modules_install
 
       local tarball_for_deploy_path="$KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR/$release.tar"
       cp_host2remote "$tarball_for_deploy_path" \
-                     "$REMOTE_KW_DEPLOY" "$remote" "$port" "" "$flag"
+        "$REMOTE_KW_DEPLOY" "$remote" "$port" "" "$flag"
 
       # 3. Deploy: Execute script
       local cmd="bash $REMOTE_KW_DEPLOY/deploy.sh --modules $release.tar"
@@ -184,7 +184,7 @@ function modules_install
 #   will display each kernel name by line.
 # @target Target can be 1 (VM_TARGET), 2 (LOCAL_TARGET), and 3 (REMOTE_TARGET)
 # @unformatted_remote We expect the REMOTE:PORT string
-function mk_list_installed_kernels
+function mk_list_installed_kernels()
 {
   local flag="$1"
   local single_line="$2"
@@ -197,7 +197,7 @@ function mk_list_installed_kernels
     1) # VM_TARGET
       vm_mount
 
-      if [ "$?" != 0 ] ; then
+      if [ "$?" != 0 ]; then
         complain "Did you check if your VM is running?"
         return 125 # ECANCELED
       fi
@@ -206,11 +206,11 @@ function mk_list_installed_kernels
       list_installed_kernels "$single_line" "${configurations[mount_point]}"
 
       vm_umount
-    ;;
+      ;;
     2) # LOCAL_TARGET
       . "$KW_PLUGINS_DIR/kernel_install/utils.sh" --source-only
       list_installed_kernels "$single_line"
-    ;;
+      ;;
     3) # REMOTE_TARGET
       local cmd="bash $REMOTE_KW_DEPLOY/deploy.sh --list_kernels $single_line"
       local remote=$(get_based_on_delimiter "$unformatted_remote" ":" 1)
@@ -220,7 +220,7 @@ function mk_list_installed_kernels
       prepare_remote_dir "$remote" "$port" "" "$flag"
 
       cmd_remotely "$cmd" "$flag" "$remote" "$port"
-    ;;
+      ;;
   esac
 
   return 0
@@ -236,7 +236,7 @@ function mk_list_installed_kernels
 #
 # Note:
 # Take a look at the available kernel plugins at: src/plugins/kernel_install
-function kernel_install
+function kernel_install()
 {
   local reboot="$1"
   local name="$2"
@@ -274,7 +274,7 @@ function kernel_install
 
   if [[ ! -f "arch/$arch_target/boot/$kernel_img_name" ]]; then
     # Try to infer the kernel image name
-    kernel_img_name=$(find "arch/$arch_target/boot/" -name "*Image" 2>/dev/null)
+    kernel_img_name=$(find "arch/$arch_target/boot/" -name "*Image" 2> /dev/null)
     if [[ -z "$kernel_img_name" ]]; then
       complain "We could not find a valid kernel image at arch/$arch_target/boot"
       complain "Please, check your compilation and/or the option kernel_img_name inside kworkflow.config"
@@ -297,7 +297,7 @@ function kernel_install
       . "$KW_PLUGINS_DIR/kernel_install/$distro.sh" --source-only
       install_kernel "$name" "$distro" "$kernel_img_name" "$reboot" "$arch_target" 'vm' "$flag"
       return "$?"
-    ;;
+      ;;
     2) # LOCAL_TARGET
       local distro=$(detect_distro "/")
 
@@ -316,7 +316,7 @@ function kernel_install
       . "$KW_PLUGINS_DIR/kernel_install/$distro.sh" --source-only
       install_kernel "$name" "$distro" "$kernel_img_name" "$reboot" "$arch_target" 'local' "$flag"
       return "$?"
-    ;;
+      ;;
     3) # REMOTE_TARGET
       local preset_file="$KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR/$name.preset"
       if [[ ! -f "$preset_file" ]]; then
@@ -333,17 +333,17 @@ function kernel_install
       distro=$(detect_distro "/" "$distro_info")
 
       cp_host2remote "$KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR/$name.preset" \
-                     "$REMOTE_KW_DEPLOY" \
-                     "$remote" "$port" "$user" "$flag"
+        "$REMOTE_KW_DEPLOY" \
+        "$remote" "$port" "$user" "$flag"
       cp_host2remote "arch/$arch_target/boot/$kernel_img_name" \
-                     "$REMOTE_KW_DEPLOY/vmlinuz-$name" \
-                     "$remote" "$port" "$user" "$flag"
+        "$REMOTE_KW_DEPLOY/vmlinuz-$name" \
+        "$remote" "$port" "$user" "$flag"
 
       # Deploy
       local cmd_parameters="$name $distro $kernel_img_name $reboot $arch_target 'remote' $flag"
       local cmd="bash $REMOTE_KW_DEPLOY/deploy.sh --kernel_update $cmd_parameters"
       cmd_remotely "$cmd" "$flag" "$remote" "$port"
-    ;;
+      ;;
   esac
 }
 
@@ -372,7 +372,7 @@ function mk_kernel_uninstall()
   case "$target" in
     1) # VM_TARGET
       echo "UNINSTALL VM"
-    ;;
+      ;;
     2) # LOCAL_TARGET
       distro=$(detect_distro "/")
 
@@ -386,7 +386,7 @@ function mk_kernel_uninstall()
       . "$KW_PLUGINS_DIR/kernel_install/$distro.sh" --source-only
       . "$KW_PLUGINS_DIR/kernel_install/utils.sh" --source-only
       kernel_uninstall "$reboot" 'local' "$kernels_target" "$flag"
-    ;;
+      ;;
     3) # REMOTE_TARGET
       local remote=$(get_based_on_delimiter "$formatted_remote" ":" 1)
       local port=$(get_based_on_delimiter "$formatted_remote" ":" 2)
@@ -400,7 +400,7 @@ function mk_kernel_uninstall()
       # line break with `\`; this may allow us to break a huge line like this.
       local cmd="bash $REMOTE_KW_DEPLOY/deploy.sh --uninstall_kernel $reboot remote $kernels_target $flag"
       cmd_remotely "$cmd" "$flag" "$remote" "$port"
-    ;;
+      ;;
   esac
 }
 
@@ -417,7 +417,7 @@ function mk_kernel_uninstall()
 #
 # @reboot If 1 the target machine will be rebooted after the kernel update
 # @name Kernel name for the deploy
-function kernel_deploy
+function kernel_deploy()
 {
   local reboot=0
   local modules=0
@@ -482,10 +482,10 @@ function kernel_deploy
     exit 125 # ECANCELED
   fi
 
-  if [[ "$target" == "$VM_TARGET" ]] ; then
+  if [[ "$target" == "$VM_TARGET" ]]; then
     vm_mount
     ret="$?"
-    if [[ "$ret" != 0 ]] ; then
+    if [[ "$ret" != 0 ]]; then
       complain "Please shutdown or umount your VM to continue."
       exit "$ret"
     fi
@@ -507,13 +507,13 @@ function kernel_deploy
 
     kernel_install "$reboot" "$name" "" "$target" "$remote"
     end=$(date +%s)
-    runtime=$(( runtime + (end - start) ))
+    runtime=$((runtime + (end - start)))
     statistics_manager "deploy" "$runtime"
   else
     statistics_manager "Modules_deploy" "$runtime"
   fi
 
-  if [[ "$target" == "$VM_TARGET" ]] ; then
+  if [[ "$target" == "$VM_TARGET" ]]; then
     # Umount VM if it remains mounted
     vm_umount
   fi
@@ -591,16 +591,16 @@ function mk_build()
   IFS=' ' read -r -a options <<< "$raw_options"
   for option in "${options[@]}"; do
     case "$option" in
-      --info|-i)
+      --info | -i)
         build_info
         exit
         ;;
-      --menu|-n)
+      --menu | -n)
         command="make ARCH=$arch $CROSS_COMPILE $menu_config"
         cmd_manager "$flag" "$command"
         exit
         ;;
-      --doc|-d)
+      --doc | -d)
         doc_type="${configurations[doc_type]}"
         doc_type=${doc_type:='htmldocs'}
         command="make $doc_type"
@@ -610,11 +610,11 @@ function mk_build()
       *)
         complain "Invalid option: $option"
         exit 22 # EINVAL
-      ;;
+        ;;
     esac
   done
 
-  if [ -x "$(command -v nproc)" ] ; then
+  if [ -x "$(command -v nproc)" ]; then
     PARALLEL_CORES=$(nproc --all)
   else
     PARALLEL_CORES=$(grep -c ^processor /proc/cpuinfo)
@@ -747,23 +747,23 @@ function deploy_parser_options()
           options_values["TARGET"]="$VM_TARGET"
           continue
           ;;
-        --reboot|-r)
+        --reboot | -r)
           options_values["REBOOT"]=1
           continue
           ;;
-        --modules|-m)
+        --modules | -m)
           options_values["MODULES"]=1
           continue
           ;;
-        --list|-l)
+        --list | -l)
           options_values["LS"]=1
           continue
           ;;
-        --ls-line|-s)
+        --ls-line | -s)
           options_values["LS_LINE"]=1
           continue
           ;;
-        --uninstall|-u)
+        --uninstall | -u)
           enable_collect_param=1
           uninstall=1
           continue
@@ -778,7 +778,7 @@ function deploy_parser_options()
       esac
     else # Handle potential parameters
       if [[ "$uninstall" != 1 &&
-            ${options_values["TARGET"]} == "$REMOTE_TARGET" ]]; then
+        ${options_values["TARGET"]} == "$REMOTE_TARGET" ]]; then
         options_values["REMOTE"]=$(get_remote_info "$option")
         if [[ "$?" == 22 ]]; then
           options_values["ERROR"]="$option"
@@ -802,8 +802,8 @@ function deploy_parser_options()
   fi
 
   case "${options_values["TARGET"]}" in
-    1|2|3)
-      ;;
+    1 | 2 | 3) ;;
+
     *)
       options_values["ERROR"]="remote option"
       return 22

--- a/src/plugins/kernel_install/arch.sh
+++ b/src/plugins/kernel_install/arch.sh
@@ -17,10 +17,10 @@ function update_arch_boot_loader()
   local setup_grub=": write /boot/grub/device.map '(hd0,1) /dev/sda'"
   local grub_install="grub-install --directory=/usr/lib/grub/i386-pc --target=i386-pc --boot-directory=/boot --recheck --debug /dev/sda"
 
-  update_boot_loader "$name" 'arch' "$target" "$cmd_init" "$setup_grub" "$grub_install"  "$flag"
+  update_boot_loader "$name" 'arch' "$target" "$cmd_init" "$setup_grub" "$grub_install" "$flag"
 }
 
-function generate_arch_temporary_root_file_system
+function generate_arch_temporary_root_file_system()
 {
   local name="$1"
   local target="$2"

--- a/src/plugins/kernel_install/debian.sh
+++ b/src/plugins/kernel_install/debian.sh
@@ -19,7 +19,7 @@ function update_debian_boot_loader()
   update_boot_loader "$name" 'debian' "$target" "$cmd_init" "$setup_grub" "$grub_install" "$flag"
 }
 
-function generate_debian_temporary_root_file_system
+function generate_debian_temporary_root_file_system()
 {
   local name="$1"
   local target="$2"

--- a/src/plugins/kernel_install/utils.sh
+++ b/src/plugins/kernel_install/utils.sh
@@ -63,13 +63,13 @@ function list_installed_kernels()
 
   grub_cfg="$prefix/boot/grub/grub.cfg"
 
-  output=$(awk -F\' '/menuentry / {print $2}' "$grub_cfg" 2>/dev/null)
+  output=$(awk -F\' '/menuentry / {print $2}' "$grub_cfg" 2> /dev/null)
 
   if [[ "$?" != 0 ]]; then
-    if ! [[ -r "$grub_cfg" ]] ; then
+    if ! [[ -r "$grub_cfg" ]]; then
       echo "For showing the available kernel in your system we have to take" \
-           "a look at '/boot/grub/grub.cfg', however, it looks like that" \
-           "that you have no read permission."
+        "a look at '/boot/grub/grub.cfg', however, it looks like that" \
+        "that you have no read permission."
       if [[ $(ask_yN "Do you want to proceed with sudo?") =~ "0" ]]; then
         echo "List kernel operation aborted"
         return 0
@@ -82,12 +82,11 @@ function list_installed_kernels()
     output=$(sudo awk -F\' '/menuentry / {print $2}' "$grub_cfg")
   fi
 
-  output=$(echo "$output" | grep recovery -v | grep with |  awk -F" "  '{print $NF}')
+  output=$(echo "$output" | grep recovery -v | grep with | awk -F" " '{print $NF}')
 
-  while read kernel
-  do
+  while read kernel; do
     if [[ -f "$prefix/boot/vmlinuz-$kernel" ]]; then
-       available_kernels+=( "$kernel" )
+      available_kernels+=("$kernel")
     fi
   done <<< "$output"
 
@@ -155,7 +154,7 @@ function update_boot_loader()
   cmd_grub="$sudo_cmd grub-mkconfig -o /boot/grub/grub.cfg"
 
   # Update grub
-  if [[ "$target" == 'vm' ]] ; then
+  if [[ "$target" == 'vm' ]]; then
     vm_update_boot_loader "$name" "$distro" "$cmd_grub" "$cmd_init" "$setup_grub" "$grub_install" "$flag"
   else
     cmd_manager "$flag" "$cmd_grub"
@@ -228,7 +227,6 @@ function vm_update_boot_loader()
   return 0
 }
 
-
 function do_uninstall()
 {
   local target="$1"
@@ -287,7 +285,7 @@ function kernel_uninstall()
   local kernel="$3"
   local flag="$4"
 
-  if [[ -z "$kernel" ]];then
+  if [[ -z "$kernel" ]]; then
     echo "Invalid argument"
     exit 22 #EINVAL
   fi

--- a/src/plugins/subsystems/drm/drm.sh
+++ b/src/plugins/subsystems/drm/drm.sh
@@ -102,13 +102,13 @@ function module_control()
   case "$target" in
     2) # LOCAL
       cmd_manager "$flag" "sudo bash -c \"$module_cmd\""
-    ;;
+      ;;
     3) # REMOTE
       local remote=$(get_based_on_delimiter "$unformatted_remote" ":" 1)
       local port=$(get_based_on_delimiter "$unformatted_remote" ":" 2)
 
       cmd_remotely "$module_cmd" "$flag" "$remote" "$port"
-    ;;
+      ;;
   esac
 }
 
@@ -167,7 +167,7 @@ function convert_module_info()
     final_command+=" && $module_str"
   done
 
-  if [[ -z "$final_command"  ]]; then
+  if [[ -z "$final_command" ]]; then
     return 22 # EINVAL
   fi
 
@@ -215,7 +215,7 @@ function gui_control()
       bind_control_cmd="sudo $bind_control_cmd"
       cmd_manager "$flag" "$gui_control_cmd"
       cmd_manager "$flag" "$bind_control_cmd"
-    ;;
+      ;;
     3) # REMOTE TARGET
       local remote=$(get_based_on_delimiter "$unformatted_remote" ":" 1)
       local port=$(get_based_on_delimiter "$unformatted_remote" ":" 2)
@@ -223,7 +223,7 @@ function gui_control()
 
       cmd_remotely "$gui_control_cmd" "$flag" "$remote" "$port"
       cmd_remotely "$bind_control_cmd" "$flag" "$remote" "$port" "root" "1"
-    ;;
+      ;;
   esac
 }
 
@@ -231,7 +231,7 @@ function gui_control()
 #
 # @target Target can be VM_TARGET, LOCAL_TARGET, and REMOTE_TARGET.
 # @unformatted_remote It is the remote location formatted as REMOTE:PORT.
-function get_available_connectors
+function get_available_connectors()
 {
   local target="$1"
   local unformatted_remote="$2"
@@ -252,7 +252,7 @@ function get_available_connectors
         return "$ret" # ENOENT
       fi
       target_label="local"
-    ;;
+      ;;
     3) # REMOTE TARGET
       local find_conn_cmd="find $SYSFS_CLASS_DRM -name 'card*'"
       local remote=$(get_based_on_delimiter "$unformatted_remote" ":" 1)
@@ -261,11 +261,10 @@ function get_available_connectors
 
       cards_raw_list=$(cmd_remotely "$find_conn_cmd" "SILENT" "$remote" "$port")
       target_label="remote"
-    ;;
+      ;;
   esac
 
-  while read card
-  do
+  while read card; do
     card=$(basename "$card")
     key=$(echo "$card" | grep card | cut -d- -f1)
     value=$(echo "$card" | grep card | cut -d- -f2)
@@ -281,8 +280,7 @@ function get_available_connectors
     fi
   done <<< "$cards_raw_list"
 
-  for card in "${!cards[@]}"
-  do
+  for card in "${!cards[@]}"; do
     i=1
     connectors="${cards[$card]}"
 
@@ -300,7 +298,7 @@ function get_available_connectors
 #
 # @target Target can be VM_TARGET, LOCAL_TARGET, and REMOTE_TARGET.
 # @unformatted_remote It is the remote location formatted as REMOTE:PORT.
-function get_supported_mode_per_connector
+function get_supported_mode_per_connector()
 {
   local target="$1"
   local unformatted_remote="$2"
@@ -319,7 +317,7 @@ function get_supported_mode_per_connector
       fi
       modes=$(eval $cmd)
       target_label="local"
-    ;;
+      ;;
     3) # REMOTE TARGET
       remote=$(get_based_on_delimiter "$unformatted_remote" ":" 1)
       port=$(get_based_on_delimiter "$unformatted_remote" ":" 2)
@@ -327,7 +325,7 @@ function get_supported_mode_per_connector
 
       modes=$(cmd_remotely "$cmd" "SILENT" "$remote" "$port" "root" "1")
       target_label="remote"
-    ;;
+      ;;
   esac
 
   modes=${modes//\/modes/}
@@ -391,7 +389,7 @@ function drm_parser_options()
           drm_options_values["GUI_OFF"]=1
           continue
           ;;
-        --load-module=*|-lm=*)
+        --load-module=* | -lm=*)
           drm_options_values["LOAD_MODULE"]=$(cut -d "=" -f2- <<< "$option")
           module_parameter=1
           if [[ -z "${drm_options_values['LOAD_MODULE']}" ]]; then
@@ -400,7 +398,7 @@ function drm_parser_options()
           fi
           continue
           ;;
-        --unload-module=*|-um=*)
+        --unload-module=* | -um=*)
           drm_options_values["UNLOAD_MODULE"]=$(cut -d "=" -f2- <<< "$option")
           unmodule_parameter=1
           if [[ -z "${drm_options_values['UNLOAD_MODULE']}" ]]; then
@@ -417,7 +415,7 @@ function drm_parser_options()
           drm_options_values["MODES_AVAILABLE"]=1
           break
           ;;
-        --help|-h|help)
+        --help | -h | help)
           drm_options_values["HELP"]=1
           break
           ;;
@@ -432,7 +430,7 @@ function drm_parser_options()
     else
       # Handle other sub-parameters
       if [[ "${drm_options_values['TARGET']}" == "$REMOTE_TARGET" &&
-            "$module_parameter" != 1 && "$unload_module" != 1 ]]; then
+        "$module_parameter" != 1 && "$unload_module" != 1 ]]; then
         drm_options_values["REMOTE"]=$(get_remote_info "$option")
       fi
 
@@ -447,8 +445,8 @@ function drm_parser_options()
   done
 
   case "${drm_options_values["TARGET"]}" in
-    2|3)
-      ;;
+    2 | 3) ;;
+
     *)
       if [[ "${drm_options_values["TARGET"]}" == 1 ]]; then
         msg=" The option --vm is not valid for drm plugin, use --remote or --local"
@@ -459,7 +457,7 @@ function drm_parser_options()
   esac
 }
 
-function drm_help
+function drm_help()
 {
   echo -e "Usage: kw drm [options]:\n" \
     "\tdrm [--remote [REMOTE:PORT]] --load-module=|-lm='MODULE[:PARAM1,PARAM2][;MODULE:...][;...]\n" \

--- a/src/pomodoro.sh
+++ b/src/pomodoro.sh
@@ -98,13 +98,13 @@ function calculate_missing_time()
   case "$time_type" in
     h)
       time_value=$((3600 * "$time_value"))
-    ;;
+      ;;
     m)
       time_value=$((60 * "$time_value"))
-    ;;
+      ;;
     s)
       time_value="$time_value"
-    ;;
+      ;;
   esac
 
   missing_time=$(($time_value - $elapsed_time))
@@ -128,8 +128,7 @@ function show_active_pomodoro_timebox()
 
   current_timestamp=$(get_timestamp_sec)
 
-  while read line
-  do
+  while read line; do
     # Get data from file
     timestamp=$(echo "$line" | cut -d',' -f1)
     timebox=$(echo "$line" | cut -d',' -f2)
@@ -170,32 +169,32 @@ function pomodoro_parser()
     if [[ "$option" =~ ^(--.*|-.*|test_mode) ]]; then
       label=0
       case "$option" in
-        --set-timer|-t)
+        --set-timer | -t)
           options_values['TIMER']=1
           timer=1
           continue
-        ;;
-        --current|-c)
+          ;;
+        --current | -c)
           options_values['SHOW_TIMER']=1
           continue
-        ;;
-        --label|-l)
+          ;;
+        --label | -l)
           options_values['LABEL']=''
           label=1
           echo "TODO: Add label"
           continue
-        ;;
-        --description|-d)
+          ;;
+        --description | -d)
           options_values['DESCRIPTION']=''
           description=1
           echo "TODO: Add description"
           continue
-        ;;
+          ;;
         *)
           complain "Invalid option: $option"
           pomodoro_help
           exit 22 # EINVAL
-        ;;
+          ;;
       esac
     else
       if [[ "$timer" == 1 ]]; then
@@ -207,9 +206,9 @@ function pomodoro_parser()
         fi
 
         time_value=$(chop "$option")
-        if ! str_is_a_number "$time_value" ; then
-           complain "'$time_value' is not a number"
-           exit 22 # EINVAL
+        if ! str_is_a_number "$time_value"; then
+          complain "'$time_value' is not a number"
+          exit 22 # EINVAL
         fi
 
         options_values['TIMER']="$option"

--- a/src/remote.sh
+++ b/src/remote.sh
@@ -175,11 +175,11 @@ function prepare_remote_dir()
 
   # Send the specific deploy script as a root
   cp_host2remote "$KW_PLUGINS_DIR/kernel_install/$distro.sh" \
-                 "$DISTRO_DEPLOY_SCRIPT" "$remote" "$port" "$user" "$flag"
+    "$DISTRO_DEPLOY_SCRIPT" "$remote" "$port" "$user" "$flag"
   cp_host2remote "$DEPLOY_SCRIPT" "$REMOTE_KW_DEPLOY/" "$remote" "$port" \
-                 "$user" "$flag"
+    "$user" "$flag"
   cp_host2remote "$DEPLOY_SCRIPT_SUPPORT" "$REMOTE_KW_DEPLOY/" "$remote" \
-                 "$port" "$user" "$flag"
+    "$port" "$user" "$flag"
 }
 
 # This function generates a tarball file to be sent to the target machine.
@@ -270,8 +270,8 @@ function get_remote_info()
 function kw_ssh()
 {
   local opts="$@"
-  local port="${configurations[ssh_port]}";
-  local target="${configurations[ssh_ip]}";
+  local port="${configurations[ssh_port]}"
+  local target="${configurations[ssh_ip]}"
 
   if [[ "$1" == -h ]]; then
     ssh_help

--- a/src/statistics.sh
+++ b/src/statistics.sh
@@ -5,16 +5,15 @@
 include "$KW_LIB_DIR/kw_config_loader.sh"
 include "$KW_LIB_DIR/kw_time_and_date.sh"
 
-
 # This is a data struct that describes the main type of data collected. We use
 # this in some internal loops.
-declare -ga statistics_opt=( 'deploy' 'build' 'list' 'uninstall' 'build_failure' 'Modules_deploy' )
+declare -ga statistics_opt=('deploy' 'build' 'list' 'uninstall' 'build_failure' 'Modules_deploy')
 
 # ATTENTION:
 # This variable is shared between function, for this reason, it is NOT SAFE to
 # parallelize code inside this file. We use this array a temporary data
 # container to be pass through other functions.
-declare -gA shared_data=( ["deploy"]='' ["build"]='' ["list"]='' ["uninstall"]='' ["build_failure"]='' ["Modules_deploy"]='' )
+declare -gA shared_data=(["deploy"]='' ["build"]='' ["list"]='' ["uninstall"]='' ["build_failure"]='' ["Modules_deploy"]='')
 
 function statistics()
 {
@@ -58,7 +57,7 @@ function statistics()
         fi
       fi
       day_statistics "$target_day"
-    ;;
+      ;;
     --week)
       local first_week_day=$(get_week_beginning_day)
 
@@ -67,7 +66,7 @@ function statistics()
       fi
 
       week_statistics "$first_week_day"
-    ;;
+      ;;
     --month)
       if [[ ! -z "$@" ]]; then
         # First month of the month
@@ -78,7 +77,7 @@ function statistics()
         fi
       fi
       month_statistics "$year_month_dir"
-    ;;
+      ;;
     --year)
       local year=$(date +%Y)
 
@@ -91,11 +90,11 @@ function statistics()
       fi
 
       year_statistics "$year"
-    ;;
+      ;;
     *)
       complain "Invalid parameter: $info_request"
       return 22 # EINVAL
-    ;;
+      ;;
   esac
 
 }
@@ -117,11 +116,11 @@ function calculate_average()
   local avg=0
 
   for value in $list_of_values; do
-    sum=$(( sum + value ))
-    (( count++ ))
+    sum=$((sum + value))
+    ((count++))
   done
 
-  avg=$(( sum / count ))
+  avg=$((sum / count))
 
   echo "$avg"
 }
@@ -270,7 +269,7 @@ function week_statistics()
   first=${first:-$(get_today_info '+%Y/%m/%d')}
 
   # 7 -> week days
-  for (( i=0 ; i < 7 ; i++ )); do
+  for ((i = 0; i < 7; i++)); do
     day=$(date --date="${first} +${i} day" +%Y/%m/%d)
     [[ ! -f "$KW_DATA_DIR/statistics/$day" ]] && continue
 

--- a/src/vm.sh
+++ b/src/vm.sh
@@ -1,7 +1,7 @@
 include "$KW_LIB_DIR/kw_config_loader.sh"
 include "$KW_LIB_DIR/kwlib.sh"
 
-function vm_mount
+function vm_mount()
 {
   local flag="$1"
   local qemu_img_path="$2"
@@ -21,16 +21,16 @@ function vm_mount
 
   guestmount_cmd="guestmount -a $qemu_img_path -i $mount_point_path 2>&1"
   cmd_manager "$flag" "$guestmount_cmd"
-  if [[ "$ret" ]] ; then
+  if [[ "$ret" ]]; then
     complain "Something went wrong when tried to mount $qemu_img_path" \
-       "in $mount_point_path"
+      "in $mount_point_path"
     return "$ret"
   fi
 
   return 0
 }
 
-function vm_umount
+function vm_umount()
 {
   local flag="$1"
   local qemu_img_path="$2"
@@ -48,9 +48,9 @@ function vm_umount
     guestumount_cmd="guestunmount $mount_point_path"
     cmd_manager "$flag" "$guestumount_cmd"
     ret="$?"
-    if [[ "$ret" != 0 ]] ; then
+    if [[ "$ret" != 0 ]]; then
       complain "Something went wrong when tried to unmount $qemu_img_path" \
-         "in $mount_point_path"
+        "in $mount_point_path"
       return "$ret"
     fi
     return 0
@@ -59,14 +59,14 @@ function vm_umount
   return 125 #ECANCELED
 }
 
-function vm_up
+function vm_up()
 {
   say "Starting Qemu with: "
   echo "${configurations[virtualizer]} ${configurations[qemu_hw_options]}" \
-       "${configurations[qemu_net_options]}" \
-       "${configurations[qemu_path_image]}"
+    "${configurations[qemu_net_options]}" \
+    "${configurations[qemu_path_image]}"
 
   ${configurations[virtualizer]} ${configurations[qemu_hw_options]} \
-        ${configurations[qemu_net_options]} \
-        ${configurations[qemu_path_image]}
+    ${configurations[qemu_net_options]} \
+    ${configurations[qemu_path_image]}
 }

--- a/tests/checkpatch_wrapper_test.sh
+++ b/tests/checkpatch_wrapper_test.sh
@@ -3,7 +3,7 @@
 include './src/checkpatch_wrapper.sh'
 include './tests/utils'
 
-function suite
+function suite()
 {
   suite_addTest "warning_Test"
   suite_addTest "error_Test"
@@ -19,7 +19,7 @@ function suite
 # Those variables hold the last line execute_checkpatch prints in a code that is
 # correct, has 1 warning, has 1 erros and has 1 check, respectively. The sample
 # codes used in this test are in tests/samples/
-function oneTimeSetUp
+function oneTimeSetUp()
 {
   mk_fake_kernel_root "$TMP_TEST_DIR"
   cp -f tests/external/checkpatch.pl "$TMP_TEST_DIR"/scripts/
@@ -28,12 +28,12 @@ function oneTimeSetUp
   cp -r tests/samples "$TMP_TEST_DIR"
 }
 
-function oneTimeTearDown
+function oneTimeTearDown()
 {
   rm -rf "$TMP_TEST_DIR"
 }
 
-function checkpatch_helper
+function checkpatch_helper()
 {
   local type_msg="$1"
   local CORRECT_MSG="$SEPARATOR"
@@ -41,38 +41,38 @@ function checkpatch_helper
   local ERROR_MSG='total: 1 errors, 0 warnings, 0 checks, 25 lines checked'
   local CHECK_MSG='total: 0 errors, 0 warnings, 1 checks, 26 lines checked'
   local res
-  declare -A MSG=( \
-      ['correct']=CORRECT_MSG \
-      ['warning']=WARNING_MSG \
-      ['error']=ERROR_MSG \
-      ['check']=CHECK_MSG \
+  declare -A MSG=(
+    ['correct']=CORRECT_MSG
+    ['warning']=WARNING_MSG
+    ['error']=ERROR_MSG
+    ['check']=CHECK_MSG
   )
 
   res=$(execute_checkpatch "$TMP_TEST_DIR/samples/codestyle_$type_msg.c" 2>&1)
   assertTrue "Checkpatch should output: ${!MSG[$type_msg]}" '[[ "$res" =~ "${!MSG[$type_msg]}" ]]'
 }
 
-function warning_Test
+function warning_Test()
 {
   checkpatch_helper 'warning'
 }
 
-function error_Test
+function error_Test()
 {
   checkpatch_helper 'error'
 }
 
-function checks_Test
+function checks_Test()
 {
   checkpatch_helper 'check'
 }
 
-function correct_Test
+function correct_Test()
 {
   checkpatch_helper 'correct'
 }
 
-function invalid_path_Test
+function invalid_path_Test()
 {
   local build_fake_path
   local output
@@ -85,7 +85,7 @@ function invalid_path_Test
   assertEquals 'We forced an invalid path and we expect an error' '2' "$ret"
 }
 
-function no_kernel_directory_Test
+function no_kernel_directory_Test()
 {
   local sample_one="$SAMPLES_DIR/codestyle_warning.c"
   local output
@@ -101,7 +101,7 @@ function no_kernel_directory_Test
   oneTimeSetUp
 }
 
-function multiple_files_output_Test
+function multiple_files_output_Test()
 {
   local delimiter="$SEPARATOR"
   local array=()
@@ -112,9 +112,9 @@ function multiple_files_output_Test
   # Reference: https://www.tutorialkart.com/bash-shell-scripting/bash-split-string/
   s="$output$delimiter"
   while [[ "$s" ]]; do
-    array+=( "${s%%"$delimiter"*}" );
-    s=${s#*"$delimiter"};
-  done;
+    array+=("${s%%"$delimiter"*}")
+    s=${s#*"$delimiter"}
+  done
 
   size="${#array[@]}"
   # We use three here because we expect one $SEPARATOR from the beginning and
@@ -122,7 +122,7 @@ function multiple_files_output_Test
   assertFalse 'We could not find more then two SEPARATOR sequence' '[[ $size -lt "3" ]]'
 }
 
-function run_checkpatch_in_a_path_Test
+function run_checkpatch_in_a_path_Test()
 {
   local cmd="perl scripts/checkpatch.pl --no-tree --color=always --strict"
   local patch_path="$TMP_TEST_DIR/samples/test.patch"
@@ -139,7 +139,7 @@ function run_checkpatch_in_a_path_Test
   compare_command_sequence expected_cmd[@] "$output" '1'
 }
 
-function run_checkpatch_in_a_file_Test
+function run_checkpatch_in_a_file_Test()
 {
   local cmd="perl scripts/checkpatch.pl --terse --no-tree --color=always --strict  --file"
   local patch_path="$TMP_TEST_DIR/samples/codestyle_correct.c"

--- a/tests/configm_test.sh
+++ b/tests/configm_test.sh
@@ -21,7 +21,7 @@ readonly DESCRIPTION_2="Hi, I'm the second description"
 
 readonly LS_NO_FILES="There's no tracked .config file"
 
-function suite
+function suite()
 {
   suite_addTest "execute_config_manager_SAVE_fails_Test"
   suite_addTest "save_config_file_check_save_failures_Test"
@@ -59,7 +59,7 @@ function tearDown()
   rm -rf "$TMP_TEST_DIR"
 }
 
-function execute_config_manager_SAVE_fails_Test
+function execute_config_manager_SAVE_fails_Test()
 {
   local msg_prefix=" --save"
 
@@ -142,7 +142,7 @@ function save_config_file_check_saved_config_Test()
   msg="Failed to find $NAME_1"
   assertTrue "$LINENO: $msg" '[[ -f $configs_path/configs/$NAME_1 ]]'
   msg="Failed the metadata related to $NAME_1"
-  assertTrue "$LINENO: $msg"  '[[ -f $configs_path/metadata/$NAME_1 ]]'
+  assertTrue "$LINENO: $msg" '[[ -f $configs_path/metadata/$NAME_1 ]]'
 
   cd "$TMP_TEST_DIR"
   ret=$(save_config_file $NO_FORCE $NAME_2)
@@ -349,7 +349,7 @@ function execute_config_manager_remove_that_should_fail_Test()
   assert_equals_helper "$msg_prefix" "$LINENO" "$COMMAND_NO_SUCH_FILE: something_wrong" "$ret"
 }
 
-function remove_config_Test
+function remove_config_Test()
 {
   local current_path="$PWD"
   local ret=0
@@ -363,12 +363,12 @@ function remove_config_Test
   assertTrue "We expected , 2 files but got $ret" '[[ $ret = "2" ]]'
 
   # Case 2: Remove one config file
-  remove_config "$NAME_1" 1  > /dev/null 2>&1
+  remove_config "$NAME_1" 1 > /dev/null 2>&1
   ret=$(ls configs/configs -1 | wc -l)
   assertTrue "$LINENO: We expected , 1 files but got $ret" '[[ $ret = "1" ]]'
 
   # Case 2: Remove all config files
-  remove_config "$NAME_2" 1  > /dev/null 2>&1
+  remove_config "$NAME_2" 1 > /dev/null 2>&1
   assertTrue "$LINENO: We expected no file related to config" '[[ ! -f configs/configs ]]'
 
   cd "$current_path"

--- a/tests/diff_test.sh
+++ b/tests/diff_test.sh
@@ -3,13 +3,13 @@
 include './src/diff.sh'
 include './tests/utils'
 
-function suite
+function suite()
 {
   suite_addTest "diff_side_by_side_Test"
   suite_addTest "diff_manager_Test"
 }
 
-function diff_side_by_side_Test
+function diff_side_by_side_Test()
 {
   local ID
   local columns=$(tput cols)
@@ -45,7 +45,7 @@ function diff_side_by_side_Test
 
 }
 
-function diff_manager_Test
+function diff_manager_Test()
 {
   local ID
   local file_1="$SAMPLES_DIR/MAINTAINERS"

--- a/tests/drm_plugin_test.sh
+++ b/tests/drm_plugin_test.sh
@@ -4,7 +4,7 @@ include './src/plugins/subsystems/drm/drm.sh'
 include './src/kwlib.sh'
 include './tests/utils'
 
-function suite
+function suite()
 {
   suite_addTest "gui_control_Test"
   suite_addTest "drm_manager_Test"
@@ -37,7 +37,7 @@ function tearDown()
   rm -rf "$TMP_TEST_DIR"
 }
 
-function drm_manager_Test
+function drm_manager_Test()
 {
   local ID
 
@@ -69,7 +69,7 @@ function drm_manager_Test
   assertEquals "($ID) Should not accept --vm:" "$?" "22"
 }
 
-function gui_control_Test
+function gui_control_Test()
 {
   local gui_on_cmd='systemctl isolate graphical.target'
   local gui_off_cmd='systemctl isolate multi-user.target'
@@ -136,7 +136,7 @@ function gui_control_Test
   compare_command_sequence expected_cmd_seq[@] "$output" "$ID"
 }
 
-function get_available_connectors_Test
+function get_available_connectors_Test()
 {
   local ID
   export SYSFS_CLASS_DRM="$FAKE_DRM_SYSFS"
@@ -160,7 +160,7 @@ function get_available_connectors_Test
   compare_command_sequence expected_output[@] "$output" "$ID"
 }
 
-function get_supported_mode_per_connector_Test
+function get_supported_mode_per_connector_Test()
 {
   declare -a expected_output=(
     "Modes per card"
@@ -198,7 +198,7 @@ function get_supported_mode_per_connector_Test
   compare_command_sequence expected_output[@] "$output" "$ID"
 }
 
-function module_control_Test
+function module_control_Test()
 {
   local ID
   local default_ssh="ssh -p 22 root@localhost"
@@ -253,7 +253,7 @@ function module_control_Test
 }
 #compare_command_sequence expected_cmd[@] "$output" "$ID"
 
-function convert_module_info_Test
+function convert_module_info_Test()
 {
   local ID
 

--- a/tests/explore_test.sh
+++ b/tests/explore_test.sh
@@ -3,7 +3,7 @@
 include './tests/utils'
 include './src/explore.sh'
 
-function suite
+function suite()
 {
   suite_addTest "explore_files_under_git_repo_Test"
   suite_addTest "explore_git_log_Test"
@@ -50,7 +50,7 @@ function tearDown()
   rm -rf "$test_path"
 }
 
-function explore_files_under_git_repo_Test
+function explore_files_under_git_repo_Test()
 {
   local ID
   local MSG_OUT
@@ -82,17 +82,17 @@ function explore_files_under_git_repo_Test
   ID=5
   cp "$current_path/tests/samples/grep_check.c" ./
   MSG_OUT="GNU grep"
-  output=$(explore "GNU grep" | cut -d: -f1 )
+  output=$(explore "GNU grep" | cut -d: -f1)
   assertEquals "($ID)" "" "$output"
   git add "grep_check.c" &> /dev/null
   MSG_OUT="GNU grep"
-  output=$(explore "GNU grep" | cut -d: -f1 )
+  output=$(explore "GNU grep" | cut -d: -f1)
   assertEquals "($ID)" "grep_check.c" "$output"
 
   cd "$current_path"
 }
 
-function explore_git_log_Test
+function explore_git_log_Test()
 {
   local ID
   local file_name
@@ -110,7 +110,7 @@ function explore_git_log_Test
   cd "$current_path"
 }
 
-function explore_grep_Test
+function explore_grep_Test()
 {
   local ID
   local expected_result
@@ -119,7 +119,7 @@ function explore_grep_Test
   cd "$test_path"
 
   ID=1
-  output=$(explore --grep "GNU grep" | cut -d/ -f2 )
+  output=$(explore --grep "GNU grep" | cut -d/ -f2)
   assertEquals "($ID)" ".git" "$output"
 
   ID=2
@@ -130,7 +130,7 @@ function explore_grep_Test
   cd "$current_path"
 }
 
-function explore_git_Test
+function explore_git_Test()
 {
   local ID
   local expected_result
@@ -145,20 +145,20 @@ function explore_git_Test
 
   # Test if the search ignores files in .git
   ID=2
-  output=$(explore --all "GNU grep" | cut -d/ -f2 )
+  output=$(explore --all "GNU grep" | cut -d/ -f2)
   assertEquals "($ID)" "" "$output"
 
   # Test if search files not under git control
   ID=3
   cp "$current_path/tests/samples/grep_check.c" ./
   MSG_OUT="GNU grep"
-  output=$(explore --all "GNU grep" | cut -d: -f1 )
+  output=$(explore --all "GNU grep" | cut -d: -f1)
   assertEquals "($ID)" "grep_check.c" "$output"
 
   cd "$current_path"
 }
 
-function explore_parser_Test
+function explore_parser_Test()
 {
   local ID
 

--- a/tests/get_maintainer_wrapper_test.sh
+++ b/tests/get_maintainer_wrapper_test.sh
@@ -5,7 +5,7 @@ include './tests/utils'
 
 # TODO: make execute_get_maintainer's tests cover more corner cases?
 
-function suite
+function suite()
 {
   suite_addTest "print_files_authors_Test"
   suite_addTest "print_files_authors_from_dir_Test"
@@ -51,7 +51,7 @@ Maintainers already in \"To:\" field of update_patch_test.patch"
 
 FAKE_KERNEL="tests/.tmp"
 
-function oneTimeSetUp
+function oneTimeSetUp()
 {
   # This creates tests/.tmp which should mock a kernel tree root. A .git
   # dir is also created inside tests/.tmp so that get_maintainer.pl thinks
@@ -70,8 +70,7 @@ function oneTimeSetUp
   cd "$original_dir"
 }
 
-
-function oneTimeTearDown
+function oneTimeTearDown()
 {
   rm -rf "$FAKE_KERNEL"
 }
@@ -88,7 +87,7 @@ function print_files_authors_from_dir_Test()
   multilineAssertEquals "$ret" "$CORRECT_DIR_MSG"
 }
 
-function execute_get_maintainer_Test
+function execute_get_maintainer_Test()
 {
   local ret
   local -r original_dir="$PWD"
@@ -112,7 +111,8 @@ function execute_get_maintainer_Test
   cd "$original_dir"
 }
 
-function execute_get_maintainer_patch_Test() {
+function execute_get_maintainer_patch_Test()
+{
 
   local original_dir="$PWD"
   cd "$FAKE_KERNEL"

--- a/tests/help_test.sh
+++ b/tests/help_test.sh
@@ -3,15 +3,16 @@
 include './tests/utils'
 include './src/help.sh'
 
-function suite
+function suite()
 {
   suite_addTest "kworkflow_help_Test"
 }
 
-function kworkflow_help_Test
+function kworkflow_help_Test()
 {
   HELP_OUTPUT=$(kworkflow_help | head -n 1)
-  [[ $HELP_OUTPUT =~ Usage:\ kw.* ]]; assertTrue "Help text not displaying correctly." $?
+  [[ $HELP_OUTPUT =~ Usage:\ kw.* ]]
+  assertTrue "Help text not displaying correctly." $?
 }
 
 invoke_shunit

--- a/tests/init_test.sh
+++ b/tests/init_test.sh
@@ -3,7 +3,7 @@
 include './src/init.sh'
 include './tests/utils'
 
-function suite
+function suite()
 {
   suite_addTest "init_kw_Test"
 }
@@ -11,7 +11,7 @@ function suite
 FAKE_DIR="tests/.tmp"
 FAKE_CONFIG_PATH="$FAKE_DIR/.config"
 
-function setUp
+function setUp()
 {
   export KW_ETC_DIR="tests/samples"
   export KW_SHARE_SOUND_DIR="tests/samples/share/sound/kw"
@@ -23,12 +23,12 @@ function setUp
   mkdir -p "$FAKE_CONFIG_PATH/$KWORKFLOW"
 }
 
-function tearDown
+function tearDown()
 {
   rm -rf "$FAKE_DIR"
 }
 
-function init_kw_Test
+function init_kw_Test()
 {
   local ID
   local kworkflow_content

--- a/tests/kw_config_loader_test.sh
+++ b/tests/kw_config_loader_test.sh
@@ -5,7 +5,7 @@ include './src/kw_config_loader.sh'
 
 TMP_DIR=tests/.tmp_kw_config_loader_test
 
-function suite
+function suite()
 {
   suite_addTest "parse_configuration_success_exit_code_Test"
   suite_addTest "parser_configuration_failed_exit_code_Test"
@@ -14,31 +14,31 @@ function suite
   suite_addTest "parse_configuration_files_loading_order_Test"
 }
 
-function setUp
+function setUp()
 {
   mkdir -p "$TMP_DIR"
   cp "$PWD/etc/kworkflow_template.config" "$TMP_DIR/kworkflow.config"
   configurations=()
 }
 
-function tearDown
+function tearDown()
 {
   rm -rf "$TMP_DIR"
 }
 
-function parse_configuration_success_exit_code_Test
+function parse_configuration_success_exit_code_Test()
 {
   parse_configuration tests/samples/kworkflow.config
   assertTrue "Kw failed to load a regular config file" "[ 0 -eq $? ]"
 }
 
-function parser_configuration_failed_exit_code_Test
+function parser_configuration_failed_exit_code_Test()
 {
   parse_configuration tests/kw_config_loader_test.sh
   assertTrue "kw loaded an unsupported file" "[ 22 -eq $? ]"
 }
 
-function assertConfigurations
+function assertConfigurations()
 {
   declare -n configurations_ref=$1
   declare -n expected_configurations_ref=$2
@@ -61,7 +61,7 @@ function assertConfigurations
 }
 
 # Test if parse_configuration correctly parses all settings in a file
-function parse_configuration_output_Test
+function parse_configuration_output_Test()
 {
   declare -A expected_configurations=(
     [arch]="arm64"
@@ -91,7 +91,7 @@ function parse_configuration_output_Test
 }
 
 # Test if etc/kworkflow_template.config contains all the expected settings
-function parse_configuration_standard_config_Test
+function parse_configuration_standard_config_Test()
 {
   local path_repo=$PWD
 
@@ -121,14 +121,17 @@ function parse_configuration_standard_config_Test
   true # Reset return value
 }
 
-function parse_configuration_files_loading_order_Test
+function parse_configuration_files_loading_order_Test()
 {
   expected="$KW_ETC_DIR/$CONFIG_FILENAME
 $HOME/.kw/$CONFIG_FILENAME
 $PWD/$CONFIG_FILENAME"
 
   output="$(
-    function parse_configuration { echo "$@"; }
+    function parse_configuration()
+    {
+      echo "$@"
+    }
     load_configuration
   )"
 

--- a/tests/kw_dash.sh
+++ b/tests/kw_dash.sh
@@ -2,12 +2,12 @@
 
 include './tests/utils'
 
-function suite
+function suite()
 {
   suite_addTest "check_dash_integration_with_kw_Test"
 }
 
-function check_dash_integration_with_kw_Test
+function check_dash_integration_with_kw_Test()
 {
   ./tests/_kw_dash.dsh
   if [ $? -ne 0 ]; then

--- a/tests/kw_include_test.sh
+++ b/tests/kw_include_test.sh
@@ -16,7 +16,8 @@ function include_Test()
   assertEquals "($LINENO)" 1 "$output"
 }
 
-function include_twice_Test() {
+function include_twice_Test()
+{
   include ./src/kwlib.sh
   include ./src/kwlib.sh
   ret="$?"

--- a/tests/kw_string_test.sh
+++ b/tests/kw_string_test.sh
@@ -3,14 +3,14 @@
 include './src/kw_string.sh'
 include './tests/utils'
 
-function suite
+function suite()
 {
   suite_addTest 'chop_Test'
   suite_addTest 'last_char_Test'
   suite_addTest 'str_is_a_number_Test'
 }
 
-function chop_Test
+function chop_Test()
 {
   local output
   local str_test='1234567'
@@ -25,7 +25,7 @@ function chop_Test
   assert_equals_helper 'Expected an empty string' "$LINENO" "" "$output"
 }
 
-function last_char_Test
+function last_char_Test()
 {
   local output
   local str_test='kworkflow'
@@ -42,7 +42,7 @@ function last_char_Test
   assert_equals_helper 'We did not get the last char' "$LINENO" '' "$output"
 }
 
-function str_is_a_number_Test
+function str_is_a_number_Test()
 {
   local output
   local str_test=333

--- a/tests/kw_test.sh
+++ b/tests/kw_test.sh
@@ -1,36 +1,37 @@
 #!/bin/bash
 
 include './tests/utils'
-unset -v KW_LIB_DIR  # to be able to test the developer mode
+unset -v KW_LIB_DIR # to be able to test the developer mode
 include './kw' > /dev/null
 # when imported kw prints the help function and we don´t want
 # to polute our test results, so we redirect its output to /dev/null
 
-function suite
+function suite()
 {
   suite_addTest "validate_global_variables_Test"
   suite_addTest "check_kworkflow_global_variable_Test"
   suite_addTest 'set_KW_LIB_DIR_in_dev_mode_Test'
 }
 
-function validate_global_variables_Test
+function validate_global_variables_Test()
 {
-  VARS=( KWORKFLOW KW_LIB_DIR )
+  VARS=(KWORKFLOW KW_LIB_DIR)
   for v in "${VARS[@]}"; do
-    test -z ${!v+x}; assertEquals "Variable $v should exist." $? 1
+    test -z ${!v+x}
+    assertEquals "Variable $v should exist." $? 1
   done
 }
 
-function check_kworkflow_global_variable_Test
+function check_kworkflow_global_variable_Test()
 {
-  VARS=( KWORKFLOW )
+  VARS=(KWORKFLOW)
   for v in "${VARS[@]}"; do
-    [[ $(declare -p $v)  =~ ^declare\ -[aAilrtu]*x[aAilrtu]*\  ]] ||
+    [[ $(declare -p $v) =~ ^declare\ -[aAilrtu]*x[aAilrtu]*\  ]] ||
       fail "Variable $v should have been exported"
   done
 }
 
-function set_KW_LIB_DIR_in_dev_mode_Test
+function set_KW_LIB_DIR_in_dev_mode_Test()
 {
   lib="${KW_LIB_DIR}/kwlib.sh"
   test -f "${lib}" || fail "kwlib.sh not found (${lib} not found)!"

--- a/tests/kw_time_and_date_test.sh
+++ b/tests/kw_time_and_date_test.sh
@@ -3,7 +3,7 @@
 include './src/kw_time_and_date.sh'
 include './tests/utils'
 
-function suite
+function suite()
 {
   suite_addTest 'sec_to_format_Test'
   suite_addTest 'get_today_info_Test'
@@ -11,14 +11,14 @@ function suite
   suite_addTest 'date_to_format_Test'
 }
 
-function setUp
+function setUp()
 {
   # Samples file data
   pre_total_sec="1846"
   pre_formated_sec="00:30:46"
 }
 
-function sec_to_format_Test
+function sec_to_format_Test()
 {
   formatted_time=$(sec_to_format "$pre_total_sec")
   assertEquals "($LINENO)" "$formatted_time" "$pre_formated_sec"
@@ -33,7 +33,7 @@ function sec_to_format_Test
   assertEquals "($LINENO)" "$formatted_time" '46'
 }
 
-function get_today_info_Test
+function get_today_info_Test()
 {
   local today=$(date +%Y/%m/%d)
 
@@ -45,7 +45,7 @@ function get_today_info_Test
   assert_equals_helper 'No parameter' "$LINENO" "$today" "$formated_today"
 }
 
-function get_week_beginning_day_Test
+function get_week_beginning_day_Test()
 {
   local ref_week='2021/05/19'
   local first_week_day='2021/05/16'
@@ -66,7 +66,7 @@ function get_week_beginning_day_Test
   assert_equals_helper 'The first day of this week' "$LINENO" "$first_week_day" "$week_day"
 }
 
-function date_to_format_Test
+function date_to_format_Test()
 {
   local formatted_date
 

--- a/tests/kwio_test.sh
+++ b/tests/kwio_test.sh
@@ -13,7 +13,7 @@ declare -A configurations
 sound_file="$PWD/tests/.kwio_test_aux/sound.file"
 visual_file="$PWD/tests/.kwio_test_aux/visual.file"
 
-function suite
+function suite()
 {
   suite_addTest "alert_completion_options_Test"
   suite_addTest "alert_completition_validate_config_file_options_Test"
@@ -21,20 +21,19 @@ function suite
   suite_addTest "alert_completion_sound_alert_Test"
 }
 
-function setUp
+function setUp()
 {
   mkdir -p tests/.kwio_test_aux
   configurations["sound_alert_command"]="touch $sound_file"
   configurations["visual_alert_command"]="touch $visual_file"
 }
 
-function tearDown
+function tearDown()
 {
   rm -rf tests/.kwio_test_aux
 }
 
-
-function alert_completion_options_Test
+function alert_completion_options_Test()
 {
   configurations["alert"]="n"
 
@@ -66,7 +65,7 @@ function alert_completion_options_Test
   true
 }
 
-function alert_completition_validate_config_file_options_Test
+function alert_completition_validate_config_file_options_Test()
 {
   mkdir -p tests/.kwio_test_aux
 
@@ -103,7 +102,7 @@ function alert_completition_validate_config_file_options_Test
   true
 }
 
-function alert_completion_visual_alert_Test
+function alert_completion_visual_alert_Test()
 {
   local output
   local expected="TESTING COMMAND"
@@ -113,7 +112,7 @@ function alert_completion_visual_alert_Test
   assertEquals "Variable v should exist." "$output" "$expected"
 }
 
-function alert_completion_sound_alert_Test
+function alert_completion_sound_alert_Test()
 {
   local output
   local expected="TESTING COMMAND"

--- a/tests/kwlib_test.sh
+++ b/tests/kwlib_test.sh
@@ -4,7 +4,7 @@ include './src/get_maintainer_wrapper.sh'
 include './src/kwlib.sh'
 include './tests/utils'
 
-function suite
+function suite()
 {
   suite_addTest "is_kernel_root_Test"
   suite_addTest "cmd_manager_check_test_mode_option_Test"
@@ -27,7 +27,7 @@ FAKE_STATISTICS_PATH="$KW_DATA_DIR/statistics"
 FAKE_STATISTICS_MONTH_PATH="$FAKE_STATISTICS_PATH/$TARGET_YEAR_MONTH"
 FAKE_STATISTICS_DAY_PATH="$FAKE_STATISTICS_MONTH_PATH/03"
 
-function setupFakeOSInfo
+function setupFakeOSInfo()
 {
   mkdir -p tests/.tmp/detect_distro/{arch,manjaro,debian,ubuntu}/etc
   cp -f tests/samples/os/arch/* tests/.tmp/detect_distro/arch/etc
@@ -36,14 +36,14 @@ function setupFakeOSInfo
   cp -f tests/samples/os/ubuntu/* tests/.tmp/detect_distro/ubuntu/etc
 }
 
-function setupPatch
+function setupPatch()
 {
   mkdir -p "$FAKE_STATISTICS_MONTH_PATH"
   touch "$FAKE_STATISTICS_DAY_PATH"
   cp -f tests/samples/test.patch tests/.tmp/
 }
 
-function setupFakeKernelRepo
+function setupFakeKernelRepo()
 {
   # This creates tests/.tmp which should mock a kernel tree root. A .git
   # dir is also created inside tests/.tmp so that get_maintainer.pl thinks
@@ -72,12 +72,12 @@ function setupFakeKernelRepo
   cp -f tests/external/get_maintainer.pl tests/.tmp/scripts/
 }
 
-function tearDownSetup
+function tearDownSetup()
 {
   rm -rf "$FAKE_STATISTICS_PATH"
 }
 
-function is_kernel_root_Test
+function is_kernel_root_Test()
 {
   setupFakeKernelRepo
   is_kernel_root "tests/.tmp"
@@ -86,7 +86,7 @@ function is_kernel_root_Test
   true # Reset return value
 }
 
-function cmd_manager_check_silent_option_Test
+function cmd_manager_check_silent_option_Test()
 {
   setupFakeKernelRepo
   cd "tests/.tmp"
@@ -110,7 +110,7 @@ function cmd_manager_check_silent_option_Test
 
 # The difference between say, complain, warning, and success it is the color
 # because of this we test all of them together
-function cmdManagerSAY_COMPLAIN_WARNING_SUCCESS_Test
+function cmdManagerSAY_COMPLAIN_WARNING_SUCCESS_Test()
 {
   setupFakeKernelRepo
   cd "tests/.tmp"
@@ -142,7 +142,7 @@ function cmdManagerSAY_COMPLAIN_WARNING_SUCCESS_Test
   tearDownSetup
 }
 
-function cmd_manager_check_test_mode_option_Test
+function cmd_manager_check_test_mode_option_Test()
 {
   ret=$(cmd_manager TEST_MODE pwd)
   assertEquals "Expected pwd, but we got $ret" "$ret" "pwd"
@@ -151,7 +151,7 @@ function cmd_manager_check_test_mode_option_Test
   assertEquals "Expected ls -lah, but we got $ret" "$ret" "ls -lah"
 }
 
-function detect_distro_Test
+function detect_distro_Test()
 {
   setupFakeOSInfo
   local root_path="tests/.tmp/detect_distro/arch"
@@ -176,7 +176,7 @@ function detect_distro_Test
   assertEquals "We got $ret." "$ret" "none"
 }
 
-function join_path_Test
+function join_path_Test()
 {
   local base="/lala/xpto"
   local ret=$(join_path "/lala" "///xpto")
@@ -193,7 +193,7 @@ function join_path_Test
   assertEquals "Expect /lala/" "$ret" "/lala/"
 }
 
-function find_kernel_root_Test
+function find_kernel_root_Test()
 {
   setupFakeKernelRepo
 
@@ -212,7 +212,7 @@ function find_kernel_root_Test
   tearDownSetup
 }
 
-function is_a_patch_Test
+function is_a_patch_Test()
 {
   setupPatch
   is_a_patch "tests/.tmp/test.patch"
@@ -221,7 +221,7 @@ function is_a_patch_Test
   true # Reset return value
 }
 
-function get_based_on_delimiter_Test
+function get_based_on_delimiter_Test()
 {
   local ID
   local ip_port_str="IP:PORT"
@@ -280,7 +280,7 @@ function get_based_on_delimiter_Test
 
 }
 
-function store_statistics_data_Test
+function store_statistics_data_Test()
 {
   local ID
   local fake_day_path="$FAKE_STATISTICS_DAY_PATH"
@@ -310,7 +310,7 @@ function store_statistics_data_Test
   tearDownSetup
 }
 
-function update_statistics_database_Test
+function update_statistics_database_Test()
 {
   local ID
 
@@ -328,7 +328,7 @@ function update_statistics_database_Test
   tearDownSetup
 }
 
-function statistics_manager_Test
+function statistics_manager_Test()
 {
   local ID
   local this_year_and_month=$(date +%Y/%m)
@@ -354,7 +354,7 @@ function statistics_manager_Test
   assertTrue "($ID) Database day" '[[ ! -f "$FAKE_STATISTICS_PATH/$this_year_and_month/$today" ]]'
 }
 
-function command_exists_Test
+function command_exists_Test()
 {
   local fake_command="a-non-existent-command -p"
   local real_command="mkdir"

--- a/tests/mk_test.sh
+++ b/tests/mk_test.sh
@@ -3,7 +3,7 @@
 include './src/mk.sh'
 include './tests/utils'
 
-function suite
+function suite()
 {
   suite_addTest "build_info_Test"
   suite_addTest "mk_build_Test"
@@ -44,7 +44,7 @@ function root_id_mock()
   echo "0"
 }
 
-function setUp
+function setUp()
 {
   local create_mkinitcpio="$1"
 
@@ -67,7 +67,7 @@ function setUp
   export DEPLOY_SCRIPT="$test_path/$kernel_install_path/deploy.sh"
   export KW_PLUGINS_DIR="$PWD/src/plugins/"
   export modules_path="$test_path/$kernel_install_path/lib/modules"
-  if [ -x "$(command -v nproc)" ] ; then
+  if [ -x "$(command -v nproc)" ]; then
     PARALLEL_CORES=$(nproc --all)
   else
     PARALLEL_CORES=$(grep -c ^processor /proc/cpuinfo)
@@ -178,7 +178,7 @@ function mk_build_Test()
 #
 # Output sequence of kernel_deploy in the TEST_MODE:
 #   $reboot $modules $target $remote $single_line $list"
-function kernel_deploy_Test
+function kernel_deploy_Test()
 {
   local ID
   local original="$PWD"
@@ -273,7 +273,7 @@ function kernel_deploy_Test
   cd "$original"
 }
 
-function modules_install_to_Test
+function modules_install_to_Test()
 {
   local ID
   local original="$PWD"
@@ -293,7 +293,7 @@ function modules_install_to_Test
   cd "$original"
 }
 
-function kernel_install_Test
+function kernel_install_Test()
 {
   local name="test"
   local original="$PWD"
@@ -359,7 +359,7 @@ function kernel_install_Test
   tearDown
 }
 
-function kernel_install_x86_64_Test
+function kernel_install_x86_64_Test()
 {
   local name="test"
   local original="$PWD"
@@ -414,7 +414,7 @@ function kernel_install_x86_64_Test
   cd "$original"
 }
 
-function kernel_modules_Test
+function kernel_modules_Test()
 {
   local count=0
   local original="$PWD"
@@ -487,11 +487,10 @@ function kernel_modules_Test
   expected_output="sudo -E make modules_install"
   assertEquals "$ID: " "$output" "$expected_output"
 
-
   cd "$original"
 }
 
-function kernel_modules_local_Test
+function kernel_modules_local_Test()
 {
   local ID
   local original="$PWD"
@@ -504,7 +503,7 @@ function kernel_modules_local_Test
   cd "$original"
 }
 
-function kernel_install_local_Test
+function kernel_install_local_Test()
 {
   local count=0
   local original="$PWD"
@@ -545,7 +544,7 @@ function kernel_install_local_Test
 # by checking the expected command sequence; It is important to highlight that
 # we are not testing the actual kernel list code, this part is validated on
 # another test file.
-function mk_list_remote_kernels_Test
+function mk_list_remote_kernels_Test()
 {
   local count=0
   local original="$PWD"
@@ -588,7 +587,7 @@ function mk_list_remote_kernels_Test
   cd "$original"
 }
 
-function mk_kernel_uninstall_Test
+function mk_kernel_uninstall_Test()
 {
   local count=0
   local original="$PWD"
@@ -647,7 +646,7 @@ function mk_kernel_uninstall_Test
   cd "$original"
 }
 
-function cleanup_after_deploy_Test
+function cleanup_after_deploy_Test()
 {
   local output=""
   local cmd_remote="rm -rf $test_path/$LOCAL_TO_DEPLOY_DIR/*"
@@ -661,12 +660,12 @@ function cleanup_after_deploy_Test
   output=$(cleanup_after_deploy "TEST_MODE")
   while read f; do
     assertFalse "$ID (cmd: $count) - Expected \"${expected_cmd[$count]}\" to be \"${f}\"" \
-                '[[ ${expected_cmd[$count]} != ${f} ]]'
+      '[[ ${expected_cmd[$count]} != ${f} ]]'
     ((count++))
   done <<< "$output"
 }
 
-function build_info_Test
+function build_info_Test()
 {
   local original="$PWD"
   local release='5.4.0-rc7-test'

--- a/tests/plugins/kernel_install/arch_test.sh
+++ b/tests/plugins/kernel_install/arch_test.sh
@@ -5,7 +5,7 @@
 . ./src/kwio.sh --source-only
 . ./tests/utils --source-only
 
-function suite
+function suite()
 {
   suite_addTest 'update_arch_boot_loader_Test'
   suite_addTest 'generate_arch_temporary_root_file_system_Test'
@@ -13,7 +13,7 @@ function suite
 
 declare -r TEST_ROOT_PATH="$PWD"
 
-function setUp
+function setUp()
 {
   rm -rf "$TMP_TEST_DIR"
 
@@ -27,7 +27,7 @@ function tearDown()
   rm -rf "$TMP_TEST_DIR"
 }
 
-function update_arch_boot_loader_Test
+function update_arch_boot_loader_Test()
 {
   output=$(update_arch_boot_loader 'xpto' '' 'TEST_MODE')
   cmd=' grub-mkconfig -o /boot/grub/grub.cfg'
@@ -38,7 +38,7 @@ function update_arch_boot_loader_Test
   assert_equals_helper 'Check local deploy' "$LINENO" "$cmd" "$output"
 }
 
-function generate_arch_temporary_root_file_system_Test
+function generate_arch_temporary_root_file_system_Test()
 {
   local name='xpto'
   local path_prefix=''

--- a/tests/plugins/kernel_install/debian_test.sh
+++ b/tests/plugins/kernel_install/debian_test.sh
@@ -5,21 +5,21 @@
 . ./src/kwio.sh --source-only
 . ./tests/utils --source-only
 
-function suite
+function suite()
 {
   suite_addTest 'update_debian_boot_loader_Test'
 }
 
 declare -r TEST_ROOT_PATH="$PWD"
 
-function setUp
+function setUp()
 {
   rm -rf "$TMP_TEST_DIR"
 
   local current_path="$PWD"
 
   mk_fake_boot "$TMP_TEST_DIR"
-#  parse_configuration "$KW_CONFIG_SAMPLE"
+  # parse_configuration "$KW_CONFIG_SAMPLE"
 }
 
 function tearDown()
@@ -27,7 +27,7 @@ function tearDown()
   rm -rf "$TMP_TEST_DIR"
 }
 
-function update_debian_boot_loader_Test
+function update_debian_boot_loader_Test()
 {
   output=$(update_debian_boot_loader 'xpto' '' 'TEST_MODE')
   cmd=' grub-mkconfig -o /boot/grub/grub.cfg'

--- a/tests/plugins/kernel_install/utils_test.sh
+++ b/tests/plugins/kernel_install/utils_test.sh
@@ -4,7 +4,7 @@
 . ./tests/utils --source-only
 . ./src/kwio.sh --source-only
 
-function suite
+function suite()
 {
   suite_addTest "human_list_installed_kernels_Test"
   suite_addTest "comman_list_installed_kernels_Test"
@@ -22,7 +22,7 @@ function suite
 
 declare -r TEST_ROOT_PATH="$PWD"
 
-function setUp
+function setUp()
 {
   rm -rf "$TMP_TEST_DIR"
 
@@ -36,7 +36,7 @@ function tearDown()
   rm -rf "$TMP_TEST_DIR"
 }
 
-function cmd_manager_Test
+function cmd_manager_Test()
 {
   local count=0
   local current_path="$PWD"
@@ -45,7 +45,7 @@ function cmd_manager_Test
   assert_equals_helper "TEST_MODE" "$LINENO" "ls something" "$output"
 }
 
-function ask_yN_Test
+function ask_yN_Test()
 {
   local count=0
   local current_path="$PWD"
@@ -69,8 +69,7 @@ function ask_yN_Test
   assert_equals_helper "TEST_MODE" "$LINENO" "0" "$output"
 }
 
-
-function human_list_installed_kernels_Test
+function human_list_installed_kernels_Test()
 {
   local count=0
 
@@ -88,7 +87,7 @@ function human_list_installed_kernels_Test
   done <<< "$output"
 }
 
-function comman_list_installed_kernels_Test
+function comman_list_installed_kernels_Test()
 {
   local count=0
 
@@ -105,7 +104,7 @@ function comman_list_installed_kernels_Test
 
 }
 
-function reboot_machine_Test
+function reboot_machine_Test()
 {
   output=$(reboot_machine '1' '' 'TEST_MODE')
   assert_equals_helper 'Enable reboot in a non-local machine' "$LINENO" ' reboot' "$output"
@@ -120,7 +119,7 @@ function reboot_machine_Test
   assert_equals_helper 'Disable reboot in a non-local machine' "$LINENO" 'sudo -E reboot' "$output"
 }
 
-function do_uninstall_cmd_sequence_Test
+function do_uninstall_cmd_sequence_Test()
 {
   local target='xpto'
   local prefix="./test"
@@ -183,7 +182,7 @@ function do_uninstall_cmd_sequence_Test
   cd "$TEST_ROOT_PATH"
 }
 
-function install_modules_Test
+function install_modules_Test()
 {
   local module_target='5.9.0-rc5-NEW-VRR-TRACK+.tar'
   local cmd
@@ -193,7 +192,7 @@ function install_modules_Test
   assert_equals_helper 'Standard uncompression' "$LINENO" "$cmd" "$output"
 }
 
-function vm_update_boot_loader_debian_Test
+function vm_update_boot_loader_debian_Test()
 {
   local name='xpto'
   local cmd_grub='grub-mkconfig -o /boot/grub/grub.cfg'
@@ -230,7 +229,7 @@ function vm_update_boot_loader_debian_Test
   compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
 }
 
-function vm_update_boot_loader_arch_Test
+function vm_update_boot_loader_arch_Test()
 {
   local name='xpto'
   local cmd_grub='grub-mkconfig -o /boot/grub/grub.cfg'
@@ -289,7 +288,7 @@ function vm_umount
   echo "vm_umount"
 }
 
-function install_kernel_remote_Test
+function install_kernel_remote_Test()
 {
   local name='5.9.0-rc5-TEST'
   local kernel_image_name='bzImage'
@@ -314,7 +313,7 @@ function install_kernel_remote_Test
   compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
 }
 
-function install_kernel_local_Test
+function install_kernel_local_Test()
 {
   local name='5.9.0-rc5-TEST'
   local kernel_image_name='bzImage'
@@ -337,7 +336,7 @@ function install_kernel_local_Test
   compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
 }
 
-function install_kernel_vm_Test
+function install_kernel_vm_Test()
 {
   local name='5.9.0-rc5-TEST'
   local kernel_image_name='bzImage'

--- a/tests/pomodoro_test.sh
+++ b/tests/pomodoro_test.sh
@@ -3,7 +3,7 @@
 include './src/pomodoro.sh'
 include './tests/utils'
 
-function suite
+function suite()
 {
   suite_addTest 'register_timebox_Test'
   suite_addTest 'remove_completed_timebox_Test'
@@ -12,7 +12,7 @@ function suite
   suite_addTest 'pomodoro_parser_Test'
 }
 
-function setUp
+function setUp()
 {
   mkdir "$TMP_TEST_DIR"
   export POMODORO_LOG_FILE="$TMP_TEST_DIR/pomodoro_current.log"
@@ -20,12 +20,12 @@ function setUp
   touch "$POMODORO_LOG_FILE"
 }
 
-function tearDown
+function tearDown()
 {
   rm -rf "$TMP_TEST_DIR"
 }
 
-function register_timebox_Test
+function register_timebox_Test()
 {
   local timebox='3332232557'
   local output
@@ -53,7 +53,7 @@ function register_timebox_Test
   compare_command_sequence expected_content[@] "$output" "($LINENO)"
 }
 
-function remove_completed_timebox_Test
+function remove_completed_timebox_Test()
 {
   # Register a bunch of data
   options_values['TIMER']='30m'
@@ -88,7 +88,7 @@ function remove_completed_timebox_Test
   assert_equals_helper 'Line was not removed' "$LINENO" '' "$output"
 }
 
-function calculate_missing_time_Test
+function calculate_missing_time_Test()
 {
   local output
 
@@ -121,7 +121,7 @@ function get_timestamp_sec_mock()
   echo 3332232700
 }
 
-function show_active_pomodoro_timebox_Test
+function show_active_pomodoro_timebox_Test()
 {
   local timestamp='3332232557'
   local timestamp_to_date
@@ -152,8 +152,7 @@ function show_active_pomodoro_timebox_Test
   compare_command_sequence expected_content[@] "$output" "($LINENO)"
 }
 
-
-function pomodoro_parser_Test
+function pomodoro_parser_Test()
 {
   local output
 

--- a/tests/remote_test.sh
+++ b/tests/remote_test.sh
@@ -5,7 +5,7 @@ include './src/kwlib.sh'
 include './src/kw_config_loader.sh'
 include './tests/utils'
 
-function suite
+function suite()
 {
   suite_addTest "get_remote_info_Test"
   suite_addTest "cmd_remote_Test"
@@ -38,7 +38,7 @@ function tearDownMockFunctions()
 
 FAKE_KW="tests/.tmp"
 
-function oneTimeSetUp
+function oneTimeSetUp()
 {
   local -r modules_name="test"
   local -r kernel_install_path="kernel_install"
@@ -53,13 +53,13 @@ function oneTimeSetUp
   mk_fake_remote "$FAKE_KW" "$modules_path"
 }
 
-function oneTimeTearDown
+function oneTimeTearDown()
 {
   unset KW_CACHE_DIR
   rm -rf "$FAKE_KW"
 }
 
-function get_remote_info_Test
+function get_remote_info_Test()
 {
   local ID
 
@@ -93,7 +93,7 @@ function get_remote_info_Test
   assertEquals "($ID) Expected 127.0.0.1:3333" "127.0.0.1:3333" "$output"
 }
 
-function cmd_remote_Test
+function cmd_remote_Test()
 {
   local command="ls -lah"
   local remote="178.31.38.12"
@@ -128,7 +128,7 @@ function cmd_remote_Test
   assertEquals "cmd_remotely should not work ($ID)" "$expected_command" "$output"
 }
 
-function cp_host2remote_Test
+function cp_host2remote_Test()
 {
   local src="/any/path"
   local dst="/any/path/2"
@@ -178,7 +178,7 @@ function cp_host2remote_Test
   assertEquals "Command did not match ($ID)" "$expected_command" "$output"
 }
 
-function which_distro_Test
+function which_distro_Test()
 {
   local cmd="cat /etc/os-release | grep -w ID | cut -d = -f 2"
   local remote="172.16.224.1"
@@ -208,7 +208,7 @@ function which_distro_Test
   assertEquals "Command did not match ($ID)" "$expected_command" "$output"
 }
 
-function preapre_host_deploy_dir_Test
+function preapre_host_deploy_dir_Test()
 {
   local ID
 
@@ -244,11 +244,11 @@ function prepare_remote_dir_Test()
   local ID
 
   declare -a expected_cmd_sequence=(
-      "ssh -p 2222 root@172.16.224.1 \"mkdir -p /root/kw_deploy\""
-      "rsync -e 'ssh -p 2222' -La tests/.tmp/kernel_install/debian.sh root@172.16.224.1:/root/kw_deploy/distro_deploy.sh"
-      "rsync -e 'ssh -p 2222' -La tests/.tmp/kernel_install/deploy.sh root@172.16.224.1:/root/kw_deploy/"
-      "rsync -e 'ssh -p 2222' -La tests/.tmp/kernel_install/utils.sh root@172.16.224.1:/root/kw_deploy/"
-    )
+    "ssh -p 2222 root@172.16.224.1 \"mkdir -p /root/kw_deploy\""
+    "rsync -e 'ssh -p 2222' -La tests/.tmp/kernel_install/debian.sh root@172.16.224.1:/root/kw_deploy/distro_deploy.sh"
+    "rsync -e 'ssh -p 2222' -La tests/.tmp/kernel_install/deploy.sh root@172.16.224.1:/root/kw_deploy/"
+    "rsync -e 'ssh -p 2222' -La tests/.tmp/kernel_install/utils.sh root@172.16.224.1:/root/kw_deploy/"
+  )
 
   setupMockFunctions
   output=$(prepare_remote_dir "$remote" "$port" "$user" "$flag")
@@ -273,7 +273,7 @@ function generate_tarball_Test()
     "test/"
     "test/file1"
     "test/file2"
-    )
+  )
 
   expected_cmd="tar -C $FAKE_KW/kernel_install/lib/modules -cf $FAKE_KW/$LOCAL_TO_DEPLOY_DIR/$tarball_name $kernel_release"
   ID=1
@@ -306,7 +306,7 @@ TEST_PATH="tests/.tmp"
 
 SSH_OK="ssh -p 3333 127.0.0.1"
 
-function setupSsh
+function setupSsh()
 {
   local -r current_path=$PWD
 
@@ -322,12 +322,12 @@ function setupSsh
   cd $current_path
 }
 
-function tearDownSsh
+function tearDownSsh()
 {
   rm -rf $TEST_PATH
 }
 
-function kw_ssh_check_fail_cases_Test
+function kw_ssh_check_fail_cases_Test()
 {
   setupSsh
 
@@ -363,7 +363,7 @@ function kw_ssh_check_fail_cases_Test
   tearDownSsh
 }
 
-function kw_ssh_basic_Test
+function kw_ssh_basic_Test()
 {
   setupSsh
 
@@ -374,7 +374,7 @@ function kw_ssh_basic_Test
   tearDownSsh
 }
 
-function kw_ssh_command_Test
+function kw_ssh_command_Test()
 {
   setupSsh
 
@@ -389,7 +389,7 @@ function kw_ssh_command_Test
   tearDownSsh
 }
 
-function kw_ssh_script_Test
+function kw_ssh_script_Test()
 {
   setupSsh
 

--- a/tests/statistics_test.sh
+++ b/tests/statistics_test.sh
@@ -8,7 +8,7 @@ include './tests/utils'
 # Average: 14
 # Min: 4
 # Max: 9433
-function suite
+function suite()
 {
   suite_addTest "statistics_Test"
   suite_addTest "calculate_average_Test"
@@ -22,7 +22,7 @@ function suite
   suite_addTest "year_statistics_Test"
 }
 
-function setUp
+function setUp()
 {
   export KW_DATA_DIR="tests/samples"
 
@@ -49,7 +49,7 @@ function setUp
   pre_formated_sec='00:30:46'
 }
 
-function statistics_Test
+function statistics_Test()
 {
   local msg
 
@@ -69,7 +69,7 @@ function statistics_Test
   assertEquals "($LINENO)" "$msg" "$output"
 }
 
-function calculate_average_Test
+function calculate_average_Test()
 {
   avg=$(calculate_average "10")
   assertEquals "($LINENO)" "10" "$avg"
@@ -78,7 +78,7 @@ function calculate_average_Test
   assertEquals "($LINENO)" "$pre_avg" "$avg"
 }
 
-function calculate_total_of_data_Test
+function calculate_total_of_data_Test()
 {
   total=$(calculate_total_of_data "1")
   assertEquals "($LINENO)" "1" "$total"
@@ -90,7 +90,7 @@ function calculate_total_of_data_Test
   assertEquals "($LINENO)" "$pre_total" "$total"
 }
 
-function max_value_Test
+function max_value_Test()
 {
   max=$(max_value "0")
   assertEquals "($LINENO)" "$max" "0"
@@ -102,7 +102,7 @@ function max_value_Test
   assertEquals "($LINENO)" "$pre_max" "$max"
 }
 
-function min_value_Test
+function min_value_Test()
 {
   min=$(min_value "0" "0")
   assertEquals "($LINENO)" "$min" "0"
@@ -114,7 +114,7 @@ function min_value_Test
   assertEquals "($LINENO)" "$min" "$pre_min"
 }
 
-function sec_to_formatted_date_Test
+function sec_to_formatted_date_Test()
 {
   formatted_time=$(sec_to_formatted_date "$pre_total_sec")
   assertEquals "($LINENO)" "$formatted_time" "$pre_formated_sec"
@@ -127,7 +127,7 @@ function sec_to_formatted_date_Test
 # These functions only concatenate the set of values before invoke
 # `basic_data_process`, for this reason, there is no point to validate this
 # operation in the weekly, monthly, and yearly tests.
-function basic_data_process_Test
+function basic_data_process_Test()
 {
   local data
   local day_path="$base_statistics/05/27"
@@ -147,7 +147,7 @@ function basic_data_process_Test
   assertEquals "($LINENO)" "" "$deploy"
 }
 
-function day_statistics_Test
+function day_statistics_Test()
 {
   local day_data
   local ID
@@ -161,7 +161,7 @@ function day_statistics_Test
   assertEquals "($LINENO)" "$msg2" "$day_data"
 }
 
-function week_statistics_Test
+function week_statistics_Test()
 {
   local day_data
   local ID
@@ -173,7 +173,7 @@ function week_statistics_Test
   assertEquals "($LINENO)" "$msg" "$week_data"
 }
 
-function month_statistics_Test
+function month_statistics_Test()
 {
   local target_month='2019/05'
   local msg='Currently, kw does not have any data for the present month.'
@@ -182,7 +182,7 @@ function month_statistics_Test
   assertEquals "($LINENO)" "$msg" "$month_data"
 }
 
-function year_statistics_Test
+function year_statistics_Test()
 {
   local target_year='2019'
   local year_data

--- a/tests/utils
+++ b/tests/utils
@@ -19,7 +19,7 @@ LOCAL_TO_DEPLOY_DIR="to_deploy"
 LOCAL_REMOTE_DIR="remote"
 KERNEL_INSTALL_PLUGIN_PATH="src/plugins/kernel_install/"
 
-function init_env
+function init_env()
 {
   unset -v KW_LIB_DIR KWORKFLOW
   KW_LIB_DIR="./src"
@@ -29,13 +29,13 @@ function init_env
 
 # Receives a string with one or more lines and print each of
 # then prefixed by "> "
-function prefix_multiline
+function prefix_multiline()
 {
   echo "$@" | sed -E "s/^/> /g"
 }
 
 # Compare strings with multiple lines and prefix them with "> "
-function multilineAssertEquals
+function multilineAssertEquals()
 {
   local message
   local left
@@ -46,8 +46,8 @@ function multilineAssertEquals
     shift
   fi
 
-  left=$'\n'"$(echo "$1" | sed -E "s/^/> /g" )"$'\n'
-  right=$'\n'"$(echo "$2" | sed -E "s/^/> /g" )"$'\n'
+  left=$'\n'"$(echo "$1" | sed -E "s/^/> /g")"$'\n'
+  right=$'\n'"$(echo "$2" | sed -E "s/^/> /g")"$'\n'
 
   if [ -n "$message" ]; then
     assertEquals "$message" "$left" "$right"
@@ -77,7 +77,7 @@ function assertFileEquals()
 
 # Receives a path and creates a fake kernel root in it. The goal is to make this
 # path recognizable by src/kwlib.sh:is_kernel_root().
-function mk_fake_kernel_root
+function mk_fake_kernel_root()
 {
   local -r path="$1"
   mkdir -p "$path"
@@ -103,7 +103,7 @@ function mk_fake_kernel_root
   touch "$path/arch/arm64/boot/Image"
 }
 
-function mk_fake_sys_class_drm
+function mk_fake_sys_class_drm()
 {
   declare -a fake_dirs=(
     "card0"
@@ -121,15 +121,14 @@ function mk_fake_sys_class_drm
     "renderD129"
     "ttm")
 
-  for dir in "${fake_dirs[@]}"
-  do
+  for dir in "${fake_dirs[@]}"; do
     mkdir -p "$FAKE_DRM_SYSFS/$dir"
   done
 
   touch "$FAKE_DRM_SYSFS/version"
   touch "$FAKE_DRM_SYSFS/card0-DP-3/modes"
 
-  cat <<END >> "$FAKE_DRM_SYSFS/card0-DP-3/modes"
+  cat << END >> "$FAKE_DRM_SYSFS/card0-DP-3/modes"
 1920x2160
 2560x1440
 1920x1080
@@ -149,7 +148,7 @@ function mk_fake_sys_class_drm
 720x400
 END
 
-  cat <<END >> "$FAKE_DRM_SYSFS/card1-HDMI-A-2/modes"
+  cat << END >> "$FAKE_DRM_SYSFS/card1-HDMI-A-2/modes"
 2560x1440
 1920x1080
 1280x1024
@@ -159,7 +158,7 @@ END
 
 }
 
-function mk_fake_remote
+function mk_fake_remote()
 {
   local -r FAKE_KW="$1"
   local -r modules_path="$2"
@@ -173,7 +172,7 @@ function mk_fake_remote
   touch "$FAKE_KW/$kernel_install_path"/{debian.sh,deploy.sh}
 }
 
-function mk_fake_remote_system
+function mk_fake_remote_system()
 {
   local prefix="$1"
   local target="$2"
@@ -193,7 +192,7 @@ function mk_fake_remote_system
   touch "$libpath"
 }
 
-function mock_target_machine
+function mock_target_machine()
 {
   local -r FAKE_KW="$1"
   local -r kernel_install_path="kernel_install"
@@ -206,7 +205,7 @@ function mock_target_machine
   cp "$KERNEL_INSTALL_PLUGIN_PATH/debian.sh" "$FAKE_KW/$remote_kw_deploy/distro_deploy.sh"
 }
 
-function mk_fake_boot
+function mk_fake_boot()
 {
   local -r FAKE_BOOT_DIR="$1"
 
@@ -220,7 +219,7 @@ function mk_fake_boot
 # @expected Command sequence as an array
 # @result_to_compare A raw output from the string
 # @ID An ID identification
-function compare_command_sequence
+function compare_command_sequence()
 {
   declare -a expected=("${!1}")
   local result_to_compare="$2"
@@ -250,13 +249,13 @@ function assert_equals_helper()
 }
 
 # Create an invalid file path
-function create_invalid_file_path
+function create_invalid_file_path()
 {
   invalid_path="$RANDOM/$RANDOM/$RANDOM/xptolala"
   echo "$invalid_path"
 }
 
-function invoke_shunit
+function invoke_shunit()
 {
   command -v shunit2 > /dev/null
   if [[ "$?" -eq 0 ]]; then

--- a/tests/vm_test.sh
+++ b/tests/vm_test.sh
@@ -3,7 +3,7 @@
 include './tests/utils'
 include './src/vm.sh'
 
-function suite
+function suite()
 {
   suite_addTest "vm_mount_Test"
   suite_addTest "vm_umount_Test"
@@ -11,7 +11,7 @@ function suite
 
 declare -r test_path="tests/.tmp"
 
-function setUp
+function setUp()
 {
   local -r current_path="$PWD"
 
@@ -22,12 +22,12 @@ function setUp
   cp -f tests/samples/kworkflow.config $test_path
 }
 
-function tearDown
+function tearDown()
 {
   rm -rf "$test_path"
 }
 
-function vm_mount_Test
+function vm_mount_Test()
 {
   local ID
   local mount_point="$test_path/lala"
@@ -82,7 +82,7 @@ function vm_mount_Test
   tearDown
 }
 
-function vm_umount_Test
+function vm_umount_Test()
 {
   local ID
   local mount_point="/"


### PR DESCRIPTION
Make all function adhere to codestyle of `function name()`
Fix indentation to enforce our 2 space identation
Format codebase with `shfmt -w -i 2 -fn -ci -sr -ln bash`

Signed-off-by: Alan Barzilay <alan.barzilay@gmail.com>


This is the first step into implementing shfmt as a formatter, next step will be to add [this github action](https://github.com/luizm/action-sh-checker) to check PRs for code formatting errors. This is a step towards #290 