### PR TITLE
shellcheck: address SC2164

### DIFF
--- a/src/checkpatch_wrapper.sh
+++ b/src/checkpatch_wrapper.sh
@@ -76,12 +76,12 @@ function execute_checkpatch()
       continue
     fi
 
-    cd "$kernel_root"
+    cd "$kernel_root" || exit_msg 'It was not possible to move to kernel root dir'
 
     cmd_manager "$flag" "$cmd_script $file"
     [[ "$?" != 0 ]] && say "$SEPARATOR"
 
-    cd "$original_working_dir"
+    cd "$original_working_dir" || exit_msg 'It was not possible to move back from kernel dir'
   done
 }
 

--- a/src/config_manager.sh
+++ b/src/config_manager.sh
@@ -37,12 +37,12 @@ function save_config_file()
 
   if [[ ! -d "$dot_configs_dir" || ! -d "$dot_configs_dir/$metadata_dir" ]]; then
     mkdir -p "$dot_configs_dir"
-    cd "$dot_configs_dir"
+    cd "$dot_configs_dir" || exit_msg 'It was not possible to move to configs dir'
     git init --quiet
     mkdir -p "$metadata_dir" "$configs_dir"
   fi
 
-  cd "$dot_configs_dir"
+  cd "$dot_configs_dir" || exit_msg 'It was not possible to move to configs dir'
 
   # Check if the metadata related to .config file already exists
   if [[ ! -f "$metadata_dir/$name" ]]; then
@@ -50,7 +50,7 @@ function save_config_file()
   elif [[ "$force" != 1 ]]; then
     if [[ $(ask_yN "$name already exists. Update?") =~ "0" ]]; then
       complain "Save operation aborted"
-      cd "$original_path"
+      cd "$original_path" || exit_msg 'It was not possible to move back from configs dir'
       exit 0
     fi
   fi
@@ -69,7 +69,7 @@ function save_config_file()
     success "Saved $name"
   fi
 
-  cd "$original_path"
+  cd "$original_path" || exit_msg 'It was not possible to move back from configs dir'
 }
 
 function list_configs()
@@ -173,10 +173,10 @@ function remove_config()
 
   basic_config_validations "$target" "$force" "Remove" "$msg"
 
-  cd "$dot_configs_dir"
+  cd "$dot_configs_dir" || exit_msg 'It was not possible to move to configs dir'
   git rm "$configs_dir/$target" "$dot_configs_dir/$metadata_dir/$target" > /dev/null 2>&1
   git commit -m "Removed $target config: $USER - $(date)" > /dev/null 2>&1
-  cd "$original_path"
+  cd "$original_path" || exit_msg 'It was not possible to move back from configs dir'
 
   say "The $target config file was removed from kw management"
 

--- a/src/get_maintainer_wrapper.sh
+++ b/src/get_maintainer_wrapper.sh
@@ -146,9 +146,9 @@ function execute_get_maintainer()
     return 1
   fi
 
-  cd "$kernel_root"
+  cd "$kernel_root" || exit_msg 'It was not possible to move to kernel root dir'
   local -r script_output="$(eval perl "$script" "$script_options" "$FILE_OR_DIR")"
-  cd "$original_working_dir"
+  cd "$original_working_dir" || exit_msg 'It was not possible to move back from kernel dir'
 
   say "$SEPARATOR"
   if "$update_patch"; then

--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -356,3 +356,17 @@ function command_exists()
   fi
   return 22 # EINVAL
 }
+
+# This function exits with a custom error message
+#
+# @err The error code to be used on exit, it takes the return code of the
+#        last command executed as default
+# @msg The custom message to be displayed
+function exit_msg()
+{
+  local err=${2:-"$?"}
+  local msg=${1:-'Something went wrong!'}
+
+  complain "$msg"
+  exit "$err"
+}

--- a/src/plugins/kernel_install/deploy.sh
+++ b/src/plugins/kernel_install/deploy.sh
@@ -30,7 +30,7 @@
 #    architecture="$4"
 #    flag="$5"
 target_kw_deploy="$HOME/kw_deploy"
