### PR TITLE
code: fixing minor shellcheck issues

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -10,7 +10,7 @@ function show_help()
 {
   echo "Usage: $0 [help] [list] [test tfile1 tfile2 ... tfilen] [prepare [-f|--force-update]]"
   echo "Run tests for kworkflow."
-  printf "Example: $0 test kw_test\n\n"
+  printf "Example: %s test kw_test\n\n" "$0"
   echo "  help - displays this help message"
   echo "  list - lists all test files under tests/"
   echo "  test - runs the given test files"

--- a/setup.sh
+++ b/setup.sh
@@ -69,7 +69,7 @@ function check_dependencies()
     return 0
   fi
 
-  if [[ ! -z "$package_list" ]]; then
+  if [[ -n "$package_list" ]]; then
     if [[ "$FORCE" == 0 ]]; then
       if [[ $(ask_yN "Can we install the following dependencies $package_list ?") =~ "0" ]]; then
         return 0

--- a/src/get_maintainer_wrapper.sh
+++ b/src/get_maintainer_wrapper.sh
@@ -24,7 +24,7 @@ function print_files_authors()
     authors=$(grep -oE "MODULE_AUTHOR *\(.*\)" $file |
       sed -E "s/(MODULE_AUTHOR *\( *\"|\" *\))//g" |
       sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/, /g')
-    if [[ ! -z $authors ]]; then
+    if [[ -n $authors ]]; then
       if [[ $printed_authors_separator = false ]]; then
         say $SEPARATOR
         say "MODULE AUTHORS:"

--- a/src/kw_config_loader.sh
+++ b/src/kw_config_loader.sh
@@ -49,7 +49,7 @@ function parse_configuration()
   if [ ! -f "$config_path" ] || [ "$filename" != kworkflow.config ]; then
     return 22 # 22 means Invalid argument - EINVAL
   fi
-
+  # shellcheck disable=SC2162
   while read line; do
     # Line started with # should be ignored
     [[ "$line" =~ ^# ]] && continue

--- a/src/kwio.sh
+++ b/src/kwio.sh
@@ -55,21 +55,22 @@ function alert_completion()
 # the color to be used and two optional params:
 #   - the option '-n', to not output the trailing newline
 #   - text message to be printed
-#
+#shellcheck disable=SC2059
 function colored_print()
 {
   local message="${@:2}"
+  local colored_format="${!1}"
 
   if [[ $# -ge 2 && $2 = "-n" ]]; then
     message="${@:3}"
     if [ -t 1 ]; then
-      printf ${!1} "$message"
+      printf "$colored_format" "$message"
     else
       echo -n "$message"
     fi
   else
     if [ -t 1 ]; then
-      printf "${!1}\n" "$message"
+      printf "$colored_format\n" "$message"
     else
       echo "$message"
     fi

--- a/src/mk.sh
+++ b/src/mk.sh
@@ -703,7 +703,7 @@ function deploy_parser_options()
   options_values["MENU_CONFIG"]="nconfig"
 
   # Set basic default values
-  if [[ ! -z ${configurations[default_deploy_target]} ]]; then
+  if [[ -n ${configurations[default_deploy_target]} ]]; then
     local config_file_deploy_target=${configurations[default_deploy_target]}
     options_values["TARGET"]=${deploy_target_opt[$config_file_deploy_target]}
   else

--- a/src/plugins/kernel_install/utils.sh
+++ b/src/plugins/kernel_install/utils.sh
@@ -84,7 +84,7 @@ function list_installed_kernels()
 
   output=$(echo "$output" | grep recovery -v | grep with | awk -F" " '{print $NF}')
 
-  while read kernel; do
+  while read -r kernel; do
     if [[ -f "$prefix/boot/vmlinuz-$kernel" ]]; then
       available_kernels+=("$kernel")
     fi

--- a/src/plugins/subsystems/drm/drm.sh
+++ b/src/plugins/subsystems/drm/drm.sh
@@ -41,7 +41,7 @@ function drm_manager()
     return 0
   fi
 
-  if [[ ! -z "$load_module" ]]; then
+  if [[ -n "$load_module" ]]; then
     module_control "LOAD" "$target" "$remote" "$load_module"
     if [[ "$?" != 0 ]]; then
       return 22
@@ -56,7 +56,7 @@ function drm_manager()
     gui_control "OFF" "$target" "$remote"
   fi
 
-  if [[ ! -z "$unload_module" ]]; then
+  if [[ -n "$unload_module" ]]; then
     # For unload DRM drivers, we need to make sure that we turn off user GUI
     [[ "$gui_off" != 1 ]] && gui_control "OFF" "$target" "$remote"
     module_control "UNLOAD" "$target" "$remote" "$unload_module"
@@ -269,7 +269,7 @@ function get_available_connectors()
     value=$(echo "$card" | grep card | cut -d- -f2)
     [[ "$key" == "$value" ]] && continue
 
-    if [[ ! -z "$key" && ! -z "$value" ]]; then
+    if [[ -n "$key" && -n "$value" ]]; then
       list_of_values="${cards[$key]}"
       if [[ -z "$list_of_values" ]]; then
         cards["$key"]="$value"

--- a/src/plugins/subsystems/drm/drm.sh
+++ b/src/plugins/subsystems/drm/drm.sh
@@ -263,7 +263,7 @@ function get_available_connectors()
       ;;
   esac
 
-  while read card; do
+  while read -r card; do
     card=$(basename "$card")
     key=$(echo "$card" | grep card | cut -d- -f1)
     value=$(echo "$card" | grep card | cut -d- -f2)

--- a/src/pomodoro.sh
+++ b/src/pomodoro.sh
@@ -273,7 +273,7 @@ function show_active_pomodoro_timebox()
 
   current_timestamp=$(get_timestamp_sec)
 
-  while read line; do
+  while read -r line; do
     # Get data from file
     timestamp=$(echo "$line" | cut -d',' -f1)
     timebox=$(echo "$line" | cut -d',' -f2)

--- a/src/remote.sh
+++ b/src/remote.sh
@@ -304,7 +304,7 @@ function kw_ssh()
   fi
 
   # Add port
-  if [ ! -z "$port" ]; then
+  if [ -n "$port" ]; then
     port="-p $port"
   fi
 

--- a/src/statistics.sh
+++ b/src/statistics.sh
@@ -175,8 +175,7 @@ function min_value()
 # Print results of "Total Max Min Average" organized in columns.
 #
 # Note: This function relies on a global variable named shared_data.
-#shellcheck disable=2059
-#shellcheck disable=2086
+#shellcheck disable=SC2059,SC2086
 function print_basic_data()
 {
   local header_format='%20s %4s %8s %12s\n'

--- a/tests/mk_test.sh
+++ b/tests/mk_test.sh
@@ -470,7 +470,7 @@ function kernel_modules_Test()
 
   ID=1
   output=$(modules_install "TEST_MODE" "3" "127.0.0.1:3333")
-  while read f; do
+  while read -r f; do
     if [[ ${expected_cmd[$count]} != ${f} ]]; then
       fail "$count - Expected cmd \"${expected_cmd[$count]}\" to be \"${f}\""
     fi
@@ -577,7 +577,7 @@ function mk_list_remote_kernels_Test()
   setupRemote
 
   output=$(mk_list_installed_kernels "TEST_MODE" "0" "3" "127.0.0.1:3333")
-  while read f; do
+  while read -r f; do
     if [[ ${expected_cmd[$count]} != ${f} ]]; then
       fail "$count - Expected cmd \"${expected_cmd[$count]}\" to be \"${f}\""
     fi
@@ -658,7 +658,7 @@ function cleanup_after_deploy_Test()
   )
 
   output=$(cleanup_after_deploy "TEST_MODE")
-  while read f; do
+  while read -r f; do
     assertFalse "$ID (cmd: $count) - Expected \"${expected_cmd[$count]}\" to be \"${f}\"" \
       '[[ ${expected_cmd[$count]} != ${f} ]]'
     ((count++))

--- a/tests/plugins/kernel_install/utils_test.sh
+++ b/tests/plugins/kernel_install/utils_test.sh
@@ -80,7 +80,7 @@ function human_list_installed_kernels_Test()
   )
 
   output=$(list_installed_kernels "0" "$TMP_TEST_DIR")
-  while read out; do
+  while read -r out; do
     assertEquals "$count - Expected kernel list" "${expected_out[$count]}" "$out"
     ((count++))
   done <<< "$output"
@@ -96,7 +96,7 @@ function comman_list_installed_kernels_Test()
   )
 
   output=$(list_installed_kernels "1" "$TMP_TEST_DIR")
-  while read out; do
+  while read -r out; do
     assertEquals "$count - Expected kernel list" "${expected_out[$count]}" "$out"
     ((count++))
   done <<< "$output"

--- a/tests/remote_test.sh
+++ b/tests/remote_test.sh
@@ -251,7 +251,7 @@ function prepare_remote_dir_Test()
 
   setupMockFunctions
   output=$(prepare_remote_dir "$remote" "$port" "$user" "$flag")
-  while read cmd; do
+  while read -r cmd; do
     if [[ ${expected_cmd_sequence[$count]} != ${cmd} ]]; then
       fail "Expected command \"${expected_cmd_sequence[$count]}\" to be \"${cmd}\")"
     fi
@@ -282,7 +282,7 @@ function generate_tarball_Test()
 
   ID=2
   output=$(tar -taf "$FAKE_KW/$LOCAL_TO_DEPLOY_DIR/$tarball_name" | sort -d)
-  while read f; do
+  while read -r f; do
     if [[ ${expected_files[$count]} != ${f} ]]; then
       fail "$ID - Expected file \"${expected_files[$count]}\" to be \"${f}\""
     fi

--- a/tests/utils
+++ b/tests/utils
@@ -228,7 +228,7 @@ function compare_command_sequence()
 
   ID=${ID:-0}
 
-  while read f; do
+  while read -r f; do
     if [[ "${expected[$count]}" != "${f}" ]]; then
       fail "($ID) $count - Expected cmd \"${expected[$count]}\" to be \"${f}\""
     fi


### PR DESCRIPTION
This commit fixes all occurrences of the following shellcheck errors:
[SC2059](https://github.com/koalaman/shellcheck/wiki/SC2059) - Don't use variables in the printf format string. Use printf "..%s.." "$foo".
[SC2162](https://github.com/koalaman/shellcheck/wiki/SC2162) - Read without -r will mangle backslashes
[SC2236](https://github.com/koalaman/shellcheck/wiki/SC2236) - Use -n instead of ! -z.

There are 2 occurrences of SC2059 that I'm not really sure what to do with, I don't know if the logic of this error apply to these cases. We can change them, manually disable this error by marking them as false positives or ignore this error as whole in the entire project. 
Here are the 2 occurrences:
on statistics.sh
![image](https://user-images.githubusercontent.com/28787373/121733115-72e85c80-cac9-11eb-831f-c67fe7560e42.png)

on kwio.sh
![image](https://user-images.githubusercontent.com/28787373/121733165-8693c300-cac9-11eb-86ff-7f1b262664d4.png)
