### PR TITLE
src: mk: run make olddefconfig before building

### DIFF
--- a/documentation/tutorials/buildlinux.rst
+++ b/documentation/tutorials/buildlinux.rst
@@ -82,7 +82,10 @@ And it can be even simpler by just running::
 
   kw b
 
+.. note:
+    kw runs `make olddefconfig` before building.
+
 Well, that's it. kw will automatically infer the number of job slots for
-compiling based on the number of cores of your machine (i.e. when running make 
+compiling based on the number of cores of your machine (i.e. when running make
 -jNUMBER, NUMBER is an integer that specifies the number of processes that will
 run at the same time), and compilation will begin!

--- a/src/build.sh
+++ b/src/build.sh
@@ -90,6 +90,11 @@ function kernel_build()
     esac
   done
 
+  if [ -f "$(join_path "$PWD" '.config')" ]; then
+    local mkflag=${flag:-'SILENT'}
+    cmd_manager "$mkflag" 'make olddefconfig &> /dev/null'
+  fi
+
   if [ -x "$(command -v nproc)" ]; then
     PARALLEL_CORES=$(nproc --all)
   else

--- a/tests/build_test.sh
+++ b/tests/build_test.sh
@@ -92,6 +92,14 @@ function test_kernel_build()
   expected_result="make -j$PARALLEL_CORES ARCH=x86_64 "
   assertEquals "($LINENO)" "$expected_result" "${output}"
 
+  cp "$original_dir/$SAMPLES_DIR/.config" .config
+  output=$(kernel_build 'TEST_MODE' | head -2) # Remove statistics output
+  declare -a expected_result=(
+    'make olddefconfig &> /dev/null'
+    "make -j$PARALLEL_CORES ARCH=x86_64"
+  )
+  compare_command_sequence expected_result[@] "$output" "$LINENO"
+  rm .config
 }
 
 function test_build_info()


### PR DESCRIPTION
Runs `make olddefconfig` before building kernel