### PR TITLE
Improve tests with shunit2's features

### DIFF
--- a/documentation/content/codingstyle.rst
+++ b/documentation/content/codingstyle.rst
@@ -213,19 +213,19 @@ Test name
 ---------
 
 Tests are an important part of kw, we only accept new features with tests, and
-we prefer bug fixes that came with tests. For trying to keep the test
+we prefer bug fixes that come with tests. For trying to keep the test
 comprehensible, we adopt the following pattern for naming a test::
 
-    target_function_name_[an_option_description]_Test
+    test_target_function_name_[an_optional_description]
 
-To better illustrate this definition, see the below example::
+To better illustrate this definition, see the example below::
 
-    detect_distro_Test
+    function test_detect_distro()
 
 This function name indicates that we are testing `detect_distro` function.
 Another example::
 
-    save_config_file_check_description_Test
+    function test_save_config_file_check_description()
 
 The function `save_config_file` is tested with a focus on description
 validation.

--- a/documentation/content/codingstyle.rst
+++ b/documentation/content/codingstyle.rst
@@ -216,7 +216,7 @@ Tests are an important part of kw, we only accept new features with tests, and
 we prefer bug fixes that come with tests. For trying to keep the test
 comprehensible, we adopt the following pattern for naming a test::
 
-    test_target_function_name_[an_optional_description]
+    test_target_function_name_[an_optional_description]()
 
 To better illustrate this definition, see the example below::
 
@@ -229,6 +229,31 @@ Another example::
 
 The function `save_config_file` is tested with a focus on description
 validation.
+
+Resources for tests
+-------------------
+
+We encourage the use of the following features offered by shunit2, kworkflow's
+unit test framework.
+
+ - Functions `oneTimeSetUp` and `oneTimeTearDown`: If defined, these functions
+   will be called once before and after any tests are run, respectively. Notice
+   that shunit2 is sourced once for each test file, so the scope of
+   these functions is effectively the test file (e.g. `help_test.sh`) in
+   which they are defined.
+ - Functions `setUp` and `tearDown`: If defined, these functions will be
+   called before and after each test (i.e. a test function) is run, respectively.
+ - Shunit2 offers a temporary directory that will be cleaned upon it's exit. The
+   path to this directory is stored in the variable `SHUNIT_TMPDIR`. Note
+   however that this directory is not cleaned up between tests, so you may
+   need to clear it in the `tearDown` function.
+
+We also encourage each assertion in each test to be identified with the variable
+`LINENO`. This variable expands to the line number currently being executed.
+This way the origin of an error message can quickly be identified by a
+developer. For example::
+
+   assertEquals "($LINENO)" "$output" "$expected_output"
 
 Help functions
 --------------

--- a/tests/checkpatch_wrapper_test.sh
+++ b/tests/checkpatch_wrapper_test.sh
@@ -3,22 +3,10 @@
 include './src/checkpatch_wrapper.sh'
 include './tests/utils.sh'
 
-function suite()
-{
-  suite_addTest "warning_Test"
-  suite_addTest "error_Test"
-  suite_addTest "checks_Test"
-  suite_addTest "correct_Test"
-  suite_addTest "invalid_path_Test"
-  suite_addTest "no_kernel_directory_Test"
-  suite_addTest "multiple_files_output_Test"
-  suite_addTest "run_checkpatch_in_a_path_Test"
-  suite_addTest "run_checkpatch_in_a_file_Test"
-}
-
 # Those variables hold the last line execute_checkpatch prints in a code that is
 # correct, has 1 warning, has 1 erros and has 1 check, respectively. The sample
 # codes used in this test are in tests/samples/
+
 function oneTimeSetUp()
 {
   mk_fake_kernel_root "$TMP_TEST_DIR"
@@ -52,27 +40,27 @@ function checkpatch_helper()
   assertTrue "Checkpatch should output: ${!MSG[$type_msg]}" '[[ "$res" =~ "${!MSG[$type_msg]}" ]]'
 }
 
-function warning_Test()
+function test_warning()
 {
   checkpatch_helper 'warning'
 }
 
-function error_Test()
+function test_error()
 {
   checkpatch_helper 'error'
 }
 
-function checks_Test()
+function test_checks()
 {
   checkpatch_helper 'check'
 }
 
-function correct_Test()
+function test_correct()
 {
   checkpatch_helper 'correct'
 }
 
-function invalid_path_Test()
+function test_invalid_path()
 {
   local build_fake_path
   local output
@@ -85,7 +73,7 @@ function invalid_path_Test()
   assertEquals 'We forced an invalid path and we expect an error' '2' "$ret"
 }
 
-function no_kernel_directory_Test()
+function test_no_kernel_directory()
 {
   local sample_one="$SAMPLES_DIR/codestyle_warning.c"
   local output
@@ -101,7 +89,7 @@ function no_kernel_directory_Test()
   oneTimeSetUp
 }
 
-function multiple_files_output_Test()
+function test_multiple_files_output()
 {
   local delimiter="$SEPARATOR"
   local array=()
@@ -122,7 +110,7 @@ function multiple_files_output_Test()
   assertFalse 'We could not find more then two SEPARATOR sequence' '[[ $size -lt "3" ]]'
 }
 
-function run_checkpatch_in_a_path_Test()
+function test_run_checkpatch_in_a_path()
 {
   local cmd="perl scripts/checkpatch.pl --no-tree --color=always --strict"
   local patch_path="$TMP_TEST_DIR/samples/test.patch"
@@ -143,7 +131,7 @@ function run_checkpatch_in_a_path_Test()
   compare_command_sequence expected_cmd[@] "$output" '1'
 }
 
-function run_checkpatch_in_a_file_Test()
+function test_run_checkpatch_in_a_file()
 {
   local cmd="perl scripts/checkpatch.pl --terse --no-tree --color=always --strict  --file"
   local patch_path="$TMP_TEST_DIR/samples/codestyle_correct.c"

--- a/tests/checkpatch_wrapper_test.sh
+++ b/tests/checkpatch_wrapper_test.sh
@@ -9,16 +9,11 @@ include './tests/utils.sh'
 
 function oneTimeSetUp()
 {
-  mk_fake_kernel_root "$TMP_TEST_DIR"
-  cp -f tests/external/checkpatch.pl "$TMP_TEST_DIR"/scripts/
-  cp -f tests/external/const_structs.checkpatch "$TMP_TEST_DIR"/scripts/
-  cp -f tests/external/spelling.txt "$TMP_TEST_DIR"/scripts/
-  cp -r tests/samples "$TMP_TEST_DIR"
-}
-
-function oneTimeTearDown()
-{
-  rm -rf "$TMP_TEST_DIR"
+  mk_fake_kernel_root "$SHUNIT_TMPDIR"
+  cp -f tests/external/checkpatch.pl "$SHUNIT_TMPDIR"/scripts/
+  cp -f tests/external/const_structs.checkpatch "$SHUNIT_TMPDIR"/scripts/
+  cp -f tests/external/spelling.txt "$SHUNIT_TMPDIR"/scripts/
+  cp -r tests/samples "$SHUNIT_TMPDIR"
 }
 
 function checkpatch_helper()
@@ -36,7 +31,7 @@ function checkpatch_helper()
     ['check']=CHECK_MSG
   )
 
-  res=$(execute_checkpatch "$TMP_TEST_DIR/samples/codestyle_$type_msg.c" 2>&1)
+  res=$(execute_checkpatch "$SHUNIT_TMPDIR/samples/codestyle_$type_msg.c" 2>&1)
   assertTrue "Checkpatch should output: ${!MSG[$type_msg]}" '[[ "$res" =~ "${!MSG[$type_msg]}" ]]'
 }
 
@@ -95,7 +90,7 @@ function test_multiple_files_output()
   local array=()
   local output
 
-  output=$(execute_checkpatch "$TMP_TEST_DIR/samples" 2>&1)
+  output=$(execute_checkpatch "$SHUNIT_TMPDIR/samples" 2>&1)
 
   # Reference: https://www.tutorialkart.com/bash-shell-scripting/bash-split-string/
   s="$output$delimiter"