-cd "$target_kw_deploy"
+cd "$target_kw_deploy" || exit_msg 'It was not possible to move to deploy dir'
 
 # Load specific distro script
 . distro_deploy.sh --source-only

--- a/src/statistics.sh
+++ b/src/statistics.sh
@@ -300,7 +300,7 @@ function month_statistics()
   fi
 
   current_path=$(pwd)
-  cd "$month_path" || exit
+  cd "$month_path" || exit_msg 'It was not possible to move to month dir'
   shopt -s nullglob
   for day in *; do
     all_file_data=$(cat "$day")
@@ -308,7 +308,7 @@ function month_statistics()
 
     all_data="${all_data}${all_file_data}\n"
   done
-  cd "$current_path" || exit
+  cd "$current_path" || exit_msg 'It was not possible to move back from month dir'
 
   if [[ -z "$all_data" ]]; then
     say "Sorry, kw does not have any record for $month"

--- a/tests/build_test.sh
+++ b/tests/build_test.sh
@@ -36,21 +36,22 @@ setUp()
 {
   # In this case we actually want to exit, since all tests below rely on
   # being in a kernel root
-  cd "$FAKE_KERNEL" ||
-    {
-      fail 'Was not able to move into fake kernel directory'
-      exit
-    }
+  cd "$FAKE_KERNEL" || {
+    fail "($LINENO) It was not possible to move into fake kernel directory"
+    return
+  }
 }
 
 tearDown()
 {
-  cd "$original_dir" || fail 'Was not able to move back to original directory'
+  cd "$original_dir" || {
+    fail "($LINENO) It was not possible to move back to original directory"
+    return
+  }
 }
 
 function test_kernel_build()
 {
-  local ID
   local expected_result
 
   output=$(kernel_build 'TEST_MODE' '--menu')
@@ -69,11 +70,10 @@ function test_kernel_build()
   expected_result="make -j$PARALLEL_CORES ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-"
   assertEquals "($LINENO)" "$expected_result" "${output}"
 
-  cd "$original_dir" ||
-    {
-      fail 'Was not able to move back to original directory'
-      return
-    }
+  cd "$original_dir" || {
+    fail "($LINENO) It was not possible to move back to original directory"
+    return
+  }
 
   output=$(kernel_build 'TEST_MODE')
   ret="$?"
@@ -83,11 +83,10 @@ function test_kernel_build()
   cp "$KW_CONFIG_SAMPLE_X86" "$FAKE_KERNEL/kworkflow.config"
   parse_configuration "$FAKE_KERNEL/kworkflow.config"
 
-  cd "$FAKE_KERNEL" ||
-    {
-      fail 'Was not able to move into temporary directory'
-      return
-    }
+  cd "$FAKE_KERNEL" || {
+    fail "($LINENO) It was not possible to move into temporary directory"
+    return
+  }
 
   output=$(kernel_build 'TEST_MODE' | head -1) # Remove statistics output
   expected_result="make -j$PARALLEL_CORES ARCH=x86_64 "

--- a/tests/configm_test.sh
+++ b/tests/configm_test.sh
@@ -22,10 +22,16 @@ function setUp()
 {
   local -r current_path="$PWD"
 
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   touch .config
   echo "$CONTENT" > .config
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 
   mkdir "$SHUNIT_TMPDIR/configs"
   KW_DATA_DIR="$SHUNIT_TMPDIR"
@@ -76,7 +82,10 @@ function test_save_config_file_check_save_failures()
   local ret=0
 
   # Test without config file -> should fail
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   rm -f .config
   ret=$(save_config_file "$NO_FORCE $NAME_1" "$DESCRIPTION_1")
   assert_equals_helper 'No .config file should return ENOENT' "$LINENO" "$?" "2"
@@ -87,7 +96,10 @@ function test_save_config_file_check_save_failures()
   assert_equals_helper "Should return ENOENT, because '.config' != '.configuration'" "$LINENO" "$?" "2"
   rm .configuration
 
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 function test_save_config_file_check_directories_creation()
@@ -95,9 +107,15 @@ function test_save_config_file_check_directories_creation()
   local current_path="$PWD"
 
   # There's no configs yet, initialize it
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 
   # Check if all the expected files were created
   assertTrue "$LINENO: The configs dir was not created" '[[ -d $configs_path ]]'
@@ -114,18 +132,30 @@ function test_save_config_file_check_saved_config()
   local tmp
 
   # There's no configs yet, initialize it
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 
   msg="Failed to find $NAME_1"
   assertTrue "$LINENO: $msg" '[[ -f $configs_path/configs/$NAME_1 ]]'
   msg="Failed the metadata related to $NAME_1"
   assertTrue "$LINENO: $msg" '[[ -f $configs_path/metadata/$NAME_1 ]]'
 
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   ret=$(save_config_file $NO_FORCE $NAME_2)
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 
   msg="Failed to find $NAME_2"
   assertTrue "$LINENO: $msg" '[[ -f $configs_path/configs/$NAME_2 ]]'
@@ -145,17 +175,29 @@ function test_save_config_file_check_description()
   local tmp
 
   # There's no configs yet, initialize it
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 
   tmp=$(cat "$configs_path/metadata/$NAME_1")
   msg="The description content for $NAME_1 does not match"
   assertTrue "$LINENO: $msg" '[[ $tmp = $DESCRIPTION_1 ]]'
 
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   ret=$(save_config_file $NO_FORCE $NAME_2 "$DESCRIPTION_2")
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 
   tmp=$(cat "$configs_path/metadata/$NAME_2")
   msg="The description content for $NAME_2 does not match"
@@ -168,12 +210,21 @@ function test_save_config_file_check_git_save_schema()
   local ret=0
 
   # There's no configs yet, initialize it
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
   ret=$(save_config_file $NO_FORCE $NAME_2 "$DESCRIPTION_2")
-  cd "configs"
+  cd "configs" || {
+    fail "($LINENO) It was not possible to move to configs directory"
+    return
+  }
   ret=$(git rev-list --all --count)
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from configs directory"
+    return
+  }
 
   assertTrue "$LINENO: We expected 2 commits, but we got $ret" '[[ $ret = "2" ]]'
 }
