### PR TITLE
code: separate declarations from assignements

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -162,9 +162,10 @@ function run_tests()
 declare -a TESTS
 function strip_path()
 {
+  local base
   TESTS=()
   for file in "$@"; do
-    local base=$(basename ${file})
+    base=$(basename ${file})
     TESTS+=("${base%.*}")
   done
 }

--- a/setup.sh
+++ b/setup.sh
@@ -47,9 +47,11 @@ declare -r CONFIGS_PATH="configs"
 
 function check_dependencies()
 {
-  local distro=$(detect_distro "/")
   local package_list=""
   local cmd=""
+  local distro
+
+  distro=$(detect_distro "/")
 
   if [[ "$distro" =~ "arch" ]]; then
     for package in "${arch_packages[@]}"; do
@@ -162,10 +164,12 @@ function confirm_complete_removal()
 
 function clean_legacy()
 {
-  local trash=$(mktemp -d)
   local completely_remove="$1"
-
   local toDelete="$app_name"
+  local trash
+
+  trash=$(mktemp -d)
+
   eval "sed -i '/\<$toDelete\>/d' $HOME/.bashrc"
 
   # Remove kw binary
@@ -321,9 +325,13 @@ function append_bashcompletion()
 
 function update_version()
 {
-  local head_hash=$(git rev-parse --short HEAD)
-  local branch_name=$(git rev-parse --short --abbrev-ref HEAD)
-  local base_version=$(cat "$libdir/VERSION" | head -n 1)
+  local head_hash
+  local branch_name
+  local base_version
+
+  head_hash=$(git rev-parse --short HEAD)
+  branch_name=$(git rev-parse --short --abbrev-ref HEAD)
+  base_version=$(cat "$libdir/VERSION" | head -n 1)
 
   cat > "$libdir/VERSION" << EOF
 $base_version

--- a/src/config_manager.sh
+++ b/src/config_manager.sh
@@ -75,6 +75,8 @@ function save_config_file()
 function list_configs()
 {
   local -r dot_configs_dir="$KW_DATA_DIR/configs"
+  local name
+  local content
 
   if [[ ! -d "$dot_configs_dir" || ! -d "$dot_configs_dir/$metadata_dir" ]]; then
     say "There's no tracked .config file"
@@ -85,8 +87,8 @@ function list_configs()
   echo
   for filename in $dot_configs_dir/$metadata_dir/*; do
     [[ ! -f "$filename" ]] && continue
-    local name=$(basename "$filename")
-    local content=$(cat "$filename")
+    name=$(basename "$filename")
+    content=$(cat "$filename")
     printf "%-30s | %-30s\n" "$name" "$content"
   done
 }

--- a/src/diff.sh
+++ b/src/diff.sh
@@ -103,9 +103,10 @@ function diff_side_by_side()
   local file_2="$2"
   local interactive="$3"
   local flag="$4"
-  local columns=$(tput cols)
   local diff_cmd="diff -y --color=always --width=$columns"
+  local columns
 
+  columns=$(tput cols)
   flag=${flag:-""}
 
   if [[ ! -f "$file_1" || ! -f "$file_2" ]]; then

--- a/src/kw_config_loader.sh
+++ b/src/kw_config_loader.sh
@@ -44,7 +44,9 @@ function show_variables()
 function parse_configuration()
 {
   local config_path="$1"
-  local filename="$(basename "$config_path")"
+  local filename
+
+  filename="$(basename "$config_path")"
 
   if [ ! -f "$config_path" ] || [ "$filename" != kworkflow.config ]; then
     return 22 # 22 means Invalid argument - EINVAL

--- a/src/kw_include.sh
+++ b/src/kw_include.sh
@@ -8,7 +8,9 @@
 function include()
 {
   local filepath="$1"
-  local varname=$(basename "$filepath" .sh)
+  local varname
+
+  varname=$(basename "$filepath" .sh)
 
   if [[ ! -e "$filepath" ]]; then
     echo "File $filepath could not be found, check your file path."

--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -156,12 +156,13 @@ function find_kernel_root()
 function is_a_patch()
 {
   local -r FILE_PATH="$@"
+  local file_content
 
   if [[ ! -f "$FILE_PATH" ]]; then
     return 1
   fi
 
-  local file_content=$(cat "$FILE_PATH")
+  file_content=$(cat "$FILE_PATH")
 
   # The following array stores strings that are expected to be present
   # in a patch file. The absence of any of these strings makes the
@@ -224,8 +225,10 @@ function detect_distro()
 {
   local root_path="$1"
   local str_check="$2"
-  local etc_path=$(join_path $root_path /etc)
   local distro="none"
+  local etc_path
+
+  etc_path=$(join_path $root_path /etc)
 
   if [[ ! -z "$str_check" ]]; then
     distro="$str_check"
@@ -257,9 +260,13 @@ function statistics_manager()
 {
   local label="$1"
   local value="$2"
-  local day=$(date +%d)
-  local year_month_dir=$(date +%Y/%m)
-  local day_path="$KW_DATA_DIR/statistics/$year_month_dir/$day"
+  local day
+  local year_month_dir
+  local day_path
+
+  day=$(date +%d)
+  year_month_dir=$(date +%Y/%m)
+  day_path="$KW_DATA_DIR/statistics/$year_month_dir/$day"
 
   elapsed_time=$(date -d@$value -u +%H:%M:%S)
   say "-> Execution time: $elapsed_time"

--- a/src/mk.sh
+++ b/src/mk.sh
@@ -119,6 +119,9 @@ function modules_install()
   local flag="$1"
   local target="$2"
   local formatted_remote="$3"
+  local remote
+  local port
+  local distro
 
   if ! is_kernel_root "$PWD"; then
     complain "Execute this command in a kernel tree."
@@ -129,7 +132,7 @@ function modules_install()
 
   case "$target" in
     1) # VM_TARGET
-      local distro=$(detect_distro "${configurations[mount_point]}/")
+      distro=$(detect_distro "${configurations[mount_point]}/")
 
       if [[ "$distro" =~ "none" ]]; then
         complain "Unfortunately, there's no support for the target distro"
@@ -147,8 +150,8 @@ function modules_install()
       # 1. Preparation steps
       prepare_host_deploy_dir
 
-      local remote=$(get_based_on_delimiter "$formatted_remote" ":" 1)
-      local port=$(get_based_on_delimiter "$formatted_remote" ":" 2)
+      remote=$(get_based_on_delimiter "$formatted_remote" ":" 1)
+      port=$(get_based_on_delimiter "$formatted_remote" ":" 2)
       # User may specify a hostname instead of bare IP
       remote=$(get_based_on_delimiter "$remote" "@" 2)
 
@@ -190,6 +193,8 @@ function mk_list_installed_kernels()
   local single_line="$2"
   local target="$3"
   local unformatted_remote="$4"
+  local remote
+  local port
 
   flag=${flag:-"SILENT"}
 
@@ -213,8 +218,8 @@ function mk_list_installed_kernels()
       ;;
     3) # REMOTE_TARGET
       local cmd="bash $REMOTE_KW_DEPLOY/deploy.sh --list_kernels $single_line"
-      local remote=$(get_based_on_delimiter "$unformatted_remote" ":" 1)
-      local port=$(get_based_on_delimiter "$unformatted_remote" ":" 2)
+      remote=$(get_based_on_delimiter "$unformatted_remote" ":" 1)
+      port=$(get_based_on_delimiter "$unformatted_remote" ":" 2)
       remote=$(get_based_on_delimiter "$remote" "@" 2)
 
       prepare_remote_dir "$remote" "$port" "" "$flag"
@@ -249,6 +254,9 @@ function kernel_install()
   local mkinitcpio_name="${configurations[mkinitcpio_name]}"
   local arch_target="${configurations[arch]}"
   local kernel_img_name="${configurations[kernel_img_name]}"
+  local remote
+  local port
+  local distro
 
   if ! is_kernel_root "$PWD"; then
     complain "Execute this command in a kernel tree."
@@ -281,7 +289,7 @@ function kernel_install()
 
   case "$target" in
     1) # VM_TARGET
-      local distro=$(detect_distro "${configurations[mount_point]}/")
+      distro=$(detect_distro "${configurations[mount_point]}/")
 
       if [[ "$distro" =~ "none" ]]; then
         complain "Unfortunately, there's no support for the target distro"
@@ -295,7 +303,7 @@ function kernel_install()
       return "$?"
       ;;
     2) # LOCAL_TARGET
-      local distro=$(detect_distro "/")
+      distro=$(detect_distro "/")
 
       if [[ "$distro" =~ "none" ]]; then
         complain "Unfortunately, there's no support for the target distro"
@@ -321,8 +329,8 @@ function kernel_install()
         sed -i "s/NAME/$name/g" "$preset_file"
       fi
 
-      local remote=$(get_based_on_delimiter "$formatted_remote" ":" 1)
-      local port=$(get_based_on_delimiter "$formatted_remote" ":" 2)
+      remote=$(get_based_on_delimiter "$formatted_remote" ":" 1)
+      port=$(get_based_on_delimiter "$formatted_remote" ":" 2)
       remote=$(get_based_on_delimiter "$remote" "@" 2)
 
       distro_info=$(which_distro "$remote" "$port" "$user")
@@ -362,6 +370,8 @@ function mk_kernel_uninstall()
   local kernels_target="$4"
   local flag="$5"
   local distro
+  local remote
+  local port
 
   flag=${flag:-""}
 
@@ -384,8 +394,8 @@ function mk_kernel_uninstall()
       kernel_uninstall "$reboot" 'local' "$kernels_target" "$flag"
       ;;
     3) # REMOTE_TARGET
-      local remote=$(get_based_on_delimiter "$formatted_remote" ":" 1)
-      local port=$(get_based_on_delimiter "$formatted_remote" ":" 2)
+      remote=$(get_based_on_delimiter "$formatted_remote" ":" 1)
+      port=$(get_based_on_delimiter "$formatted_remote" ":" 2)
       remote=$(get_based_on_delimiter "$remote" "@" 2)
 
       prepare_remote_dir "$remote" "$port" "" "$flag"
@@ -532,16 +542,21 @@ function deploy_help()
 # will be compiled.
 function build_info()
 {
-  local flag="$1"
-  local kernel_name=$(get_kernel_release "$flag")
-  local kernel_version=$(get_kernel_version "$flag")
+  local flag
+  local kernel_name
+  local kernel_version
+  local compiled_modules
+
+  flag="$1"
+  kernel_name=$(get_kernel_release "$flag")
+  kernel_version=$(get_kernel_version "$flag")
 
   say "Kernel source information"
   echo -e "\tName: $kernel_name"
   echo -e "\tVersion: $kernel_version"
 
   if [[ -f '.config' ]]; then
-    local compiled_modules=$(grep -c '=m' .config)
+    compiled_modules=$(grep -c '=m' .config)
     echo -e "\tTotal modules to be compiled: $compiled_modules"
   fi
 }

--- a/src/plugins/subsystems/drm/drm.sh
+++ b/src/plugins/subsystems/drm/drm.sh
@@ -91,6 +91,8 @@ function module_control()
   local parameters="$4"
   local flag="$5"
   local module_cmd=""
+  local remote
+  local port
 
   module_cmd=$(convert_module_info "$operation" "$parameters")
   if [[ "$?" != 0 ]]; then
@@ -103,8 +105,8 @@ function module_control()
       cmd_manager "$flag" "sudo bash -c \"$module_cmd\""
       ;;
     3) # REMOTE
-      local remote=$(get_based_on_delimiter "$unformatted_remote" ":" 1)
-      local port=$(get_based_on_delimiter "$unformatted_remote" ":" 2)
+      remote=$(get_based_on_delimiter "$unformatted_remote" ":" 1)
+      port=$(get_based_on_delimiter "$unformatted_remote" ":" 2)
 
       cmd_remotely "$module_cmd" "$flag" "$remote" "$port"
       ;;
@@ -192,6 +194,8 @@ function gui_control()
   local gui_control_cmd
   local vt_console
   local isolate_target
+  local remote
+  local port
 
   if [[ "$operation" == "ON" ]]; then
     isolate_target='graphical.target'
@@ -216,8 +220,8 @@ function gui_control()
       cmd_manager "$flag" "$bind_control_cmd"
       ;;
     3) # REMOTE TARGET
-      local remote=$(get_based_on_delimiter "$unformatted_remote" ":" 1)
-      local port=$(get_based_on_delimiter "$unformatted_remote" ":" 2)
+      remote=$(get_based_on_delimiter "$unformatted_remote" ":" 1)
+      port=$(get_based_on_delimiter "$unformatted_remote" ":" 2)
       remote=$(get_based_on_delimiter "$remote" "@" 2)
 
       cmd_remotely "$gui_control_cmd" "$flag" "$remote" "$port"
@@ -240,6 +244,9 @@ function get_available_connectors()
   local value
   local connectors
   local i
+  local remote
+  local port
+  local find_conn_cmd
   declare -A cards
 
   case "$target" in
@@ -253,9 +260,9 @@ function get_available_connectors()
       target_label="local"
       ;;
     3) # REMOTE TARGET
-      local find_conn_cmd="find $SYSFS_CLASS_DRM -name 'card*'"
-      local remote=$(get_based_on_delimiter "$unformatted_remote" ":" 1)
-      local port=$(get_based_on_delimiter "$unformatted_remote" ":" 2)
+      find_conn_cmd="find $SYSFS_CLASS_DRM -name 'card*'"
+      remote=$(get_based_on_delimiter "$unformatted_remote" ":" 1)
+      port=$(get_based_on_delimiter "$unformatted_remote" ":" 2)
       remote=$(get_based_on_delimiter "$remote" "@" 2)
 
       cards_raw_list=$(cmd_remotely "$find_conn_cmd" "SILENT" "$remote" "$port")

--- a/src/pomodoro.sh
+++ b/src/pomodoro.sh
@@ -198,8 +198,10 @@ function remove_completed_timebox()
 # current timestamp and uses it to register itself in the Pomodoro log file.
 function timer_thread()
 {
-  local timestamp=$(get_timestamp_sec)
+  local timestamp
   local flag
+
+  timestamp=$(get_timestamp_sec)
 
   flag=${flag:-'SILENT'}
 

--- a/src/remote.sh
+++ b/src/remote.sh
@@ -272,6 +272,7 @@ function kw_ssh()
   local opts="$@"
   local port="${configurations[ssh_port]}"
   local target="${configurations[ssh_ip]}"
+  local script_path
 
   if [[ "$1" == -h ]]; then
     ssh_help
@@ -289,7 +290,7 @@ function kw_ssh()
     if [[ "$opts" =~ ^(--command|-c)= ]]; then
       opts="$(echo $opts | cut -d = -f2)"
     elif [[ "$opts" =~ ^(--script|-s)= ]]; then
-      local script_path=$(echo $opts | cut -d = -f2)
+      script_path=$(echo $opts | cut -d = -f2)
 
       if [[ ! -f $script_path ]]; then
         complain "No such file: \"$script_path\""

--- a/tests/checkpatch_wrapper_test.sh
+++ b/tests/checkpatch_wrapper_test.sh
@@ -126,9 +126,13 @@ function run_checkpatch_in_a_path_Test()
 {
   local cmd="perl scripts/checkpatch.pl --no-tree --color=always --strict"
   local patch_path="$TMP_TEST_DIR/samples/test.patch"
-  local real_path=$(realpath "$patch_path")
-  local base_msg="Running checkpatch.pl on: $real_path"
   local output
+  local real_path
+  local base_msg
+
+  real_path=$(realpath "$patch_path")
+  base_msg="Running checkpatch.pl on: $real_path"
+
   declare -a expected_cmd=(
     "$base_msg"
     "$SEPARATOR"
@@ -143,9 +147,13 @@ function run_checkpatch_in_a_file_Test()
 {
   local cmd="perl scripts/checkpatch.pl --terse --no-tree --color=always --strict  --file"
   local patch_path="$TMP_TEST_DIR/samples/codestyle_correct.c"
-  local real_path=$(realpath "$patch_path")
-  local base_msg="Running checkpatch.pl on: $real_path"
   local output
+  local real_path
+  local base_msg
+
+  real_path=$(realpath "$patch_path")
+  base_msg="Running checkpatch.pl on: $real_path"
+
   declare -a expected_cmd=(
     "$base_msg"
     "$SEPARATOR"

--- a/tests/configm_test.sh
+++ b/tests/configm_test.sh
@@ -129,6 +129,7 @@ function save_config_file_check_saved_config_Test()
   local current_path="$PWD"
   local ret=0
   local msg
+  local tmp
 
   # There's no configs yet, initialize it
   cd "$TMP_TEST_DIR"
@@ -149,7 +150,7 @@ function save_config_file_check_saved_config_Test()
   msg="Failed the metadata related to $NAME_2"
   assertTrue "$LINENO: $msg" '[[ -f $configs_path/metadata/$NAME_2 ]]'
 
-  local tmp=$(cat $configs_path/configs/$NAME_2)
+  tmp=$(cat $configs_path/configs/$NAME_2)
   msg="Content in the file does not match"
   assertTrue "$LINENO: $msg" '[[ $tmp = $CONTENT ]]'
 }
@@ -159,13 +160,14 @@ function save_config_file_check_description_Test()
   local current_path="$PWD"
   local ret=0
   local msg
+  local tmp
 
   # There's no configs yet, initialize it
   cd "$TMP_TEST_DIR"
   ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
   cd "$current_path"
 
-  local tmp=$(cat $configs_path/metadata/$NAME_1)
+  tmp=$(cat $configs_path/metadata/$NAME_1)
   msg="The description content for $NAME_1 does not match"
   assertTrue "$LINENO: $msg" '[[ $tmp = $DESCRIPTION_1 ]]'
 

--- a/tests/diff_test.sh
+++ b/tests/diff_test.sh
@@ -12,10 +12,13 @@ function suite()
 function diff_side_by_side_Test()
 {
   local ID
-  local columns=$(tput cols)
   local file_1="$SAMPLES_DIR/MAINTAINERS"
   local file_2="$SAMPLES_DIR/dmesg"
-  local diff_cmd="diff -y --color=always --width=$columns $file_1 $file_2 | less -R"
+  local columns
+  local diff_cmd
+
+  columns=$(tput cols)
+  diff_cmd="diff -y --color=always --width=$columns $file_1 $file_2 | less -R"
 
   declare -a expected_cmd=(
     "$diff_cmd"

--- a/tests/init_test.sh
+++ b/tests/init_test.sh
@@ -32,8 +32,10 @@ function init_kw_Test()
 {
   local ID
   local kworkflow_content
-  local output=$(init_kw)
   local path_config="$FAKE_CONFIG_PATH/$KWORKFLOW/kworkflow.config"
+  local output
+
+  output=$(init_kw)
 
   kworkflow_content=$(cat "$path_config" | grep "$USER" -o | head -n 1)
 

--- a/tests/kw_time_and_date_test.sh
+++ b/tests/kw_time_and_date_test.sh
@@ -35,8 +35,9 @@ function sec_to_format_Test()
 
 function get_today_info_Test()
 {
-  local today=$(date +%Y/%m/%d)
+  local today
 
+  today=$(date +%Y/%m/%d)
   formated_today=$(get_today_info '+%Y/%m/%d')
   assert_equals_helper 'Today info did not match' "$LINENO" "$today" "$formated_today"
 

--- a/tests/kwlib_test.sh
+++ b/tests/kwlib_test.sh
@@ -155,8 +155,9 @@ function detect_distro_Test()
 {
   setupFakeOSInfo
   local root_path="tests/.tmp/detect_distro/arch"
-  local ret=$(detect_distro $root_path)
+  local ret
 
+  ret=$(detect_distro $root_path)
   assertEquals "We got $ret." "$ret" "arch"
 
   root_path="tests/.tmp/detect_distro/debian"
@@ -179,8 +180,9 @@ function detect_distro_Test()
 function join_path_Test()
 {
   local base="/lala/xpto"
-  local ret=$(join_path "/lala" "///xpto")
+  local ret
 
+  ret=$(join_path "/lala" "///xpto")
   assertEquals "Expect /lala/xpto" "$ret" "$base"
 
   ret=$(join_path "/lala" "/xpto////")
@@ -202,8 +204,9 @@ function find_kernel_root_Test()
 
   local fake_path="tests/.tmp/lala/xpto"
   mkdir -p $fake_path
-  local kernel_path=$(find_kernel_root $fake_path)
+  local kernel_path
 
+  kernel_path=$(find_kernel_root $fake_path)
   assertEquals "We expected to find a kernel path" "$kernel_path" "tests/.tmp"
 
   kernel_path=$(find_kernel_root "/tmp")
@@ -334,8 +337,11 @@ function update_statistics_database_Test()
 function statistics_manager_Test()
 {
   local ID
-  local this_year_and_month=$(date +%Y/%m)
-  local today=$(date +%d)
+  local this_year_and_month
+  local today
+
+  this_year_and_month=$(date +%Y/%m)
+  today=$(date +%d)
 
   setupPatch
 

--- a/tests/remote_test.sh
+++ b/tests/remote_test.sh
@@ -331,8 +331,9 @@ function kw_ssh_check_fail_cases_Test()
   setupSsh
 
   local args="--lala"
-  local ret=$(kw_ssh $args)
+  local ret
 
+  ret=$(kw_ssh $args)
   assertTrue "We expected a substring \"$INVALID_ARG: $args\", but we got \"$ret\"" '[[ $ret =~ "$INVALID_ARG: $args" ]]'
 
   args="-m"


### PR DESCRIPTION
When a declaration and an assignment happen at the same time, the
return code may be masked, so in this commit we separate them to avoid
this.

This commit fixes all occurrences of the [SC2155](https://github.com/koalaman/shellcheck/wiki/SC2155) shellcheck error

Signed-off-by: Alan Barzilay <alan.barzilay@gmail.com>