### PR TITLE
CI/CD: add shellcheck as a test in our pipeline

### DIFF
--- a/.github/workflows/shellcheck_reviewdog.yml
+++ b/.github/workflows/shellcheck_reviewdog.yml
@@ -1,0 +1,19 @@
+name: shellcheck-reviewdog
+on: [pull_request]
+jobs:
+  shellcheck:
+    name: runner / shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: shellcheck
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          level: info
+          filter_mode: added # This determines the scope of what reviewdog will report
+          fail_on_error: true
+          path: "."
+          pattern: "*.sh"
+          shellcheck_flags: "--external-sources --shell=bash --exclude=SC2016,SC2181,SC2034"


### PR DESCRIPTION
After studying the reviewdog documentation I realized it is possible to run shellcheck only on our changed files, so I have configured a new action to do this. Hopefully this will help us avoid introducing more problems into our code base while we cleanup the ones we already have.

Reviewdog can create a report in 3 levels: error, warning and info. I configured it to fail if any of these are raised, and excluded a few shellcheck errors:

 ## [SC2016](https://github.com/koalaman/shellcheck/wiki/SC2016) - Expressions don't expand in single quotes, use double quotes for that.

This is not so much an error as it is more a warning. The problem is how we use the assertTrue and assertFalse assertions of shunit, we pass commands delimited by single quotes that are seen as errors by shellcheck. We could insert a directive next to each one of these, but they are so bountiful in our code that I don´t think its worth it. I believe this particular error would just introduce noise. An example from configm_test.sh:
![image](https://user-images.githubusercontent.com/28787373/121757809-26b31180-caf5-11eb-83a0-cd026cdaef65.png)


## [SC2181](https://github.com/koalaman/shellcheck/wiki/SC2181) - Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.

As we discussed in our last meeting, we often opt to do this to improve legibility or because we need the output of the command as well as checking its return value. To avoid littering our codebase with exclude directives I think we should just exclude it from the analysis.


## [SC2034](https://github.com/koalaman/shellcheck/wiki/SC2034) - foo appears unused. Verify it or export it.

This error is an important one but it will always comes with a lot of noise from false positives. I would rather avoid littering our codebase with exclude directives. From the shellcheck wiki:

>  #### Exceptions
> 
> This warning may be falsely emitted when a variable is only referenced indirectly, and for variables that are intentionally unused.
>  ##### Indirection
> 
> It's ShellCheck's intended behavior to emit this warning for any variable that is only referenced though indirection:
> 
> `# foo generates a warning, even though it has five indirect references`
>` foo=42     `
> `name=foo`
> `echo "${!name} $((name))"`
> `export "$name"; eval "echo $name"`
> `declare -n name; echo "$name"`
> 
> This is an intentional design decision and not a bug. If you have variables that will not have direct references, consider using an associative array in bash, or just Ignore the warning.
> 
> Tracking indirect references is a common problem for compilers and static analysis tool, and it is known to be unsolvable in the most general case. There are two ways to handle unresolved indirections (which in a realistic program will essentially be all of them):
> 
>     
> - Avoid false positives by assuming all variables may potentially be used (disable all unused variable warnings)
> - Keep true positives by allowing some false positives (emit unused variable warnings that may be incorrect)
> 
> Compilers are forced to do the former, but static analysis tools generally do the latter. This includes pylint, jshint and shellcheck itself. This is a design decision meant to make the tools more helpful at the expense of some noise. For consistency and to avoid giving the impression that it should work more generally, ShellCheck does not attempt to resolve even trivial indirections.
> 

----------------------

To illustrate how this action works and to see it working in practice, I prepared [this dummy PR](https://github.com/alan-barzilay/kworkflow/pull/2) in my fork.
There may be other shellcheck errors that we disagree with, but looking at the most prevalent ones in our code I think we already decided that we agree with them and thus I think we should deal with new errors on a case by case basis, after all there are more then 400 different shellcheck errors

Closes #228 
