### PR TITLE
Show hardware information.

### DIFF
--- a/src/remote.sh
+++ b/src/remote.sh
@@ -1,6 +1,7 @@
 # NOTE: It is recommended that src/kw_config_loader.sh be included before this
 # file
 include "$KW_LIB_DIR/kw_config_loader.sh"
+include "$KW_LIB_DIR/kwlib.sh"
 
 # We now have a kw directory visible for users in the home directory, which is
 # used for saving temporary files to be deployed in the target machine.


### PR DESCRIPTION
This PR is far from ready, and it is a first attempt into showing hardware information from remote machines. To use it, run `kw statistics --remote IP PORT`, and then if everything is okay, it will show an output like the one below, providing information about the CPU, RAM, and type of storage devices.

```
CPU:
        Name: QEMU Virtual CPU version 2.5+
        Frequency:
                CPU MHz:             2304.066
RAM:
        Total RAM: 2037488 kB
Storage devices:
        fd0    rotational
        sda    rotational
        sr0    rotational
```

I haven't added tests yet, and the option still doesn't provide warnings when users mistakenly use the command. I also need to add another option for showing hardware information from the local machine. But before I proceed, I would like to receive feedback on what's been done so far.