@@ -184,10 +235,16 @@ function test_save_config_file_check_force()
   local ret=0
 
   # There's no configs yet, initialize it
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   ret=$(save_config_file $YES_FORCE $NAME_2 "$DESCRIPTION_2")
   ret=$(save_config_file $YES_FORCE $NAME_2 "$DESCRIPTION_2")
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
   assertTrue "$LINENO: We expected no changes" '[[ $ret =~ Warning ]]'
 }
 
@@ -208,10 +265,16 @@ function test_list_config_normal_output()
   local msg
 
   # There's no configs yet, initialize it
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   ret=$(save_config_file $YES_FORCE $NAME_1 "$DESCRIPTION_1")
   ret=$(save_config_file $YES_FORCE $NAME_2 "$DESCRIPTION_2")
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 
   # There's no configs yet, initialize it
   ret=$(list_configs)
@@ -261,13 +324,22 @@ function test_get_config()
   )
 
   # There's no configs yet, initialize it
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
   ret=$(save_config_file $NO_FORCE $NAME_2 "$DESCRIPTION_2")
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 
   # Case 1: We already have a local config, pop up with replace question
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   output=$(echo 'y' | get_config "$NAME_1")
   compare_command_sequence expected_output[@] "$output" "$LINENO"
 
@@ -275,7 +347,10 @@ function test_get_config()
   rm -f .config
   output=$(get_config "$NAME_1")
   ret=$(cat .config)
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 
   assertTrue "$LINENO: We expected $CONTENT, but we got $ret" '[[ $ret =~ $CONTENT ]]'
 }
