### PR TITLE
Fix problems with `kw vars`

### DIFF
--- a/documentation/man/kw.rst
+++ b/documentation/man/kw.rst
@@ -284,8 +284,8 @@ the current .config file. The user can suppress this warning by using -f flag.
 warning message because it will remove the config file from kw management. The
 user can suppress this warning by using -f.
 
-v, vars
-~~~~~~~
+vars
+~~~~
 Shows configurations being used by **kw** in the current working directory. To
 do that, it examines both global and local *kworkflow.config* files.
 

--- a/src/help.sh
+++ b/src/help.sh
@@ -29,7 +29,7 @@ function kworkflow_help()
     "\tstatistics - Provide basic statistics related to daily development\n" \
     "\tumount,um - Umount partition created with qemu-nbd\n" \
     "\tup,u - Wake up vm\n" \
-    "\tvars,v - Show variables\n" \
+    "\tvars - Show variables\n" \
     "\tversion,--version,-v - show kw version\n"
 }
 

--- a/src/kw_config_loader.sh
+++ b/src/kw_config_loader.sh
@@ -19,6 +19,7 @@ declare -gA deploy_target_opt=(['vm']=1 ['local']=2 ['remote']=3)
 # This function is used to show the current set up used by kworkflow.
 function show_variables()
 {
+  local test_mode=0
   local has_local_config_path="No"
 
   if [ -f "$PWD/kworkflow.config" ]; then
@@ -27,14 +28,70 @@ function show_variables()
     has_local_config_path="No"
   fi
 
-  say "Variables:"
-  echo -e "\tLocal config file: $has_local_config_path"
-  echo -e "\tTarget arch: ${configurations[arch]}"
-  echo -e "\tMount point: ${configurations[mount_point]}"
-  echo -e "\tVirtualization tool: ${configurations[virtualizer]}"
-  echo -e "\tQEMU options: ${configurations[qemu_hw_options]}"
-  echo -e "\tQEMU Net options: ${configurations[qemu_net_options]}"
-  echo -e "\tVdisk: ${configurations[qemu_path_image]}"
+  if [[ "$1" == 'TEST_MODE' ]]; then
+    test_mode='1'
+  fi
+
+  local -Ar ssh=(
+    [ssh_ip]='SSH address'
+    [ssh_port]='SSH port'
+  )
+
+  local -Ar build=(
+    [mount_point]='Mount point'
+    [arch]='Target arch'
+    [kernel_img_name]='Kernel image name'
+    [cross_compile]='Cross-compile name'
+    [menu_config]='Kernel menu config'
+    [doc_type]='Command to generate kernel-doc'
+  )
+
+  local -Ar qemu=(
+    [virtualizer]='Virtualisation tool'
+    [qemu_hw_options]='QEMU hardware setup'
+    [qemu_net_options]='QEMU Net options'
+    [qemu_path_image]='Path for QEMU image'
+  )
+
+  local -Ar notification=(
+    [alert]='Default alert options'
+    [sound_alert_command]='Command for sound notification'
+    [visual_alert_command]='Command for visual notification'
+  )
+
+  local -Ar deploy=(
+    [default_deploy_target]='Deploy target'
+    [reboot_after_deploy]='Reboot after deploy'
+  )
+
+  local -Ar misc=(
+    [disable_statistics_data_track]='Disable tracking of statistical data'
+    [gui_on]='Command to activate GUI'
+    [gui_off]='Command to deactivate GUI'
+  )
+
+  local -Ar group_descriptions=(
+    [build]='Kernel build options'
+    [deploy]='kernel deploy options'
+    [ssh]='SSH options'
+    [qemu]='QEMU options'
+    [notification]='Notification options'
+    [misc]='Miscellaneous options'
+  )
+
+  say "kw configuration variables:"
+  echo -e "  Local config file: $has_local_config_path"
+
+  for group in 'build' 'deploy' 'qemu' 'ssh' 'notification' 'misc'; do
+    echo "  ${group_descriptions["$group"]}:"
+    local -n descriptions="$group"
+
+    for option in "${!descriptions[@]}"; do
+      if [[ -v configurations["$option"] || "$test_mode" == '1' ]]; then
+        echo "    ${descriptions[$option]} ($option): ${configurations[$option]}"
+      fi
+    done
+  done
 }
 
 # This function read the configuration file and make the parser of the data on


### PR DESCRIPTION
This PR includes two commits regarding `kw vars`:
 - `574037c` The command was not showing every configuration option. Now it shows all configuration options which are defined. Closes #142.
 - `580bf26` The abbreviation `kw v` was removed in the code when merging #169, but the documentation was never updated. This commit does that.

@matheustavares suggested as a possible solution for #142 to iterate over configurations and print it's entries. Besides the downside he described himself for this approach (printing mistakenly user-defined options) I would add that it doesn't allow a meaningful description of the options. The downside of hard-coding options in `src/kw_config_loader.sh` (our approach here) is that every new option added to `kworkflow_template.config` needs to be implemented in `src/kw_config_loader.sh` too. For developers to remember to do so, this PR also introduces a test to check whether the options in `etc/kworkflow_template.config` match the options defined in `src/kw_config_loader.sh`.