@@ -114,6 +109,7 @@ function test_run_checkpatch_in_a_path()
 {
   local cmd="perl scripts/checkpatch.pl --no-tree --color=always --strict"
   local patch_path="$TMP_TEST_DIR/samples/test.patch"
+  local patch_path="$SHUNIT_TMPDIR/samples/test.patch"
   local output
   local real_path
   local base_msg
@@ -134,7 +130,7 @@ function test_run_checkpatch_in_a_path()
 function test_run_checkpatch_in_a_file()
 {
   local cmd="perl scripts/checkpatch.pl --terse --no-tree --color=always --strict  --file"
-  local patch_path="$TMP_TEST_DIR/samples/codestyle_correct.c"
+  local patch_path="$SHUNIT_TMPDIR/samples/codestyle_correct.c"
   local output
   local real_path
   local base_msg

--- a/tests/configm_test.sh
+++ b/tests/configm_test.sh
@@ -22,20 +22,20 @@ function setUp()
 {
   local -r current_path="$PWD"
 
-  rm -rf "$TMP_TEST_DIR"
-
-  mkdir -p "$TMP_TEST_DIR"
-  cd "$TMP_TEST_DIR"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   touch .config
   echo "$CONTENT" > .config
   cd "$current_path"
-  KW_DATA_DIR="$current_path/$TMP_TEST_DIR"
+
+  mkdir "$SHUNIT_TMPDIR/configs"
+  KW_DATA_DIR="$SHUNIT_TMPDIR"
   configs_path="$KW_DATA_DIR/configs"
 }
 
 function tearDown()
 {
-  rm -rf "$TMP_TEST_DIR"
+  rm -rf "$SHUNIT_TMPDIR"
+  mkdir -p "$SHUNIT_TMPDIR"
 }
 
 function test_execute_config_manager_SAVE_fails()
@@ -76,7 +76,7 @@ function test_save_config_file_check_save_failures()
   local ret=0
 
   # Test without config file -> should fail
-  cd "$TMP_TEST_DIR"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   rm -f .config
   ret=$(save_config_file "$NO_FORCE $NAME_1" "$DESCRIPTION_1")
   assert_equals_helper 'No .config file should return ENOENT' "$LINENO" "$?" "2"
@@ -95,7 +95,7 @@ function test_save_config_file_check_directories_creation()
   local current_path="$PWD"
 
   # There's no configs yet, initialize it
-  cd "$TMP_TEST_DIR"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
   cd "$current_path"
 
@@ -114,7 +114,7 @@ function test_save_config_file_check_saved_config()
   local tmp
 
   # There's no configs yet, initialize it
-  cd "$TMP_TEST_DIR"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
   cd "$current_path"
 
@@ -123,7 +123,7 @@ function test_save_config_file_check_saved_config()
   msg="Failed the metadata related to $NAME_1"
   assertTrue "$LINENO: $msg" '[[ -f $configs_path/metadata/$NAME_1 ]]'
 
-  cd "$TMP_TEST_DIR"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   ret=$(save_config_file $NO_FORCE $NAME_2)
   cd "$current_path"
 
@@ -145,7 +145,7 @@ function test_save_config_file_check_description()
   local tmp
 
   # There's no configs yet, initialize it
-  cd "$TMP_TEST_DIR"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
   cd "$current_path"
 
@@ -153,7 +153,7 @@ function test_save_config_file_check_description()
   msg="The description content for $NAME_1 does not match"
   assertTrue "$LINENO: $msg" '[[ $tmp = $DESCRIPTION_1 ]]'
 
-  cd "$TMP_TEST_DIR"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   ret=$(save_config_file $NO_FORCE $NAME_2 "$DESCRIPTION_2")
   cd "$current_path"
 
@@ -166,10 +166,9 @@ function test_save_config_file_check_git_save_schema()
 {
   local current_path="$PWD"
   local ret=0
-  local config_files_path="$current_path/$TMP_TEST_DIR"
 
   # There's no configs yet, initialize it
-  cd "$TMP_TEST_DIR"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
   ret=$(save_config_file $NO_FORCE $NAME_2 "$DESCRIPTION_2")
   cd "configs"
@@ -183,10 +182,9 @@ function test_save_config_file_check_force()
 {
   local current_path="$PWD"
   local ret=0
-  local config_files_path="$current_path/$TMP_TEST_DIR"
 
   # There's no configs yet, initialize it
-  cd "$TMP_TEST_DIR"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   ret=$(save_config_file $YES_FORCE $NAME_2 "$DESCRIPTION_2")
   ret=$(save_config_file $YES_FORCE $NAME_2 "$DESCRIPTION_2")
   cd "$current_path"
@@ -197,7 +195,6 @@ function test_list_config_check_when_there_is_no_config()
 {
   local current_path="$PWD"
   local ret=0
-  local config_files_path="$current_path/$TMP_TEST_DIR"
 
   # There's no configs yet, initialize it
   ret=$(list_configs)
@@ -207,12 +204,11 @@ function test_list_config_check_when_there_is_no_config()
 function test_list_config_normal_output()
 {
   local current_path="$PWD"
-  local config_files_path="$current_path/$TMP_TEST_DIR"
   local ret=0
   local msg
 
   # There's no configs yet, initialize it
-  cd "$TMP_TEST_DIR"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   ret=$(save_config_file $YES_FORCE $NAME_1 "$DESCRIPTION_1")
   ret=$(save_config_file $YES_FORCE $NAME_2 "$DESCRIPTION_2")
   cd "$current_path"
@@ -255,7 +251,6 @@ function test_execute_config_manager_get_config_invalid_option()
 function test_get_config()
 {
   local current_path="$PWD"
-  local config_files_path="$current_path/$TMP_TEST_DIR"
   local ret=0
   local msg="This operation will override the current .config file"
   local replace_msg="Current config file updated based on $NAME_1"
@@ -266,13 +261,13 @@ function test_get_config()
   )
 
   # There's no configs yet, initialize it
-  cd "$TMP_TEST_DIR"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
   ret=$(save_config_file $NO_FORCE $NAME_2 "$DESCRIPTION_2")
   cd "$current_path"
 
   # Case 1: We already have a local config, pop up with replace question
-  cd "$TMP_TEST_DIR"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   output=$(echo 'y' | get_config "$NAME_1")
   compare_command_sequence expected_output[@] "$output" "$LINENO"
 
@@ -288,17 +283,16 @@ function test_get_config()
 function test_get_config_with_force()
 {
   local current_path="$PWD"
-  local config_files_path="$current_path/$TMP_TEST_DIR"
   local ret=0
 
   # There's no configs yet, initialize it
-  cd "$TMP_TEST_DIR"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
   ret=$(save_config_file $NO_FORCE $NAME_2 "$DESCRIPTION_2")
   cd "$current_path"
 
   # Case 1: There's no local .config file
-  cd "$TMP_TEST_DIR"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   rm -f .config
   get_config "$NAME_1" 1 > /dev/null 2>&1
   ret=$(cat .config)
@@ -307,7 +301,7 @@ function test_get_config_with_force()
   assertTrue "$LINENO: We expected $CONTENT, but we got $ret" '[[ $ret =~ $CONTENT ]]'
 
   # Case 2: There's a .config file
-  cd "$TMP_TEST_DIR"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   get_config "$NAME_2" 1 > /dev/null 2>&1
   ret=$(cat .config)
   cd "$current_path"
@@ -333,9 +327,8 @@ function test_remove_config()
 {
   local current_path="$PWD"
   local ret=0
-  local config_files_path="$current_path/$TMP_TEST_DIR"
 
-  cd "$TMP_TEST_DIR"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
   ret=$(save_config_file $NO_FORCE $NAME_2 "$DESCRIPTION_2")
   ret=$(ls configs/configs -1 | wc -l)

--- a/tests/configm_test.sh
+++ b/tests/configm_test.sh
@@ -18,24 +18,6 @@ readonly NAME_2="test_save_2"
 readonly DESCRIPTION_1="This is the first description"
 readonly DESCRIPTION_2="Hi, I'm the second description"
 
-function suite()
-{
-  suite_addTest "execute_config_manager_SAVE_fails_Test"
-  suite_addTest "save_config_file_check_save_failures_Test"
-  suite_addTest "save_config_file_check_directories_creation_Test"
-  suite_addTest "save_config_file_check_saved_config_Test"
-  suite_addTest "save_config_file_check_description_Test"
-  suite_addTest "save_config_file_check_git_save_schema_Test"
-  suite_addTest "save_config_file_check_force_Test"
-  suite_addTest "list_config_check_when_there_is_no_config_Test"
-  suite_addTest "list_config_normal_output_Test"
-  suite_addTest "get_config_with_force_Test"
-  suite_addTest "get_config_Test"
-  suite_addTest "execute_config_manager_get_config_invalid_option_Test"
-  suite_addTest "execute_config_manager_remove_that_should_fail_Test"
-  suite_addTest "remove_config_Test"
-}
-
 function setUp()
 {
   local -r current_path="$PWD"
@@ -56,7 +38,7 @@ function tearDown()
   rm -rf "$TMP_TEST_DIR"
 }
 
-function execute_config_manager_SAVE_fails_Test()
+function test_execute_config_manager_SAVE_fails()
 {
   local msg_prefix=" --save"
 
@@ -88,7 +70,7 @@ function execute_config_manager_SAVE_fails_Test()
   assert_equals_helper "$msg_prefix -f" "$LINENO" "$COMMAND_MSG_INVALID_ARG" "$ret"
 }
 
-function save_config_file_check_save_failures_Test()
+function test_save_config_file_check_save_failures()
 {
   local current_path="$PWD"
   local ret=0
@@ -108,7 +90,7 @@ function save_config_file_check_save_failures_Test()
   cd "$current_path"
 }
 
-function save_config_file_check_directories_creation_Test()
+function test_save_config_file_check_directories_creation()
 {
   local current_path="$PWD"
 
@@ -124,7 +106,7 @@ function save_config_file_check_directories_creation_Test()
   assertTrue "$LINENO: The configs dir is not available" '[[ -d $configs_path/configs ]]'
 }
 
-function save_config_file_check_saved_config_Test()
+function test_save_config_file_check_saved_config()
 {
   local current_path="$PWD"
   local ret=0
@@ -155,7 +137,7 @@ function save_config_file_check_saved_config_Test()
   assertTrue "$LINENO: $msg" '[[ $tmp = $CONTENT ]]'
 }
 
-function save_config_file_check_description_Test()
+function test_save_config_file_check_description()
 {
   local current_path="$PWD"
   local ret=0
@@ -180,7 +162,7 @@ function save_config_file_check_description_Test()
   assertTrue "$LINENO: $msg" '[[ $tmp = $DESCRIPTION_2 ]]'
 }
 
-function save_config_file_check_git_save_schema_Test()
+function test_save_config_file_check_git_save_schema()
 {
   local current_path="$PWD"
   local ret=0
@@ -197,7 +179,7 @@ function save_config_file_check_git_save_schema_Test()
   assertTrue "$LINENO: We expected 2 commits, but we got $ret" '[[ $ret = "2" ]]'
 }
 
-function save_config_file_check_force_Test()
+function test_save_config_file_check_force()
 {
   local current_path="$PWD"
   local ret=0
@@ -211,7 +193,7 @@ function save_config_file_check_force_Test()
   assertTrue "$LINENO: We expected no changes" '[[ $ret =~ Warning ]]'
 }
 
-function list_config_check_when_there_is_no_config_Test()
+function test_list_config_check_when_there_is_no_config()
 {
   local current_path="$PWD"
   local ret=0
@@ -222,7 +204,7 @@ function list_config_check_when_there_is_no_config_Test()
   assertTrue "$LINENO: We expected no changes" '[[ $ret =~ $LS_NO_FILES ]]'
 }
 
-function list_config_normal_output_Test()
+function test_list_config_normal_output()
 {
   local current_path="$PWD"
   local config_files_path="$current_path/$TMP_TEST_DIR"
@@ -256,7 +238,7 @@ function list_config_normal_output_Test()
   assertTrue "$LINENO:$msg" '[[ $ret =~ $DESCRIPTION_2 ]]'
 }
 
-function execute_config_manager_get_config_invalid_option_Test()
+function test_execute_config_manager_get_config_invalid_option()
 {
   local msg_prefix=" --get"
 
@@ -270,7 +252,7 @@ function execute_config_manager_get_config_invalid_option_Test()
   assert_equals_helper "$msg_prefix" "$LINENO" "$COMMAND_NO_SUCH_FILE: something_wrong" "$ret"
 }
 
-function get_config_Test()
+function test_get_config()
 {
   local current_path="$PWD"
   local config_files_path="$current_path/$TMP_TEST_DIR"
@@ -303,7 +285,7 @@ function get_config_Test()
   assertTrue "$LINENO: We expected $CONTENT, but we got $ret" '[[ $ret =~ $CONTENT ]]'
 }
 
-function get_config_with_force_Test()
+function test_get_config_with_force()
 {
   local current_path="$PWD"
   local config_files_path="$current_path/$TMP_TEST_DIR"
@@ -333,7 +315,7 @@ function get_config_with_force_Test()
   assertTrue "$LINENO: We expected $CONTENT, but we got $ret" '[[ $ret =~ $CONTENT ]]'
 }
 
-function execute_config_manager_remove_that_should_fail_Test()
+function test_execute_config_manager_remove_that_should_fail()
 {
   local msg_prefix=" -rm"
 
@@ -347,7 +329,7 @@ function execute_config_manager_remove_that_should_fail_Test()
   assert_equals_helper "$msg_prefix" "$LINENO" "$COMMAND_NO_SUCH_FILE: something_wrong" "$ret"
 }
 
-function remove_config_Test()
+function test_remove_config()
 {
   local current_path="$PWD"
   local ret=0

--- a/tests/diff_test.sh
+++ b/tests/diff_test.sh
@@ -3,13 +3,7 @@
 include './src/diff.sh'
 include './tests/utils.sh'
 
-function suite()
-{
-  suite_addTest "diff_side_by_side_Test"
-  suite_addTest "diff_manager_Test"
-}
-
-function diff_side_by_side_Test()
+function test_diff_side_by_side()
 {
   local ID
   local file_1="$SAMPLES_DIR/MAINTAINERS"
@@ -48,7 +42,7 @@ function diff_side_by_side_Test()
 
 }
 
-function diff_manager_Test()
+function test_diff_manager()
 {
   local ID
   local file_1="$SAMPLES_DIR/MAINTAINERS"

--- a/tests/drm_plugin_test.sh
+++ b/tests/drm_plugin_test.sh
@@ -4,16 +4,6 @@ include './src/plugins/subsystems/drm/drm.sh'
 include './src/kwlib.sh'
 include './tests/utils.sh'
 
-function suite()
-{
-  suite_addTest "gui_control_Test"
-  suite_addTest "drm_manager_Test"
-  suite_addTest "get_supported_mode_per_connector_Test"
-  #suite_addTest "get_available_connectors_Test"
-  suite_addTest "module_control_Test"
-  suite_addTest "convert_module_info_Test"
-}
-
 function setUp()
 {
   # Create a temporary directory for holding different config file
@@ -36,7 +26,7 @@ function tearDown()
   rm -rf "$TMP_TEST_DIR"
 }
 
-function drm_manager_Test()
+function test_drm_manager()
 {
   local ID
 
@@ -68,7 +58,7 @@ function drm_manager_Test()
   assertEquals "($ID) Should not accept --vm:" "$?" "22"
 }
 
-function gui_control_Test()
+function test_gui_control()
 {
   local gui_on_cmd='systemctl isolate graphical.target'
   local gui_off_cmd='systemctl isolate multi-user.target'
@@ -135,31 +125,7 @@ function gui_control_Test()
   compare_command_sequence expected_cmd_seq[@] "$output" "$ID"
 }
 
-function get_available_connectors_Test()
-{
-  local ID
-  export SYSFS_CLASS_DRM="$FAKE_DRM_SYSFS"
-
-  declare -a expected_output=(
-    "[local] Card1 supports:"
-    "DP"
-    "DP"
-    "HDMI"
-    "DP"
-    "[local] Card0 supports:"
-    "DP"
-    "DP"
-    "DP"
-    "HDMI"
-    "DVI"
-  )
-
-  ID=1
-  output=$(get_available_connectors 2)
-  compare_command_sequence expected_output[@] "$output" "$ID"
-}
-
-function get_supported_mode_per_connector_Test()
+function test_get_supported_mode_per_connector()
 {
   declare -a expected_output=(
     "Modes per card"
@@ -197,7 +163,7 @@ function get_supported_mode_per_connector_Test()
   compare_command_sequence expected_output[@] "$output" "$ID"
 }
 
-function module_control_Test()
+function test_module_control()
 {
   local ID
   local default_ssh="ssh -p 22 root@localhost"
@@ -252,7 +218,7 @@ function module_control_Test()
 }
 #compare_command_sequence expected_cmd[@] "$output" "$ID"
 
-function convert_module_info_Test()
+function test_convert_module_info()
 {
   local ID
 

--- a/tests/explore_test.sh
+++ b/tests/explore_test.sh
@@ -3,15 +3,6 @@
 include './tests/utils.sh'
 include './src/explore.sh'
 
-function suite()
-{
-  suite_addTest "explore_files_under_git_repo_Test"
-  suite_addTest "explore_git_log_Test"
-  suite_addTest "explore_parser_Test"
-  suite_addTest "explore_grep_Test"
-  suite_addTest "explore_git_Test"
-}
-
 declare -r test_path="tests/.tmp"
 
 # Note: these file names came from tests/samples/
@@ -50,7 +41,7 @@ function tearDown()
   rm -rf "$test_path"
 }
 
-function explore_files_under_git_repo_Test()
+function test_explore_files_under_git_repo()
 {
   local ID
   local MSG_OUT
@@ -92,7 +83,7 @@ function explore_files_under_git_repo_Test()
   cd "$current_path"
 }
 
-function explore_git_log_Test()
+function test_explore_git_log()
 {
   local ID
   local file_name
@@ -110,7 +101,7 @@ function explore_git_log_Test()
   cd "$current_path"
 }
 
-function explore_grep_Test()
+function test_explore_grep()
 {
   local ID
   local expected_result
@@ -130,7 +121,7 @@ function explore_grep_Test()
   cd "$current_path"
 }
 
-function explore_git_Test()
+function test_explore_git()
 {
   local ID
   local expected_result
@@ -158,7 +149,7 @@ function explore_git_Test()
   cd "$current_path"
 }
 
-function explore_parser_Test()
+function test_explore_parser()
 {
   local ID
 

--- a/tests/explore_test.sh
+++ b/tests/explore_test.sh
@@ -3,8 +3,6 @@
 include './tests/utils.sh'
 include './src/explore.sh'
 
-declare -r test_path="tests/.tmp"
-
 # Note: these file names came from tests/samples/
 declare -a samples_names=(
   "codestyle_check.c"
@@ -17,10 +15,7 @@ function setUp()
 {
   local -r current_path="$PWD"
 
-  rm -rf "$test_path"
-
-  mkdir -p "$test_path"
-  cd "$test_path"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   # Setup git repository for test
   git init &> /dev/null
 
@@ -38,7 +33,8 @@ function setUp()
 
 function tearDown()
 {
-  rm -rf "$test_path"
+  rm -rf "$SHUNIT_TMPDIR"
+  mkdir -p "$SHUNIT_TMPDIR"
 }
 
 function test_explore_files_under_git_repo()
@@ -52,7 +48,7 @@ function test_explore_files_under_git_repo()
   output=$(explore)
   assertEquals "($ID) - Expected an error message." "$MSG_OUT" "$output"
 
-  cd "$test_path"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
 
   ID=2
   MSG_OUT="camelCase(void)"
@@ -90,7 +86,7 @@ function test_explore_git_log()
   local commit_msg
   local -r current_path="$PWD"
 
-  cd "$test_path"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
 
   ID=1
   commit_msg="Commit number 2"
@@ -107,7 +103,7 @@ function test_explore_grep()
   local expected_result
   local -r current_path="$PWD"
 
-  cd "$test_path"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
 
   ID=1
   output=$(explore --grep "GNU grep" | cut -d/ -f2)
@@ -127,7 +123,7 @@ function test_explore_git()
   local expected_result
   local -r current_path="$PWD"
 
-  cd "$test_path"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
 
   ID=1
   output=$(explore --all "GNU grep" "." "TEST_MODE")

--- a/tests/get_maintainer_wrapper_test.sh
+++ b/tests/get_maintainer_wrapper_test.sh
@@ -5,14 +5,6 @@ include './tests/utils.sh'
 
 # TODO: make execute_get_maintainer's tests cover more corner cases?
 
-function suite()
-{
-  suite_addTest "print_files_authors_Test"
-  suite_addTest "print_files_authors_from_dir_Test"
-  suite_addTest "execute_get_maintainer_Test"
-  suite_addTest "execute_get_maintainer_patch_Test"
-}
-
 # The following variables hold the the lines print_files_authors should
 # print when given the file samples/print_file_author_test_dir directory
 # and samples/print_file_author_test_dir/code1.c file, respectively.
@@ -75,19 +67,19 @@ function oneTimeTearDown()
   rm -rf "$FAKE_KERNEL"
 }
 
-function print_files_authors_Test()
+function test_print_files_authors()
 {
   local -r ret=$(print_files_authors "tests/samples/print_file_author_test_dir/code1.c")
   multilineAssertEquals "$ret" "$CORRECT_FILE_MSG"
 }
 
-function print_files_authors_from_dir_Test()
+function test_print_files_authors_from_dir()
 {
   local -r ret=$(print_files_authors "tests/samples/print_file_author_test_dir")
   multilineAssertEquals "$ret" "$CORRECT_DIR_MSG"
 }
 
-function execute_get_maintainer_Test()
+function test_execute_get_maintainer()
 {
   local ret
   local -r original_dir="$PWD"
@@ -111,9 +103,8 @@ function execute_get_maintainer_Test()
   cd "$original_dir"
 }
 
-function execute_get_maintainer_patch_Test()
+function test_execute_get_maintainer_patch()
 {
-
   local original_dir="$PWD"
   cd "$FAKE_KERNEL"
 

--- a/tests/help_test.sh
+++ b/tests/help_test.sh
@@ -3,12 +3,7 @@
 include './tests/utils.sh'
 include './src/help.sh'
 
-function suite()
-{
-  suite_addTest "kworkflow_help_Test"
-}
-
-function kworkflow_help_Test()
+function test_kworkflow_help()
 {
   HELP_OUTPUT=$(kworkflow_help | head -n 1)
   [[ $HELP_OUTPUT =~ Usage:\ kw.* ]]

--- a/tests/init_test.sh
+++ b/tests/init_test.sh
@@ -3,11 +3,6 @@
 include './src/init.sh'
 include './tests/utils.sh'
 
-function suite()
-{
-  suite_addTest "init_kw_Test"
-}
-
 FAKE_DIR="tests/.tmp"
 FAKE_CONFIG_PATH="$FAKE_DIR/.config"
 
@@ -28,7 +23,7 @@ function tearDown()
   rm -rf "$FAKE_DIR"
 }
 
-function init_kw_Test()
+function test_init_kw()
 {
   local ID
   local kworkflow_content

--- a/tests/kw_config_loader_test.sh
+++ b/tests/kw_config_loader_test.sh
@@ -5,15 +5,6 @@ include './src/kw_config_loader.sh'
 
 TMP_DIR=tests/.tmp_kw_config_loader_test
 
-function suite()
-{
-  suite_addTest "parse_configuration_success_exit_code_Test"
-  suite_addTest "parser_configuration_failed_exit_code_Test"
-  suite_addTest "parse_configuration_output_Test"
-  suite_addTest "parse_configuration_standard_config_Test"
-  suite_addTest "parse_configuration_files_loading_order_Test"
-}
-
 function setUp()
 {
   mkdir -p "$TMP_DIR"
@@ -26,13 +17,13 @@ function tearDown()
   rm -rf "$TMP_DIR"
 }
 
-function parse_configuration_success_exit_code_Test()
+function test_parse_configuration_success_exit_code()
 {
   parse_configuration tests/samples/kworkflow.config
   assertTrue "Kw failed to load a regular config file" "[ 0 -eq $? ]"
 }
 
-function parser_configuration_failed_exit_code_Test()
+function test_parser_configuration_failed_exit_code()
 {
   parse_configuration tests/kw_config_loader_test.sh
   assertTrue "kw loaded an unsupported file" "[ 22 -eq $? ]"
@@ -61,7 +52,7 @@ function assertConfigurations()
 }
 
 # Test if parse_configuration correctly parses all settings in a file
-function parse_configuration_output_Test()
+function test_parse_configuration_output()
 {
   declare -A expected_configurations=(
     [arch]="arm64"
@@ -91,7 +82,7 @@ function parse_configuration_output_Test()
 }
 
 # Test if etc/kworkflow_template.config contains all the expected settings
-function parse_configuration_standard_config_Test()
+function test_parse_configuration_standard_config()
 {
 
   declare -A expected_configurations=(
@@ -120,7 +111,7 @@ function parse_configuration_standard_config_Test()
   true # Reset return value
 }
 
-function parse_configuration_files_loading_order_Test()
+function test_parse_configuration_files_loading_order()
 {
   expected="$KW_ETC_DIR/$CONFIG_FILENAME
 $HOME/.kw/$CONFIG_FILENAME

--- a/tests/kw_dash.sh
+++ b/tests/kw_dash.sh
@@ -2,12 +2,7 @@
 
 include './tests/utils.sh'
 
-function suite()
-{
-  suite_addTest "check_dash_integration_with_kw_Test"
-}
-
-function check_dash_integration_with_kw_Test()
+function test_check_dash_integration_with_kw()
 {
   ./tests/_kw_dash.dsh
   if [ $? -ne 0 ]; then

--- a/tests/kw_include_test.sh
+++ b/tests/kw_include_test.sh
@@ -2,21 +2,14 @@
 
 include './tests/utils.sh'
 
-function suite()
-{
-  suite_addTest 'include_Test'
-  suite_addTest 'include_twice_Test'
-  suite_addTest 'include_wrong_path_Test'
-}
-
-function include_Test()
+function test_include()
 {
   include ./src/kwio.sh
   output="$KWIO_IMPORTED"
   assertEquals "($LINENO)" 1 "$output"
 }
 
-function include_twice_Test()
+function test_include_twice()
 {
   include ./src/kwlib.sh
   include ./src/kwlib.sh
@@ -24,7 +17,7 @@ function include_twice_Test()
   assertEquals "($LINENO)" 0 "$ret"
 }
 
-function include_wrong_path_Test()
+function test_include_wrong_path()
 {
   output=$(include ./src/batata.sh)
   ret="$?"

--- a/tests/kw_string_test.sh
+++ b/tests/kw_string_test.sh
@@ -3,17 +3,7 @@
 include './src/kw_string.sh'
 include './tests/utils.sh'
 
-function suite()
-{
-  suite_addTest 'chop_Test'
-  suite_addTest 'last_char_Test'
-  suite_addTest 'str_is_a_number_Test'
-  suite_addTest 'str_length_Test'
-  suite_addTest 'str_trim_Test'
-  suite_addTest 'str_strip_Test'
-}
-
-function chop_Test()
+function test_chop()
 {
   local output
   local str_test='1234567'
@@ -28,7 +18,7 @@ function chop_Test()
   assert_equals_helper 'Expected an empty string' "$LINENO" "" "$output"
 }
 
-function last_char_Test()
+function test_last_char()
 {
   local output
   local str_test='kworkflow'
@@ -45,7 +35,7 @@ function last_char_Test()
   assert_equals_helper 'We did not get the last char' "$LINENO" '' "$output"
 }
 
-function str_is_a_number_Test()
+function test_str_is_a_number()
 {
   local output
   local str_test=333
@@ -72,7 +62,7 @@ function str_is_a_number_Test()
 
 }
 
-function str_length_Test
+function test_str_length()
 {
   local output
   local string_sample="let's check the string lenght" # 29
@@ -84,7 +74,7 @@ function str_length_Test
   assert_equals_helper 'Empty string should be 0 length' "$LINENO" 0 "$output"
 }
 
-function str_trim_Test
+function test_str_trim()
 {
   local output
   local string_sample='This is a simple string'
@@ -103,7 +93,7 @@ function str_trim_Test
   assert_equals_helper 'Trim 0 should be empty' "$LINENO" '' "$output"
 }
 
-function str_strip_Test
+function test_str_strip
 {
   local output
   local string_sample='    lala xpto    '

--- a/tests/kw_test.sh
+++ b/tests/kw_test.sh
@@ -6,14 +6,7 @@ include './kw' > /dev/null
 # when imported kw prints the help function and we don´t want
 # to polute our test results, so we redirect its output to /dev/null
 
-function suite()
-{
-  suite_addTest "validate_global_variables_Test"
-  suite_addTest "check_kworkflow_global_variable_Test"
-  suite_addTest 'set_KW_LIB_DIR_in_dev_mode_Test'
-}
-
-function validate_global_variables_Test()
+function test_validate_global_variables()
 {
   VARS=(KWORKFLOW KW_LIB_DIR)
   for v in "${VARS[@]}"; do
@@ -22,7 +15,7 @@ function validate_global_variables_Test()
   done
 }
 
-function check_kworkflow_global_variable_Test()
+function test_check_kworkflow_global_variable()
 {
   VARS=(KWORKFLOW)
   for v in "${VARS[@]}"; do
@@ -31,7 +24,7 @@ function check_kworkflow_global_variable_Test()
   done
 }
 
-function set_KW_LIB_DIR_in_dev_mode_Test()
+function test_set_KW_LIB_DIR_in_dev_mode()
 {
   lib="${KW_LIB_DIR}/kwlib.sh"
   test -f "${lib}" || fail "kwlib.sh not found (${lib} not found)!"

--- a/tests/kw_time_and_date_test.sh
+++ b/tests/kw_time_and_date_test.sh
@@ -3,14 +3,6 @@
 include './src/kw_time_and_date.sh'
 include './tests/utils.sh'
 
-function suite()
-{
-  suite_addTest 'sec_to_format_Test'
-  suite_addTest 'get_today_info_Test'
-  suite_addTest 'get_week_beginning_day_Test'
-  suite_addTest 'date_to_format_Test'
-}
-
 function setUp()
 {
   # Samples file data
@@ -18,7 +10,7 @@ function setUp()
   pre_formated_sec="00:30:46"
 }
 
-function sec_to_format_Test()
+function test_sec_to_format()
 {
   formatted_time=$(sec_to_format "$pre_total_sec")
   assertEquals "($LINENO)" "$formatted_time" "$pre_formated_sec"
@@ -33,7 +25,7 @@ function sec_to_format_Test()
   assertEquals "($LINENO)" "$formatted_time" '46'
 }
 
-function get_today_info_Test()
+function test_get_today_info()
 {
   local today
 
@@ -46,7 +38,7 @@ function get_today_info_Test()
   assert_equals_helper 'No parameter' "$LINENO" "$today" "$formated_today"
 }
 
-function get_week_beginning_day_Test()
+function test_get_week_beginning_day()
 {
   local ref_week='2021/05/19'
   local first_week_day='2021/05/16'
@@ -67,7 +59,7 @@ function get_week_beginning_day_Test()
   assert_equals_helper 'The first day of this week' "$LINENO" "$first_week_day" "$week_day"
 }
 
-function date_to_format_Test()
+function test_date_to_format()
 {
   local formatted_date
 

--- a/tests/kwio_test.sh
+++ b/tests/kwio_test.sh
@@ -13,14 +13,6 @@ declare -A configurations
 sound_file="$PWD/tests/.kwio_test_aux/sound.file"
 visual_file="$PWD/tests/.kwio_test_aux/visual.file"
 
-function suite()
-{
-  suite_addTest "alert_completion_options_Test"
-  suite_addTest "alert_completition_validate_config_file_options_Test"
-  suite_addTest "alert_completion_visual_alert_Test"
-  suite_addTest "alert_completion_sound_alert_Test"
-}
-
 function setUp()
 {
   mkdir -p tests/.kwio_test_aux
@@ -33,7 +25,7 @@ function tearDown()
   rm -rf tests/.kwio_test_aux
 }
 
-function alert_completion_options_Test()
+function test_alert_completion_options()
 {
   configurations["alert"]="n"
 
@@ -65,7 +57,7 @@ function alert_completion_options_Test()
   true
 }
 
-function alert_completition_validate_config_file_options_Test()
+function test_alert_completition_validate_config_file_options()
 {
   mkdir -p tests/.kwio_test_aux
 
@@ -102,7 +94,7 @@ function alert_completition_validate_config_file_options_Test()
   true
 }
 
-function alert_completion_visual_alert_Test()
+function test_alert_completion_visual_alert()
 {
   local output
   local expected="TESTING COMMAND"
@@ -112,7 +104,7 @@ function alert_completion_visual_alert_Test()
   assertEquals "Variable v should exist." "$output" "$expected"
 }
 
-function alert_completion_sound_alert_Test()
+function test_alert_completion_sound_alert()
 {
   local output
   local expected="TESTING COMMAND"

--- a/tests/kwlib_test.sh
+++ b/tests/kwlib_test.sh
@@ -4,23 +4,6 @@ include './src/get_maintainer_wrapper.sh'
 include './src/kwlib.sh'
 include './tests/utils.sh'
 
-function suite()
-{
-  suite_addTest "is_kernel_root_Test"
-  suite_addTest "cmd_manager_check_test_mode_option_Test"
-  suite_addTest "cmd_manager_check_silent_option_Test"
-  suite_addTest "cmdManagerSAY_COMPLAIN_WARNING_SUCCESS_Test"
-  suite_addTest "detect_distro_Test"
-  suite_addTest "join_path_Test"
-  suite_addTest "find_kernel_root_Test"
-  suite_addTest "is_a_patch_Test"
-  suite_addTest "get_based_on_delimiter_Test"
-  suite_addTest "store_statistics_data_Test"
-  suite_addTest "update_statistics_database_Test"
-  suite_addTest "statistics_manager_Test"
-  suite_addTest "command_exists_Test"
-}
-
 KW_DATA_DIR="tests/.tmp"
 TARGET_YEAR_MONTH="2020/05"
 FAKE_STATISTICS_PATH="$KW_DATA_DIR/statistics"
@@ -77,7 +60,7 @@ function tearDownSetup()
   rm -rf "$FAKE_STATISTICS_PATH"
 }
 
-function is_kernel_root_Test()
+function test_is_kernel_root()
 {
   setupFakeKernelRepo
   is_kernel_root "tests/.tmp"
@@ -86,7 +69,7 @@ function is_kernel_root_Test()
   true # Reset return value
 }
 
-function cmd_manager_check_silent_option_Test()
+function test_cmd_manager_check_silent_option()
 {
   setupFakeKernelRepo
   cd "tests/.tmp"
@@ -110,7 +93,7 @@ function cmd_manager_check_silent_option_Test()
 
 # The difference between say, complain, warning, and success it is the color
 # because of this we test all of them together
-function cmdManagerSAY_COMPLAIN_WARNING_SUCCESS_Test()
+function test_cmdManagerSAY_COMPLAIN_WARNING_SUCCESS()
 {
   setupFakeKernelRepo
   cd "tests/.tmp"
@@ -142,7 +125,7 @@ function cmdManagerSAY_COMPLAIN_WARNING_SUCCESS_Test()
   tearDownSetup
 }
 
-function cmd_manager_check_test_mode_option_Test()
+function test_cmd_manager_check_test_mode_option()
 {
   ret=$(cmd_manager TEST_MODE pwd)
   assertEquals "Expected pwd, but we got $ret" "$ret" "pwd"
@@ -151,7 +134,7 @@ function cmd_manager_check_test_mode_option_Test()
   assertEquals "Expected ls -lah, but we got $ret" "$ret" "ls -lah"
 }
 
-function detect_distro_Test()
+function test_detect_distro()
 {
   setupFakeOSInfo
   local root_path="tests/.tmp/detect_distro/arch"
@@ -177,7 +160,7 @@ function detect_distro_Test()
   assertEquals "We got $ret." "$ret" "none"
 }
 
-function join_path_Test()
+function test_join_path()
 {
   local base="/lala/xpto"
   local ret
@@ -198,7 +181,7 @@ function join_path_Test()
   assertEquals "Expect /lala/" "$ret" "/lala/"
 }
 
-function find_kernel_root_Test()
+function test_find_kernel_root()
 {
   setupFakeKernelRepo
 
@@ -218,7 +201,7 @@ function find_kernel_root_Test()
   tearDownSetup
 }
 
-function is_a_patch_Test()
+function test_is_a_patch()
 {
   setupPatch
   is_a_patch "tests/.tmp/test.patch"
@@ -227,7 +210,7 @@ function is_a_patch_Test()
   true # Reset return value
 }
 
-function get_based_on_delimiter_Test()
+function test_get_based_on_delimiter()
 {
   local ID
   local ip_port_str="IP:PORT"
@@ -286,7 +269,7 @@ function get_based_on_delimiter_Test()
 
 }
 
-function store_statistics_data_Test()
+function test_store_statistics_data()
 {
   local ID
   local fake_day_path="$FAKE_STATISTICS_DAY_PATH"
@@ -316,7 +299,7 @@ function store_statistics_data_Test()
   tearDownSetup
 }
 
-function update_statistics_database_Test()
+function test_update_statistics_database()
 {
   local ID
 
@@ -334,7 +317,7 @@ function update_statistics_database_Test()
   tearDownSetup
 }
 
-function statistics_manager_Test()
+function test_statistics_manager()
 {
   local ID
   local this_year_and_month
@@ -363,7 +346,7 @@ function statistics_manager_Test()
   assertTrue "($ID) Database day" '[[ ! -f "$FAKE_STATISTICS_PATH/$this_year_and_month/$today" ]]'
 }
 
-function command_exists_Test()
+function test_command_exists()
 {
   local fake_command="a-non-existent-command -p"
   local real_command="mkdir"

--- a/tests/mk_test.sh
+++ b/tests/mk_test.sh
@@ -3,22 +3,6 @@
 include './src/mk.sh'
 include './tests/utils.sh'
 
-function suite()
-{
-  suite_addTest "build_info_Test"
-  suite_addTest "mk_build_Test"
-  suite_addTest "kernel_deploy_Test"
-  suite_addTest "modules_install_to_Test"
-  suite_addTest "kernel_install_Test"
-  suite_addTest "kernel_install_x86_64_Test"
-  suite_addTest "kernel_modules_Test"
-  suite_addTest "kernel_modules_local_Test"
-  suite_addTest "kernel_install_local_Test"
-  suite_addTest "mk_list_remote_kernels_Test"
-  suite_addTest "mk_kernel_uninstall_Test"
-  suite_addTest "cleanup_after_deploy_Test"
-}
-
 FAKE_KERNEL="tests/.tmp"
 
 # Some of the functions invoked by kw need to be mocked; otherwise, we cannot
@@ -128,7 +112,7 @@ function test_expected_string()
   assertEquals "$msg" "$target" "$expected"
 }
 
-function mk_build_Test()
+function test_mk_build()
 {
   local ID
   local expected_result
@@ -178,7 +162,7 @@ function mk_build_Test()
 #
 # Output sequence of kernel_deploy in the TEST_MODE:
 #   $reboot $modules $target $remote $single_line $list"
-function kernel_deploy_Test()
+function test_kernel_deploy()
 {
   local ID
   local original="$PWD"
@@ -273,7 +257,7 @@ function kernel_deploy_Test()
   cd "$original"
 }
 
-function modules_install_to_Test()
+function test_modules_install_to()
 {
   local ID
   local original="$PWD"
@@ -293,7 +277,7 @@ function modules_install_to_Test()
   cd "$original"
 }
 
-function kernel_install_Test()
+function test_kernel_install()
 {
   local name="test"
   local original="$PWD"
@@ -359,7 +343,7 @@ function kernel_install_Test()
   tearDown
 }
 
-function kernel_install_x86_64_Test()
+function test_kernel_install_x86_64()
 {
   local name="test"
   local original="$PWD"
@@ -414,7 +398,7 @@ function kernel_install_x86_64_Test()
   cd "$original"
 }
 
-function kernel_modules_Test()
+function test_kernel_modules()
 {
   local count=0
   local original="$PWD"
@@ -490,7 +474,7 @@ function kernel_modules_Test()
   cd "$original"
 }
 
-function kernel_modules_local_Test()
+function test_kernel_modules_local()
 {
   local ID
   local original="$PWD"
@@ -503,7 +487,7 @@ function kernel_modules_local_Test()
   cd "$original"
 }
 
-function kernel_install_local_Test()
+function test_kernel_install_local()
 {
   local count=0
   local original="$PWD"
@@ -544,7 +528,7 @@ function kernel_install_local_Test()
 # by checking the expected command sequence; It is important to highlight that
 # we are not testing the actual kernel list code, this part is validated on
 # another test file.
-function mk_list_remote_kernels_Test()
+function test_mk_list_remote_kernels()
 {
   local count=0
   local original="$PWD"
@@ -587,7 +571,7 @@ function mk_list_remote_kernels_Test()
   cd "$original"
 }
 
-function mk_kernel_uninstall_Test()
+function test_mk_kernel_uninstall()
 {
   local count=0
   local original="$PWD"
@@ -646,7 +630,7 @@ function mk_kernel_uninstall_Test()
   cd "$original"
 }
 
-function cleanup_after_deploy_Test()
+function test_cleanup_after_deploy()
 {
   local output=""
   local cmd_remote="rm -rf $test_path/$LOCAL_TO_DEPLOY_DIR/*"
@@ -665,7 +649,7 @@ function cleanup_after_deploy_Test()
   done <<< "$output"
 }
 
-function build_info_Test()
+function test_build_info()
 {
   local original="$PWD"
   local release='5.4.0-rc7-test'

--- a/tests/plugins/kernel_install/arch_test.sh
+++ b/tests/plugins/kernel_install/arch_test.sh
@@ -7,14 +7,12 @@
 
 function setUp()
 {
-  rm -rf "$TMP_TEST_DIR"
-
-  mk_fake_boot "$TMP_TEST_DIR"
+  mk_fake_boot "$SHUNIT_TMPDIR"
 }
 
 function tearDown()
 {
-  rm -rf "$TMP_TEST_DIR"
+  rm -rf "$SHUNIT_TMPDIR"
 }
 
 function test_update_arch_boot_loader()

--- a/tests/plugins/kernel_install/arch_test.sh
+++ b/tests/plugins/kernel_install/arch_test.sh
@@ -5,12 +5,6 @@
 . ./src/kwio.sh --source-only
 . ./tests/utils.sh --source-only
 
-function suite()
-{
-  suite_addTest 'update_arch_boot_loader_Test'
-  suite_addTest 'generate_arch_temporary_root_file_system_Test'
-}
-
 function setUp()
 {
   rm -rf "$TMP_TEST_DIR"
@@ -23,7 +17,7 @@ function tearDown()
   rm -rf "$TMP_TEST_DIR"
 }
 
-function update_arch_boot_loader_Test()
+function test_update_arch_boot_loader()
 {
   output=$(update_arch_boot_loader 'xpto' '' 'TEST_MODE')
   cmd=' grub-mkconfig -o /boot/grub/grub.cfg'
@@ -34,7 +28,7 @@ function update_arch_boot_loader_Test()
   assert_equals_helper 'Check local deploy' "$LINENO" "$cmd" "$output"
 }
 
-function generate_arch_temporary_root_file_system_Test()
+function test_generate_arch_temporary_root_file_system()
 {
   local name='xpto'
   local path_prefix=''

--- a/tests/plugins/kernel_install/debian_test.sh
+++ b/tests/plugins/kernel_install/debian_test.sh
@@ -5,11 +5,6 @@
 . ./src/kwio.sh --source-only
 . ./tests/utils.sh --source-only
 
-function suite()
-{
-  suite_addTest 'update_debian_boot_loader_Test'
-}
-
 function setUp()
 {
   rm -rf "$TMP_TEST_DIR"
@@ -23,7 +18,7 @@ function tearDown()
   rm -rf "$TMP_TEST_DIR"
 }
 
-function update_debian_boot_loader_Test()
+function test_update_debian_boot_loader()
 {
   output=$(update_debian_boot_loader 'xpto' '' 'TEST_MODE')
   cmd=' grub-mkconfig -o /boot/grub/grub.cfg'

--- a/tests/plugins/kernel_install/debian_test.sh
+++ b/tests/plugins/kernel_install/debian_test.sh
@@ -7,15 +7,13 @@
 
 function setUp()
 {
-  rm -rf "$TMP_TEST_DIR"
-
-  mk_fake_boot "$TMP_TEST_DIR"
+  mk_fake_boot "$SHUNIT_TMPDIR"
   # parse_configuration "$KW_CONFIG_SAMPLE"
 }
 
 function tearDown()
 {
-  rm -rf "$TMP_TEST_DIR"
+  rm -rf "$SHUNIT_TMPDIR"
 }
 
 function test_update_debian_boot_loader()

--- a/tests/plugins/kernel_install/utils_test.sh
+++ b/tests/plugins/kernel_install/utils_test.sh
@@ -4,22 +4,6 @@
 . ./tests/utils.sh --source-only
 . ./src/kwio.sh --source-only
 
-function suite()
-{
-  suite_addTest "human_list_installed_kernels_Test"
-  suite_addTest "comman_list_installed_kernels_Test"
-  suite_addTest "cmd_manager_Test"
-  suite_addTest "ask_yN_Test"
-  suite_addTest "reboot_machine_Test"
-  suite_addTest "do_uninstall_cmd_sequence_Test"
-  suite_addTest 'install_modules_Test'
-  suite_addTest 'vm_update_boot_loader_debian_Test'
-  suite_addTest 'vm_update_boot_loader_arch_Test'
-  suite_addTest 'install_kernel_remote_Test'
-  suite_addTest 'install_kernel_local_Test'
-  suite_addTest 'install_kernel_vm_Test'
-}
-
 declare -r TEST_ROOT_PATH="$PWD"
 
 function setUp()
@@ -36,7 +20,7 @@ function tearDown()
   rm -rf "$TMP_TEST_DIR"
 }
 
-function cmd_manager_Test()
+function test_cmd_manager()
 {
   local count=0
   local current_path="$PWD"
@@ -45,7 +29,7 @@ function cmd_manager_Test()
   assert_equals_helper "TEST_MODE" "$LINENO" "ls something" "$output"
 }
 
-function ask_yN_Test()
+function test_ask_yN()
 {
   local count=0
 
@@ -68,7 +52,8 @@ function ask_yN_Test()
   assert_equals_helper "TEST_MODE" "$LINENO" "0" "$output"
 }
 
-function human_list_installed_kernels_Test()
+
+function test_human_list_installed_kernels()
 {
   local count=0
 
@@ -86,7 +71,7 @@ function human_list_installed_kernels_Test()
   done <<< "$output"
 }
 
-function comman_list_installed_kernels_Test()
+function test_comman_list_installed_kernels()
 {
   local count=0
 
@@ -103,7 +88,7 @@ function comman_list_installed_kernels_Test()
 
 }
 
-function reboot_machine_Test()
+function test_reboot_machine()
 {
   output=$(reboot_machine '1' '' 'TEST_MODE')
   assert_equals_helper 'Enable reboot in a non-local machine' "$LINENO" ' reboot' "$output"
@@ -118,7 +103,7 @@ function reboot_machine_Test()
   assert_equals_helper 'Disable reboot in a non-local machine' "$LINENO" 'sudo -E reboot' "$output"
 }
 
-function do_uninstall_cmd_sequence_Test()
+function test_do_uninstall_cmd_sequence()
 {
   local target='xpto'
   local prefix="./test"
@@ -181,7 +166,7 @@ function do_uninstall_cmd_sequence_Test()
   cd "$TEST_ROOT_PATH"
 }
 
-function install_modules_Test()
+function test_install_modules()
 {
   local module_target='5.9.0-rc5-NEW-VRR-TRACK+.tar'
   local cmd
@@ -191,7 +176,7 @@ function install_modules_Test()
   assert_equals_helper 'Standard uncompression' "$LINENO" "$cmd" "$output"
 }
 
-function vm_update_boot_loader_debian_Test()
+function test_vm_update_boot_loader_debian()
 {
   local name='xpto'
   local cmd_grub='grub-mkconfig -o /boot/grub/grub.cfg'
@@ -228,7 +213,7 @@ function vm_update_boot_loader_debian_Test()
   compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
 }
 
-function vm_update_boot_loader_arch_Test()
+function test_vm_update_boot_loader_arch()
 {
   local name='xpto'
   local cmd_grub='grub-mkconfig -o /boot/grub/grub.cfg'
@@ -282,12 +267,12 @@ function findmnt_mock()
   echo "/home  /dev/lala ext4   rw,relatime"
 }
 
-function vm_umount
+function vm_umount()
 {
   echo "vm_umount"
 }
 
-function install_kernel_remote_Test()
+function test_install_kernel_remote()
 {
   local name='5.9.0-rc5-TEST'
   local kernel_image_name='bzImage'
@@ -312,7 +297,7 @@ function install_kernel_remote_Test()
   compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
 }
 
-function install_kernel_local_Test()
+function test_install_kernel_local()
 {
   local name='5.9.0-rc5-TEST'
   local kernel_image_name='bzImage'
@@ -335,7 +320,7 @@ function install_kernel_local_Test()
   compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
 }
 
-function install_kernel_vm_Test()
+function test_install_kernel_vm()
 {
   local name='5.9.0-rc5-TEST'
   local kernel_image_name='bzImage'

--- a/tests/plugins/kernel_install/utils_test.sh
+++ b/tests/plugins/kernel_install/utils_test.sh
@@ -8,16 +8,14 @@ declare -r TEST_ROOT_PATH="$PWD"
 
 function setUp()
 {
-  rm -rf "$TMP_TEST_DIR"
-
   local current_path="$PWD"
 
-  mk_fake_boot "$TMP_TEST_DIR"
+  mk_fake_boot "$SHUNIT_TMPDIR"
 }
 
 function tearDown()
 {
-  rm -rf "$TMP_TEST_DIR"
+  rm -rf "$SHUNIT_TMPDIR"
 }
 
 function test_cmd_manager()
@@ -52,7 +50,6 @@ function test_ask_yN()
   assert_equals_helper "TEST_MODE" "$LINENO" "0" "$output"
 }
 
-
 function test_human_list_installed_kernels()
 {
   local count=0
@@ -64,14 +61,14 @@ function test_human_list_installed_kernels()
     "linux"
   )
 
-  output=$(list_installed_kernels "0" "$TMP_TEST_DIR")
+  output=$(list_installed_kernels "0" "$SHUNIT_TMPDIR")
   while read -r out; do
     assertEquals "$count - Expected kernel list" "${expected_out[$count]}" "$out"
     ((count++))
   done <<< "$output"
 }
 
-function test_comman_list_installed_kernels()
+function test_command_list_installed_kernels()
 {
   local count=0
 
@@ -80,7 +77,7 @@ function test_comman_list_installed_kernels()
     "5.5.0-rc2-VKMS+,5.6.0-rc2-AMDGPU+,linux"
   )
 
-  output=$(list_installed_kernels "1" "$TMP_TEST_DIR")
+  output=$(list_installed_kernels "1" "$SHUNIT_TMPDIR")
   while read -r out; do
     assertEquals "$count - Expected kernel list" "${expected_out[$count]}" "$out"
     ((count++))
@@ -126,7 +123,7 @@ function test_do_uninstall_cmd_sequence()
   compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
 
   # Good sequence
-  cd "$TMP_TEST_DIR"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   mkdir -p "$prefix"
   mk_fake_remote_system "$prefix" "$target"
 
@@ -327,13 +324,14 @@ function test_install_kernel_vm()
   local reboot='1'
   local architecture='x86_64'
   local target='vm'
-  local path_prefix="$TMP_TEST_DIR"
+  local path_prefix="$SHUNIT_TMPDIR"
 
   # Setup this specific test
-  touch "$TMP_TEST_DIR/boot/vmlinuz-$name"
-  touch "$TMP_TEST_DIR/.config"
-  touch "$TMP_TEST_DIR/virty.qcow2"
-  configurations[mount_point]="$TMP_TEST_DIR"
+  touch "$SHUNIT_TMPDIR/boot/vmlinuz-$name"
+  touch "$SHUNIT_TMPDIR/.config"
+  touch "$SHUNIT_TMPDIR/virty.qcow2"
+  rm -rf "${SHUNIT_TMPDIR:?}"/boot
+  configurations[mount_point]="$SHUNIT_TMPDIR"
 
   # Check standard remote kernel installation
   declare -a cmd_sequence=(
@@ -344,7 +342,7 @@ function test_install_kernel_vm()
     'update_debian_boot_loader_mock'
   )
 
-  cd "$TMP_TEST_DIR"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
   shopt -s expand_aliases
   alias findmnt='findmnt_mock'
   alias vm_umount='vm_umount'

--- a/tests/pomodoro_test.sh
+++ b/tests/pomodoro_test.sh
@@ -6,8 +6,8 @@ include './tests/utils.sh'
 function setUp()
 {
   mkdir -p "$TMP_TEST_DIR"
-  export POMODORO_LOG_FILE="$TMP_TEST_DIR/pomodoro_current.log"
-  export KW_POMODORO_DATA="$TMP_TEST_DIR/pomodoro"
+  export POMODORO_LOG_FILE="$SHUNIT_TMPDIR/pomodoro_current.log"
+  export KW_POMODORO_DATA="$SHUNIT_TMPDIR/pomodoro"
   export KW_POMODORO_TAG_LIST="$KW_POMODORO_DATA/tags"
 
   touch "$POMODORO_LOG_FILE"
@@ -15,7 +15,8 @@ function setUp()
 
 function tearDown()
 {
-  rm -rf "$TMP_TEST_DIR"
+  rm -rf "$SHUNIT_TMPDIR"
+  mkdir -p "$SHUNIT_TMPDIR"
 }
 
 function test_register_timebox()

--- a/tests/remote_test.sh
+++ b/tests/remote_test.sh
@@ -21,7 +21,6 @@ function tearDownMockFunctions()
   unalias which_distro
 }
 
-
 function oneTimeSetUp()
 {
   FAKE_KW="$SHUNIT_TMPDIR/fake_kw"
@@ -35,9 +34,9 @@ function oneTimeSetUp()
   cp -f tests/samples/kworkflow.config "$TEST_PATH"
   cp -f tests/samples/dmesg "$TEST_PATH"
 
-  cd "$TEST_PATH"
+  cd "$TEST_PATH" || fail 'Was not able to move to temporary directory'
   load_configuration
-  cd "$current_path"
+  cd "$current_path" || fail 'Was not able return to original directory'
 
   local -r kernel_install_path="kernel_install"
 

--- a/tests/statistics_test.sh
+++ b/tests/statistics_test.sh
@@ -8,20 +8,6 @@ include './tests/utils.sh'
 # Average: 14
 # Min: 4
 # Max: 9433
-function suite()
-{
-  suite_addTest "statistics_Test"
-  suite_addTest "calculate_average_Test"
-  suite_addTest "calculate_total_of_data_Test"
-  suite_addTest "max_value_Test"
-  suite_addTest "min_value_Test"
-  suite_addTest "basic_data_process_Test"
-  suite_addTest "day_statistics_Test"
-  suite_addTest "week_statistics_Test"
-  suite_addTest "month_statistics_Test"
-  suite_addTest "year_statistics_Test"
-}
-
 function setUp()
 {
   export KW_DATA_DIR='tests/samples'
@@ -54,7 +40,7 @@ function setUp()
   )
 }
 
-function statistics_Test()
+function test_statistics()
 {
   local msg
 
@@ -98,7 +84,7 @@ function statistics_Test()
   assertEquals "($LINENO)" "$msg" "$output"
 }
 
-function calculate_average_Test()
+function test_calculate_average()
 {
   avg=$(calculate_average "10")
   assertEquals "($LINENO)" "10" "$avg"
@@ -107,7 +93,7 @@ function calculate_average_Test()
   assertEquals "($LINENO)" "$pre_avg" "$avg"
 }
 
-function calculate_total_of_data_Test()
+function test_calculate_total_of_data()
 {
   total=$(calculate_total_of_data "1")
   assertEquals "($LINENO)" "1" "$total"
@@ -119,7 +105,7 @@ function calculate_total_of_data_Test()
   assertEquals "($LINENO)" "$pre_total" "$total"
 }
 
-function max_value_Test()
+function test_max_value()
 {
   max=$(max_value "0")
   assertEquals "($LINENO)" "$max" "0"
@@ -131,7 +117,7 @@ function max_value_Test()
   assertEquals "($LINENO)" "$pre_max" "$max"
 }
 
-function min_value_Test()
+function test_min_value()
 {
   min=$(min_value "0" "0")
   assertEquals "($LINENO)" "$min" "0"
@@ -143,20 +129,11 @@ function min_value_Test()
   assertEquals "($LINENO)" "$min" "$pre_min"
 }
 
-function sec_to_formatted_date_Test()
-{
-  formatted_time=$(sec_to_formatted_date "$pre_total_sec")
-  assertEquals "($LINENO)" "$formatted_time" "$pre_formated_sec"
-
-  formatted_time=$(sec_to_formatted_date "")
-  assertEquals "($LINENO)" "$formatted_time" "00:00:00"
-}
-
 # Note: The weekly, monthly, and yearly calculation uses `basic_data_process`.
 # These functions only concatenate the set of values before invoke
 # `basic_data_process`, for this reason, there is no point to validate this
 # operation in the weekly, monthly, and yearly tests.
-function basic_data_process_Test()
+function test_basic_data_process()
 {
   local data
   local day_path="$base_statistics/05/27"
@@ -176,7 +153,7 @@ function basic_data_process_Test()
   assertEquals "($LINENO)" "" "$deploy"
 }
 
-function day_statistics_Test()
+function test_day_statistics()
 {
   local day_data
   local msg1='Currently, kw does not have any data for the present date.'
@@ -192,7 +169,7 @@ function day_statistics_Test()
   compare_command_sequence may_27_2020[@] "$day_data" "$LINENO"
 }
 
-function week_statistics_Test()
+function test_week_statistics()
 {
   local day_data
   local week_data
@@ -207,7 +184,7 @@ function week_statistics_Test()
   compare_command_sequence may_27_2020[@] "$week_data" "$LINENO"
 }
 
-function month_statistics_Test()
+function test_month_statistics()
 {
   local target_month='2019/05'
   local month_data
@@ -226,7 +203,7 @@ function month_statistics_Test()
   rm -rf "$base_statistics/04"
 }
 
-function year_statistics_Test()
+function test_year_statistics()
 {
   local target_year='2019'
   local year_data

--- a/tests/vm_test.sh
+++ b/tests/vm_test.sh
@@ -3,28 +3,21 @@
 include './tests/utils.sh'
 include './src/vm.sh'
 
-declare -r test_path="tests/.tmp"
-
 function setUp()
 {
-  local -r current_path="$PWD"
-
-  rm -rf "$test_path"
-
-  mkdir -p $test_path
-
-  cp -f tests/samples/kworkflow.config $test_path
+  cp -f tests/samples/kworkflow.config "$SHUNIT_TMPDIR"
 }
 
 function tearDown()
 {
-  rm -rf "$test_path"
+  rm -rf "$SHUNIT_TMPDIR"
+  mkdir -p "$SHUNIT_TMPDIR"
 }
 
 function test_vm_mount()
 {
   local ID
-  local mount_point="$test_path/lala"
+  local mount_point="$SHUNIT_TMPDIR/lala"
   local qemu_path="/any/path"
   local -r current_path="$PWD"
   local ret
@@ -41,9 +34,10 @@ function test_vm_mount()
     "$guestmount_cmd"
   )
 
+  tearDown
   setUp
 
-  cd "$test_path"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
 
   ID=1
   output=$(vm_mount "TEST_MODE")
@@ -95,9 +89,7 @@ function test_vm_umount()
     "$guestmount_cmd"
   )
 
-  setUp
-
-  cd "$test_path"
+  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
 
   ID=1
   output=$(vm_umount "TEST_MODE")
@@ -115,8 +107,6 @@ function test_vm_umount()
   compare_command_sequence expected_cmd[@] "$output" "$ID"
 
   cd "$current_path"
-
-  tearDown
 }
 
 invoke_shunit

--- a/tests/vm_test.sh
+++ b/tests/vm_test.sh
@@ -3,12 +3,6 @@
 include './tests/utils.sh'
 include './src/vm.sh'
 
-function suite()
-{
-  suite_addTest "vm_mount_Test"
-  suite_addTest "vm_umount_Test"
-}
-
 declare -r test_path="tests/.tmp"
 
 function setUp()
@@ -27,7 +21,7 @@ function tearDown()
   rm -rf "$test_path"
 }
 
-function vm_mount_Test()
+function test_vm_mount()
 {
   local ID
   local mount_point="$test_path/lala"
@@ -82,7 +76,7 @@ function vm_mount_Test()
   tearDown
 }
 
-function vm_umount_Test()
+function test_vm_umount()
 {
   local ID
   local mount_point="/"


### PR DESCRIPTION
This patch improves kw's tests by using two features of shunit2:
 - The fact that function names starting with `test` are automatically queued up for execution, sparing the need of a `suite` function;
 - The offering of a temporary directory which will be cleaned up by shunit2 upon it's exiting.

Each of these features gets a commit implementing it in kw's tests. When implementing these changes to `remote_test.sh`, I noticed it needed a bit of refactoring, so there is a commit for that too.

Addresses:  #152