@@ -286,25 +361,43 @@ function test_get_config_with_force()
   local ret=0
 
   # There's no configs yet, initialize it
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
   ret=$(save_config_file $NO_FORCE $NAME_2 "$DESCRIPTION_2")
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 
   # Case 1: There's no local .config file
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   rm -f .config
   get_config "$NAME_1" 1 > /dev/null 2>&1
   ret=$(cat .config)
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 
   assertTrue "$LINENO: We expected $CONTENT, but we got $ret" '[[ $ret =~ $CONTENT ]]'
 
   # Case 2: There's a .config file
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   get_config "$NAME_2" 1 > /dev/null 2>&1
   ret=$(cat .config)
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 
   assertTrue "$LINENO: We expected $CONTENT, but we got $ret" '[[ $ret =~ $CONTENT ]]'
 }
@@ -328,7 +421,10 @@ function test_remove_config()
   local current_path="$PWD"
   local ret=0
 
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   ret=$(save_config_file $NO_FORCE $NAME_1 "$DESCRIPTION_1")
   ret=$(save_config_file $NO_FORCE $NAME_2 "$DESCRIPTION_2")
   ret=$(ls configs/configs -1 | wc -l)
@@ -344,7 +440,10 @@ function test_remove_config()
   remove_config "$NAME_2" 1 > /dev/null 2>&1
   assertTrue "$LINENO: We expected no file related to config" '[[ ! -f configs/configs ]]'
 
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 invoke_shunit

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -115,7 +115,10 @@ function test_kernel_deploy()
   local ID
   local original="$PWD"
 
-  cd "$FAKE_KERNEL"
+  cd "$FAKE_KERNEL" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
 
   # From kworkflow.config file we expect 0 0 1 127.0.0.1:3333 0 0
   ID=1
@@ -202,7 +205,10 @@ function test_kernel_deploy()
   expected_result="$?"
   assertEquals "($ID) No config:" "$expected_result" "22"
 
-  cd "$original"
+  cd "$original" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 function test_modules_install_to()
@@ -213,7 +219,10 @@ function test_modules_install_to()
   # Copy test.preset to remote
   local make_install_cmd="make INSTALL_MOD_PATH=$test_path modules_install"
 
-  cd "$test_path"
+  cd "$test_path" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
 
   ID=1
   output=$(modules_install_to "$test_path" "TEST_MODE")
@@ -222,7 +231,10 @@ function test_modules_install_to()
     fail "$ID - Expected \"$output\" to be \"$make_install_cmd\""
   fi
 
-  cd "$original"
+  cd "$original" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 function test_kernel_install()
@@ -255,7 +267,10 @@ function test_kernel_install()
     "$cmd_deploy_image"
   )
 
-  cd "$FAKE_KERNEL"
+  cd "$FAKE_KERNEL" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
 
   output=$(kernel_install "1" "test" "TEST_MODE" "3" "127.0.0.1:3333")
   compare_command_sequence expected_cmd[@] "$output" "$LINENO"
@@ -278,12 +293,21 @@ function test_kernel_install()
   compare_command_sequence expected_cmd[@] "$output" "$LINENO"
 
   # We want to test an corner case described by the absence of mkinitcpio
-  cd "$original"
+  cd "$original" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
   tearDown
   setUp "no_mkinitcpio"
-  cd "$FAKE_KERNEL"
+  cd "$FAKE_KERNEL" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   output=$(kernel_install "0" "test" "TEST_MODE" "3" "127.0.0.1:3333")
-  cd "$original"
+  cd "$original" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 
   local preset_file="$KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR/$name.preset"
   assertTrue "The mkinit file was not created" '[[ -f "$preset_file" ]]'
@@ -306,11 +330,17 @@ function test_kernel_install_x86_64()
   local deploy_params="$name debian bzImage $reboot x86_64 'remote' TEST_MODE"
   local deploy_cmd="bash $REMOTE_KW_DEPLOY/deploy.sh --kernel_update $deploy_params"
 
