### PR TITLE
shellcheck: add error SC2154 to ignore list

### DIFF
--- a/.github/workflows/shellcheck_reviewdog.yml
+++ b/.github/workflows/shellcheck_reviewdog.yml
@@ -16,4 +16,4 @@ jobs:
           fail_on_error: true
           path: "."
           pattern: "*.sh"
-          shellcheck_flags: "--external-sources --shell=bash --exclude=SC2016,SC2181,SC2034"
+          shellcheck_flags: "--external-sources --shell=bash --exclude=SC2016,SC2181,SC2034,SC2154"


### PR DESCRIPTION
SC2154 - foo is referenced but not assigned

As discussed in PR #330, this is a common false positive in our codebase
caused by our include function that renders shellcheck incapable of
seeing imports, so we will start to ignore it occurrence.

Signed-off-by: Alan Barzilay <alan.barzilay@gmail.com>