### PR TITLE
sphinx-doc: turn warnings into errors and nitpicky mode

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -385,7 +385,7 @@ case "$1" in
     usage
     ;;
   --docs)
-    sphinx-build -b html documentation/ build
+    sphinx-build -nW -b html documentation/ build
     ;;
   *)
     complain "Invalid number of arguments"


### PR DESCRIPTION
In sphinx-build, the -n flag activates the nitpicky mode that warns
about all missing references and the -W flag turns warnings into
errors.

This will make our CI/CD pipeline detect when we failed to build
the docs and report it as a failed test.
Closes kworkflow/kworkflow#302

Signed-off-by: Alan Barzilay <alan.barzilay@gmail.com>