-  cd "$original"
+  cd "$original" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
   configurations=()
   cp "$KW_CONFIG_SAMPLE_X86" "$FAKE_KERNEL/kworkflow.config"
   parse_configuration "$FAKE_KERNEL/kworkflow.config"
-  cd "$FAKE_KERNEL"
+  cd "$FAKE_KERNEL" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
 
   # For this test we expected three steps:
   # 1. Copy preset file (cmd_preset_remote)
@@ -343,7 +373,10 @@ function test_kernel_install_x86_64()
   assertEquals "($LINENO): " "$output" "$expected_msg"
   assert_equals_helper "Could not find a valid image" "$LINENO" "$expected_msg" "$output"
 
-  cd "$original"
+  cd "$original" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 function test_kernel_modules()
@@ -396,7 +429,10 @@ function test_kernel_modules()
     "$exec_module_install"
   )
 
-  cd "$FAKE_KERNEL"
+  cd "$FAKE_KERNEL" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
 
   setupRemote
 
@@ -419,7 +455,10 @@ function test_kernel_modules()
   expected_output="sudo -E make modules_install"
   assertEquals "$ID: " "$output" "$expected_output"
 
-  cd "$original"
+  cd "$original" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 function test_kernel_modules_local()
@@ -428,11 +467,17 @@ function test_kernel_modules_local()
   local original="$PWD"
   local cmd="sudo -E make modules_install"
 
-  cd "$FAKE_KERNEL"
+  cd "$FAKE_KERNEL" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   ID=1
   output=$(modules_install "TEST_MODE" "2")
   assertFalse "$ID - Expected $output to be $cmd" '[[ "$cmd" != "$output" ]]'
-  cd "$original"
+  cd "$original" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 function test_kernel_install_local()
@@ -458,7 +503,10 @@ function test_kernel_install_local()
   # we have to update KW_PLUGINS_DIR for this test for making sure that we use a
   # real plugin.
   export KW_PLUGINS_DIR="../../src/plugins"
-  cd "$FAKE_KERNEL"
+  cd "$FAKE_KERNEL" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
 
   output=$(kernel_install "1" "test" "TEST_MODE" "2")
   compare_command_sequence expected_cmd[@] "$output" "$LINENO"
@@ -469,7 +517,10 @@ function test_kernel_install_local()
   ret="$?"
   assertEquals "($LINENO)" '1' "$ret"
 
-  cd "$original"
+  cd "$original" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 # This test validates the correct behavior of list kernel on a remote machine
@@ -504,7 +555,10 @@ function test_list_remote_kernels()
     "$remote_list_cmd"
   )
 
-  cd "$FAKE_KERNEL"
+  cd "$FAKE_KERNEL" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
 
   setupRemote
 
@@ -516,7 +570,10 @@ function test_list_remote_kernels()
     ((count++))
   done <<< "$output"
 
-  cd "$original"
+  cd "$original" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 function test_kernel_uninstall()
@@ -548,7 +605,10 @@ function test_kernel_uninstall()
     "$kernel_uninstall_cmd"
   )
 
-  cd "$FAKE_KERNEL"
+  cd "$FAKE_KERNEL" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
 
   setupRemote
 
@@ -575,7 +635,10 @@ function test_kernel_uninstall()
 
   compare_command_sequence expected_cmd[@] "$output" "$ID"
 
-  cd "$original"
+  cd "$original" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 function test_cleanup_after_deploy()

