### PR TITLE
Fix typo

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@
 . src/kwlib.sh --source-only
 
 # List of dependences per distro
-arch_packages=(qemu bash git tar python-docutils pulseaudio libpulse dunst python-sphinx imagemagick graphviz python-virtualenvi texlive-bin librsvg)
+arch_packages=(qemu bash git tar python-docutils pulseaudio libpulse dunst python-sphinx imagemagick graphviz python-virtualenv texlive-bin librsvg)
 debian_packages=(qemu git tar python3-docutils pulseaudio-utils dunst sphinx-doc imagemagick graphviz dvipng python3-venv latexmk librsvg2-bin texlive-xetex python3-sphinx python3-dask-sphinx-theme)
 
 SILENT=1


### PR DESCRIPTION
There is a typo on one of the arch packages listed as a dependency in setup.sh