--- a/tests/explore_test.sh
+++ b/tests/explore_test.sh
@@ -15,7 +15,10 @@ function setUp()
 {
   local -r current_path="$PWD"
 
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   # Setup git repository for test
   git init &> /dev/null
 
@@ -28,7 +31,10 @@ function setUp()
 
   cp "$current_path/tests/samples/grep_check.c" .git
 
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 function tearDown()
@@ -48,7 +54,10 @@ function test_explore_files_under_git_repo()
   output=$(explore)
   assertEquals "($ID) - Expected an error message." "$MSG_OUT" "$output"
 
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
 
   ID=2
   MSG_OUT="camelCase(void)"
@@ -76,7 +85,10 @@ function test_explore_files_under_git_repo()
   output=$(explore "GNU grep" | cut -d: -f1)
   assertEquals "($ID)" "grep_check.c" "$output"
 
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 function test_explore_git_log()
@@ -86,7 +98,10 @@ function test_explore_git_log()
   local commit_msg
   local -r current_path="$PWD"
 
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
 
   ID=1
   commit_msg="Commit number 2"
@@ -94,7 +109,10 @@ function test_explore_git_log()
   output=$(explore --log "$commit_msg" | grep "$commit_msg" | awk '{print $1, $2, $3}')
   assertEquals "($ID)" "$commit_msg" "$output"
 
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 function test_explore_grep()
@@ -103,7 +121,10 @@ function test_explore_grep()
   local expected_result
   local -r current_path="$PWD"
 
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
 
   ID=1
   output=$(explore --grep "GNU grep" | cut -d/ -f2)
@@ -114,7 +135,10 @@ function test_explore_grep()
   expected_result="grep --color -nrI . -e \"GNU grep\""
   assertEquals "($ID)" "$expected_result" "$output"
 
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 function test_explore_git()
@@ -123,7 +147,10 @@ function test_explore_git()
   local expected_result
   local -r current_path="$PWD"
 
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
 
   ID=1
   output=$(explore --all "GNU grep" "." "TEST_MODE")
@@ -142,7 +169,10 @@ function test_explore_git()
   output=$(explore --all "GNU grep" | cut -d: -f1)
   assertEquals "($ID)" "grep_check.c" "$output"
 
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 function test_explore_parser()

--- a/tests/get_maintainer_wrapper_test.sh
+++ b/tests/get_maintainer_wrapper_test.sh
@@ -54,12 +54,18 @@ function oneTimeSetUp()
   cp -f tests/samples/MAINTAINERS "$FAKE_KERNEL"/MAINTAINERS
   cp -f tests/external/get_maintainer.pl "$FAKE_KERNEL"/scripts/
   cp -f tests/samples/update_patch_test{_model,}{,2}.patch "$FAKE_KERNEL"/
-  cd "$FAKE_KERNEL"
+  cd "$FAKE_KERNEL" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   touch fs/some_file
   git init --quiet
   git add fs/some_file
   git commit --quiet -m "Test message"
-  cd "$original_dir"
+  cd "$original_dir" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 function oneTimeTearDown()
@@ -87,26 +93,38 @@ function test_execute_get_maintainer()
   ret="$(execute_get_maintainer tests/.tmp)"
   multilineAssertEquals "$ret" "$CORRECT_TMP_MSG"
 
-  cd "$FAKE_KERNEL"
+  cd "$FAKE_KERNEL" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   ret="$(execute_get_maintainer .)"
   multilineAssertEquals "$ret" "$CORRECT_TMP_MSG"
 
   ret="$(execute_get_maintainer fs)"
   multilineAssertEquals "$ret" "$CORRECT_TMP_FS_MSG"
 
-  cd fs
+  cd fs || {
+    fail "($LINENO) It was not possible to move to fs directory"
+    return
+  }
   ret="$(execute_get_maintainer ..)"
   multilineAssertEquals "$ret" "$CORRECT_TMP_MSG"
 
   ret="$(execute_get_maintainer .)"
   multilineAssertEquals "$ret" "$CORRECT_TMP_FS_MSG"
-  cd "$original_dir"
+  cd "$original_dir" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 function test_execute_get_maintainer_patch()
 {
   local original_dir="$PWD"
-  cd "$FAKE_KERNEL"
+  cd "$FAKE_KERNEL" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
 
   ret="$(execute_get_maintainer update_patch_test.patch)"
   multilineAssertEquals "$ret" "$CORRECT_TMP_MSG"
@@ -133,7 +151,10 @@ function test_execute_get_maintainer_patch()
   multilineAssertEquals "$ret" "$CORRECT_TMP_PATCH2_MSG"
   assertFileEquals update_patch_test{,_model}2.patch
 
-  cd "$original_dir"
+  cd "$original_dir" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 invoke_shunit

--- a/tests/kw_config_loader_test.sh
+++ b/tests/kw_config_loader_test.sh
@@ -72,9 +72,15 @@ function test_parse_configuration_output()
 
   cp tests/samples/kworkflow.config "$TMP_DIR/"
 
-  pushd "$TMP_DIR" > /dev/null
+  pushd "$TMP_DIR" > /dev/null || {
+    fail "($LINENO) It was not possible to pushd into temp directory"
+    return
+  }
   parse_configuration "$PWD/kworkflow.config"
-  popd > /dev/null
+  popd > /dev/null || {
+    fail "($LINENO) It was not possible to popd from temp directory"
+    return
+  }
 
   assertConfigurations configurations expected_configurations
 

--- a/tests/kwlib_test.sh
+++ b/tests/kwlib_test.sh
@@ -36,7 +36,10 @@ function setupFakeKernelRepo()
   # dir is also created inside $SHUNIT_TMPDIR so that get_maintainer.pl thinks
   # it is a git repo. This is done in order to avoid some warnings that
   # get_maintainer.pl prints when no .git is found.
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   touch "COPYING"
   touch "CREDITS"
   touch "Kbuild"
@@ -53,7 +56,10 @@ function setupFakeKernelRepo()
   mkdir -p "lib"
   mkdir -p "scripts"
   mkdir -p ".git"
-  cd "$ORIGINAL_DIR" || fail ''
+  cd "$ORIGINAL_DIR" || {
+    fail "($LINENO) It was not possible to move back to original directory"
+    return
+  }
   cp -f tests/samples/MAINTAINERS "$SHUNIT_TMPDIR/MAINTAINERS"
   cp -f tests/external/get_maintainer.pl "$SHUNIT_TMPDIR/scripts/"
 }
@@ -61,7 +67,10 @@ function setupFakeKernelRepo()
 function tearDown()
 {
   rm -rf "$FAKE_STATISTICS_PATH"
-  cd "$ORIGINAL_DIR" || fail 'Was not able to move back to original directory'
+  cd "$ORIGINAL_DIR" || {
+    fail "($LINENO) It was not possible to move back to original directory"
+    return
+  }
 }
 
 function test_is_kernel_root()
@@ -75,7 +84,10 @@ function test_is_kernel_root()
 function test_cmd_manager_check_silent_option()
 {
   setupFakeKernelRepo
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   ret=$(cmd_manager SILENT ls)
 
   assertFalse "We used SILENT mode, we should not find ls" '[[ $ret =~ ls ]]'
@@ -96,7 +108,10 @@ function test_cmd_manager_check_silent_option()
 function test_cmdManagerSAY_COMPLAIN_WARNING_SUCCESS()
 {
   setupFakeKernelRepo
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   ret=$(cmd_manager ls)
 
   assertTrue "We expected to find the ls command" '[[ $ret =~ ls ]]'

--- a/tests/kwlib_test.sh
+++ b/tests/kwlib_test.sh
@@ -350,4 +350,31 @@ function test_command_exists()
   assertEquals "$LINENO - We expected 0 as a return" 0 "$ret"
 }
 
+function test_exit_msg()
+{
+  local default_msg='Something went wrong!'
+  local custom_msg='Custom error message.'
+
+  # The `:` operation always returns 0, giving us consistent outputs
+  output=$(: && exit_msg)
+  ret="$?"
+  assertEquals "($LINENO) We expected the default msg" "$default_msg" "$output"
+  assertEquals "($LINENO) We expected 0 as a return" 0 "$ret"
+
+  output=$(: && exit_msg "$custom_msg")
+  ret="$?"
+  assertEquals "($LINENO) We expected the custom msg" "$custom_msg" "$output"
+  assertEquals "($LINENO) We expected 0 as a return" 0 "$ret"
+
+  output=$(: && exit_msg '' 3)
+  ret="$?"
+  assertEquals "($LINENO) We expected the default msg" "$default_msg" "$output"
+  assertEquals "($LINENO) We expected 3 as a return" 3 "$ret"
+
+  output=$(: && exit_msg "$custom_msg" 3)
+  ret="$?"
+  assertEquals "($LINENO) We expected the custom msg" "$custom_msg" "$output"
+  assertEquals "($LINENO) We expected 3 as a return" 3 "$ret"
+}
+
 invoke_shunit

--- a/tests/plugins/kernel_install/utils_test.sh
+++ b/tests/plugins/kernel_install/utils_test.sh
@@ -123,7 +123,10 @@ function test_do_uninstall_cmd_sequence()
   compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
 
   # Good sequence
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   mkdir -p "$prefix"
   mk_fake_remote_system "$prefix" "$target"
 
@@ -160,7 +163,10 @@ function test_do_uninstall_cmd_sequence()
   output=$(do_uninstall "$target" "$prefix" 'TEST_MODE')
   compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
 
-  cd "$TEST_ROOT_PATH"
+  cd "$TEST_ROOT_PATH" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 function test_install_modules()
@@ -342,7 +348,10 @@ function test_install_kernel_vm()
     'update_debian_boot_loader_mock'
   )
 
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   shopt -s expand_aliases
   alias findmnt='findmnt_mock'
   alias vm_umount='vm_umount'
@@ -350,7 +359,10 @@ function test_install_kernel_vm()
   output=$(install_kernel "$name" 'debian' "$kernel_image_name" "$reboot" "$architecture" "$target" 'TEST_MODE')
   compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
 
-  cd "$TEST_ROOT_PATH"
+  cd "$TEST_ROOT_PATH" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 invoke_shunit

--- a/tests/remote_test.sh
+++ b/tests/remote_test.sh
@@ -34,9 +34,15 @@ function oneTimeSetUp()
   cp -f tests/samples/kworkflow.config "$TEST_PATH"
   cp -f tests/samples/dmesg "$TEST_PATH"
 
-  cd "$TEST_PATH" || fail 'Was not able to move to temporary directory'
+  cd "$TEST_PATH" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
   load_configuration
-  cd "$current_path" || fail 'Was not able return to original directory'
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible return to original directory"
+    return
+  }
 
   local -r kernel_install_path="kernel_install"
 

--- a/tests/signal_manager_test.sh
+++ b/tests/signal_manager_test.sh
@@ -12,7 +12,10 @@ function oneTimeSetUp()
 
 function setUp()
 {
-  cd "$SHUNIT_TMPDIR" || fail "($LINENO): Was not able to cd into temporary directory"
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO): It was not possible to cd into temporary directory"
+    return
+  }
 }
 
 function write_to_file()

--- a/tests/vm_test.sh
+++ b/tests/vm_test.sh
@@ -37,7 +37,10 @@ function test_vm_mount()
   tearDown
   setUp
 
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
 
   ID=1
   output=$(vm_mount "TEST_MODE")
@@ -65,7 +68,10 @@ function test_vm_mount()
   output=$(vm_mount "TEST_MODE" "" "$mount_point")
   compare_command_sequence expected_cmd[@] "$output" "$ID"
 
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 
   tearDown
 }
@@ -89,7 +95,10 @@ function test_vm_umount()
     "$guestmount_cmd"
   )
 
-  cd "$SHUNIT_TMPDIR" || fail 'Was not able to move to temporary directory'
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
 
   ID=1
   output=$(vm_umount "TEST_MODE")
@@ -106,7 +115,10 @@ function test_vm_umount()
   output=$(vm_umount "TEST_MODE" "" "$mount_point")
   compare_command_sequence expected_cmd[@] "$output" "$ID"
 
-  cd "$current_path"
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 invoke_shunit


### PR DESCRIPTION
Make kw exit if a `cd` command fails, in fixing shellcheck's SC2164
warnings.

Closes #319

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@usp.br>