### PR TITLE
New option to show hardware information

### DIFF
--- a/documentation/man/kw.rst
+++ b/documentation/man/kw.rst
@@ -384,6 +384,18 @@ Users can follow the timebox section status by using:
 *--list,-l*: This command shows information associated with each Pomodoro
 timebox created by the user.
 
+device [--local]
+~~~~~~~~~~~~~~~~
+In order to easily retrieve basic information about the hardware of a target
+machine, kw provides the 'device' option, which outputs details such as:
+- CPU architecture
+- RAM
+- Operating system
+- Storage device
+- GPU
+
+1. --local: Show hardware information from host machine.
+
 df, diff [OPTIONS] FILE1 FILE2
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 This is a wrapper to some useful usage of diff command. By default, it shows

--- a/documentation/man/kw.rst
+++ b/documentation/man/kw.rst
@@ -384,8 +384,8 @@ Users can follow the timebox section status by using:
 *--list,-l*: This command shows information associated with each Pomodoro
 timebox created by the user.
 
-device [--local|--vm]
-~~~~~~~~~~~~~~~~~~~~~
+device [--local|--vm|--remote [REMOTE:PORT]]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In order to easily retrieve basic information about the hardware of a target
 machine, kw provides the 'device' option, which outputs details such as:
 - CPU architecture
@@ -396,6 +396,7 @@ machine, kw provides the 'device' option, which outputs details such as:
 
 1. --local: Show hardware information from host machine.
 2. --vm: Show hardware information from virtual machine.
+3. --remote: Show hardware information from remote machine.
 
 df, diff [OPTIONS] FILE1 FILE2
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/documentation/man/kw.rst
+++ b/documentation/man/kw.rst
@@ -384,8 +384,8 @@ Users can follow the timebox section status by using:
 *--list,-l*: This command shows information associated with each Pomodoro
 timebox created by the user.
 
-device [--local]
-~~~~~~~~~~~~~~~~
+device [--local|--vm]
+~~~~~~~~~~~~~~~~~~~~~
 In order to easily retrieve basic information about the hardware of a target
 machine, kw provides the 'device' option, which outputs details such as:
 - CPU architecture
@@ -395,6 +395,7 @@ machine, kw provides the 'device' option, which outputs details such as:
 - GPU
 
 1. --local: Show hardware information from host machine.
+2. --vm: Show hardware information from virtual machine.
 
 df, diff [OPTIONS] FILE1 FILE2
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/kw
+++ b/kw
@@ -201,6 +201,13 @@ function kw()
         report "$@"
       )
       ;;
+    device)
+      (
+        include "$KW_LIB_DIR/device_info.sh"
+
+        device_info "$@"
+      )
+      ;;
     clear-cache)
       include "$KW_LIB_DIR/deploy.sh"
 

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -7,7 +7,7 @@ function _kw_autocomplete()
   kw_options="explore e bd build b init ssh s clear-cache
                 mount mo umount um vars up u codestyle c configm g
                 maintainers m deploy d help h version statistics
-                pomodoro p report r drm diff df --version -v man"
+                pomodoro p report r device drm diff df --version -v man"
 
   # By default, autocomplete with kw_options
   if [[ ${previous_command} == kw ]]; then

--- a/src/device_info.sh
+++ b/src/device_info.sh
@@ -1,0 +1,369 @@
+# This file deals with functions related to hardware information
+
+include "$KW_LIB_DIR/remote.sh"
+include "$KW_LIB_DIR/kwlib.sh"
+
+declare -gA device_info_data=(['ram']='' # RAM memory in KB
+  ['cpu_model']=''                       # CPU model vendor
+  ['cpu_currently']=''                   # Current frequency of CPU in MHz
+  ['cpu_max']=''                         # Maximum frequency of CPU in MHz
+  ['cpu_min']=''                         # Minimum frequency of CPU in MHz
+  ['desktop_environment']=''             # Desktop environment
+  ['disk_size']=''                       # Disk size in KB
+  ['root_path']=''                       # Root directory path
+  ['fs_mount']=''                        # Path where root is mounted
+  ['os']=''                              # Operating system name
+  ['motherboard_name']=''                # Motherboard name
+  ['motherboard_vendor']=''              # Motherboard vendor
+  ['chassis']='')                        # Chassis type
+
+declare -gA gpus
+
+declare -gA device_options
+
+# This function calls other functions to process and display the hardware
+# information of a target machine.
+function device_info()
+{
+  local ret
+  device_info_parser "$@"
+
+  ret="$?"
+  if [[ "$ret" != 0 ]]; then
+    return "$ret"
+  fi
+
+  learn_device "${device_options['target']}"
+  show_data
+}
+
+# This function populates the ram element from the device_info_data global
+# variable with the total RAM memory from the target machine in kB.
+#
+# @target Target machine
+function get_ram()
+{
+  local target="$1"
+  local flag="$2"
+  local ram
+  local cmd
+
+  flag=${flag:-'SILENT'}
+  cmd="[ -f '/proc/meminfo' ] && cat /proc/meminfo | grep 'MemTotal' | grep -o '[0-9]*'"
+  case "$target" in
+    2) # LOCAL_TARGET
+      ram=$(cmd_manager "$flag" "$cmd")
+      ;;
+  esac
+
+  if [[ "$flag" == 'TEST_MODE' ]]; then
+    echo "$ram"
+    return 0
+  fi
+
+  device_info_data['ram']="$ram"
+}
+
+# This function provides the model and frequency of the CPU from a machine
+#
+# @target Target machine
+function get_cpu()
+{
+  local target="$1"
+  local flag="$2"
+  local cpu_model
+  local cpu_frequency
+  local cpu_currently
+  local cpu_max
+  local cpu_min
+
+  flag=${flag:-'SILENT'}
+  cmd_frequency="lscpu | grep MHz | sed -r 's/(CPU.*)/\t\t\1/'"
+  cmd_model="lscpu | grep 'Model name:' | sed -r 's/Model name:\s+//g' | cut -d' ' -f1"
+  case "$target" in
+    2) # LOCAL_TARGET
+      cpu_model=$(cmd_manager "$flag" "$cmd_model")
+      cpu_frequency=$(cmd_manager "$flag" "$cmd_frequency")
+      ;;
+  esac
+
+  device_info_data['cpu_model']="$cpu_model"
+
+  if [[ "$flag" == 'TEST_MODE' ]]; then
+    echo "$cpu_model"
+    echo "$cpu_frequency"
+    return 0
+  fi
+
+  cpu_currently=$(echo "$cpu_frequency" | grep 'CPU MHz')
+  cpu_max=$(echo "$cpu_frequency" | grep 'CPU max MHz')
+  cpu_min=$(echo "$cpu_frequency" | grep 'CPU min MHz')
+
+  cpu_currently=${cpu_currently//[!0-9,.]/}
+  cpu_max=${cpu_max//[!0-9,.]/}
+  cpu_min=${cpu_min//[!0-9,.]/}
+
+  device_info_data['cpu_currently']="$cpu_currently"
+  device_info_data['cpu_max']="$cpu_max"
+  device_info_data['cpu_min']="$cpu_min"
+}
+
+# This function populates the values from the size and fs (filesystem) key of
+# the device_info_data variable.
+#
+# @target Target machine
+function get_disk()
+{
+  local target="$1"
+  local flag="$2"
+  local cmd
+  local info
+  local size
+  local mount
+  local fs
+
+  flag=${flag:-'SILENT'}
+  cmd="df -h / | tail -n 1 | tr -s ' '"
+  case "$target" in
+    2) # LOCAL_TARGET
+      info=$(cmd_manager "$flag" "$cmd")
+      ;;
+  esac
+
+  if [[ "$flag" == 'TEST_MODE' ]]; then
+    echo "$info"
+    return 0
+  fi
+
+  fs="$(echo "$info" | cut -d' ' -f1)"
+  size="$(echo "$info" | cut -d' ' -f2)"
+  mount="$(echo "$info" | cut -d' ' -f6)"
+
+  device_info_data['disk_size']="$size"
+  device_info_data['root_path']="$fs"
+  device_info_data['fs_mount']="$mount"
+}
+
+# This function populates the os and desktop environment variables from the
+# device_info_data variable.
+#
+# @target Target machine
+function get_os()
+{
+  local target="$1"
+  local flag="$2"
+  local cmd
+  local os
+  local desktop_env
+
+  flag=${flag:-'SILENT'}
+  cmd="find /usr/share/xsessions -type f -printf '%f ' | sed -r 's/\.desktop//g'"
+  case "$target" in
+    2) # LOCAL_TARGET
+      os=$(detect_distro '/')
+      desktop_env=$(cmd_manager "$flag" "$cmd")
+      ;;
+  esac
+
+  device_info_data['os']="$os"
+  device_info_data['desktop_environment']="$desktop_env"
+}
+
+# This function populates the gpu associative array with the vendor and
+# fetchable memory from each GPU found in the target machine.
+function get_gpu()
+{
+  local target="$1"
+  local flag="$2"
+  local pci_addresses
+  local gpu_info
+  local cmd_pci_address
+
+  flag=${flag:-'SILENT'}
+  # The first thing we want to do is retrieve all PCI addresses from any GPU in
+  # the target machine. After that, we will get, for each GPU, the desired
+  # information.
+  cmd_pci_address="lspci | grep -e VGA -e 3D | cut -d' ' -f1"
+  case "$target" in
+    2) # LOCAL_TARGET
+      pci_addresses=$(cmd_manager "$flag" "$cmd_pci_address")
+      for g in $pci_addresses; do
+        gpu_info=$(cmd_manager "$flag" "lspci -v -s $g")
+        gpu_name=$(echo "$gpu_info" | sed -nr '/Subsystem/s/\s*.*:\s+(.*)/\1/p')
+        gpu_provider=$(echo "$gpu_info" | sed -nr '/controller/s/.+controller: *([^\[\(]+).+/\1/p')
+        gpus["$g"]="$gpu_name;$gpu_provider"
+      done
+      ;;
+  esac
+}
+
+# This function retrieves both the name and vendor from the motherboard of a
+# target machine.
+#
+# @target Target machine
+function get_motherboard()
+{
+  local target="$1"
+  local flag="$2"
+  local mb_name
+  local mb_vendor
+  local cmd_name
+  local cmd_vendor
+
+  flag=${flag:-'SILENT'}
+  cmd_name='[ -f /sys/devices/virtual/dmi/id/board_name ] && cat /sys/devices/virtual/dmi/id/board_name'
+  cmd_vendor='[ -f /sys/devices/virtual/dmi/id/board_vendor ] && cat /sys/devices/virtual/dmi/id/board_vendor'
+  case "$target" in
+    2) # LOCAL_TARGET
+      mb_name=$(cmd_manager "$flag" "$cmd_name")
+      mb_vendor=$(cmd_manager "$flag" "$cmd_vendor")
+      ;;
+  esac
+
+  if [[ "$flag" == 'TEST_MODE' ]]; then
+    echo "$cmd_name"
+    echo "$cmd_vendor"
+    return 0
+  fi
+
+  device_info_data['motherboard_name']="$mb_name"
+  device_info_data['motherboard_vendor']="$mb_vendor"
+}
+
+# This function gets the chassis type of the target machine.
+#
+# @target Target machine
+function get_chassis()
+{
+  local target="$1"
+  local flag="$2"
+  local cmd
+  local chassis_type
+
+  declare -a chassis_table=('Other' 'Unknown' 'Desktop' 'Low Profile Desktop'
+    'Pizza Box' 'Mini Tower' 'Tower' 'Portable' 'Laptop' 'Notebook' 'Hand Held'
+    'Docking Station' 'All in One' 'Sub Notebook' 'Space-Saving' 'Lunch Box'
+    'Main System Chassis' 'Expansion Chassis' 'SubChassis' 'Bus Expansion Chassis'
+    'Peripheral Chassis' 'Storage Chassis' 'Rack Mount Chassis' 'Sealed-Case PC'
+    'VM')
+
+  flag=${flag:-'SILENT'}
+  cmd='cat /sys/devices/virtual/dmi/id/chassis_type'
+  case "$target" in
+    2) # LOCAL_TARGET
+      chassis_type=$(cmd_manager "$flag" "$cmd")
+      ;;
+  esac
+
+  if [[ "$flag" == 'TEST_MODE' ]]; then
+    echo "$cmd"
+    return 0
+  fi
+
+  device_info_data['chassis']="${chassis_table[(($chassis_type - 1))]}"
+}
+
+# This function calls other functions to populate the device_info_data variable
+# with the data related to the hardware from the target machine.
+#
+# @target Target machine
+function learn_device()
+{
+  local target="$1"
+  local flag="$2"
+
+  flag=${flag:-'SILENT'}
+
+  get_ram "$target" "$flag"
+  get_cpu "$target" "$flag"
+  get_disk "$target" "$flag"
+  get_os "$target" "$flag"
+  get_gpu "$target" "$flag"
+  get_motherboard "$target" "$flag"
+  get_chassis "$target" "$flag"
+}
+
+# This function shows the information stored in the device_info_data variable.
+function show_data()
+{
+  say 'Chassis:'
+  printf '  Type: %s\n' "${device_info_data['chassis']}"
+
+  say 'CPU:'
+  printf '  Model: %s\n' "${device_info_data['cpu_model']}"
+
+  if [[ -n "${device_info_data['cpu_currently']}" ]]; then
+    printf '  Current frequency (MHz): %s\n' "${device_info_data['cpu_currently']}"
+  fi
+
+  if [[ -n "${device_info_data['cpu_max']}" ]]; then
+    printf '  Max frequency (MHz): %s\n' "${device_info_data['cpu_max']}"
+  fi
+
+  if [[ -n "${device_info_data['cpu_min']}" ]]; then
+    printf '  Min frequency (MHz): %s\n' "${device_info_data['cpu_min']}"
+  fi
+
+  if [[ -n "${device_info_data['ram']}" ]]; then
+    say 'RAM:'
+    printf '  Total RAM: %s\n' "$(numfmt --from=si --to=iec "${device_info_data['ram']}K")"
+  fi
+
+  say 'Storage devices:'
+  printf '  Root filesystem: %s\n' "${device_info_data['root_path']}"
+  printf '  Size: %s\n' "${device_info_data['disk_size']}"
+  printf '  Mounted on: %s\n' "${device_info_data['fs_mount']}"
+
+  say 'Operating System:'
+  printf '  Distribution: %s\n' "${device_info_data['os']}"
+  printf '  Desktop environments: %s\n' "${device_info_data['desktop_environment']}"
+
+  if [[ "$target" != "$VM_TARGET" ]]; then
+    say 'Motherboard:'
+    printf '  Vendor: %s\n' "${device_info_data['motherboard_vendor']}"
+    printf '  Name: %s\n' "${device_info_data['motherboard_name']}"
+  fi
+
+  if [[ -n "${gpus[*]}" ]]; then
+    say 'GPU:'
+    for g in "${!gpus[@]}"; do
+      printf '  Model: %s\n' "$(echo "${gpus[$g]}" | cut -d';' -f1)"
+      printf '  Provider: %s\n' "$(echo "${gpus[$g]}" | cut -d';' -f2-)"
+    done
+  fi
+}
+
+# This function parses the options provided to 'kw device' and makes the
+# necessary ajustments. If no argument is provided, then the function assigns
+# the value from configurations[default_deploy_target] to the option variable;
+# if there is no value there either, then option is by default assigned to
+# local.
+function device_info_parser()
+{
+  local option="$1"
+
+  if [[ -z "$option" && -n "${configurations[default_deploy_target]}" ]]; then
+    option='--'"${configurations[default_deploy_target]}"
+  fi
+  option=${option:-'--local'}
+
+  case "$option" in
+    --local)
+      device_options['target']="$LOCAL_TARGET"
+      ;;
+    -h)
+      device_info_help
+      exit 0
+      ;;
+    *)
+      complain "Invalid option: $option"
+      return 22 # EINVAL
+      ;;
+  esac
+}
+
+function device_info_help()
+{
+  echo -e 'kw device:\n' \
+    '\t--local - Retrieve information from this machine'
+}

--- a/src/help.sh
+++ b/src/help.sh
@@ -16,6 +16,7 @@ function kworkflow_help()
     "\tcodestyle,c - Apply checkpatch on directory or file\n" \
     "\tconfigm,g - Manage config files\n" \
     "\tdeploy,d - Deploy a new kernel image to a target machine\n" \
+    "\tdevice - Show basic hardware information\n" \
     "\tdiff,df - Diff files\n" \
     "\tdrm - Set of commands to work with DRM drivers \n" \
     "\texplore,e - Explore string patterns\n" \

--- a/tests/device_test.sh
+++ b/tests/device_test.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+include './src/device_info.sh'
+include './tests/utils.sh'
+
+function test_get_ram()
+{
+  local cmd
+  local output
+
+  cmd="[ -f '/proc/meminfo' ] && cat /proc/meminfo | grep 'MemTotal' | grep -o '[0-9]*'"
+  output=$(get_ram "$LOCAL_TARGET" 'TEST_MODE')
+  assertEquals "($LINENO)" "$cmd" "$output"
+}
+
+function test_get_cpu()
+{
+  local output
+  declare -a expected_cmd=(
+    "lscpu | grep 'Model name:' | sed -r 's/Model name:\s+//g' | cut -d' ' -f1"
+    "lscpu | grep MHz | sed -r 's/(CPU.*)/\t\t\1/'"
+  )
+
+  output=$(get_cpu "$LOCAL_TARGET" 'TEST_MODE')
+  compare_command_sequence expected_cmd[@] "$output" "$LINENO"
+}
+
+function test_get_disk()
+{
+  local cmd
+  local output
+
+  cmd="df -h / | tail -n 1 | tr -s ' '"
+  output=$(get_disk "$LOCAL_TARGET" 'TEST_MODE')
+  assertEquals "($LINENO)" "$cmd" "$output"
+}
+
+function test_get_motherboard()
+{
+  local output
+  declare -a expected_cmd=(
+    '[ -f /sys/devices/virtual/dmi/id/board_name ] && cat /sys/devices/virtual/dmi/id/board_name'
+    '[ -f /sys/devices/virtual/dmi/id/board_vendor ] && cat /sys/devices/virtual/dmi/id/board_vendor'
+  )
+
+  output=$(get_motherboard "$LOCAL_TARGET" 'TEST_MODE')
+  compare_command_sequence expected_cmd[@] "$output" "$LINENO"
+}
+
+function test_get_chassis()
+{
+  local cmd
+  local output
+
+  cmd='cat /sys/devices/virtual/dmi/id/chassis_type'
+  output=$(get_chassis "$LOCAL_TARGET" 'TEST_MODE')
+  assertEquals "($LINENO)" "$cmd" "$output"
+}
+
+function test_display_data()
+{
+  local output
+
+  declare -a expected_cmd=(
+    'Chassis:'
+    'Type: Pizza Box'
+    'CPU:'
+    'Model: A model'
+    'Current frequency (MHz): 1400'
+    'RAM:'
+    'Total RAM: 16G'
+    'Storage devices:'
+    'Root filesystem: dev/something'
+    'Size: 250G'
+    'Mounted on: /'
+    'Operating System:'
+    'Distribution: debian'
+    'Desktop environments: gnome'
+    'Motherboard:'
+    'Vendor: Vendor'
+    'Name: ABC123'
+  )
+
+  device_options['target']="$LOCAL_TARGET"
+  device_info_data['chassis']='Pizza Box'
+  device_info_data['ram']='16777216'
+  device_info_data['cpu_model']='A model'
+  device_info_data['cpu_currently']=1400
+  device_info_data['disk_size']='250G'
+  device_info_data['root_path']='dev/something'
+  device_info_data['fs_mount']='/'
+  device_info_data['os']='debian'
+  device_info_data['desktop_environment']='gnome'
+  device_info_data['motherboard_vendor']='Vendor'
+  device_info_data['motherboard_name']='ABC123'
+  output=$(show_data)
+  compare_command_sequence expected_cmd[@] "$output" "$LINENO"
+}
+
+invoke_shunit


### PR DESCRIPTION
Here's a draft of `kw device`, which, for now, only supports the `--local` option.

For storing the data, I got inspired by src/statistics.sh, and chose to have an associative array for each pieace of information. It's also called `shared_data`.

Each function for retrieving information behaves mostly the same: their main goal is to update the associative array with their corresponding value.

Two things that I see that could be improved:
1) The way the CPU frequency is stored. As for now, it's a whole string with tabs, letters and numbers:
```
		CPU MHz:                         799.951
		CPU max MHz:                     4900,0000
		CPU min MHz:                     400,0000
```
I think this should be just numbers. Maybe I could add more keys to `shared_data`, and have `cpu_currently`, `cpu_max`, `cpu_min`, and then associate it with the numbers above.

2) Same thing with how the storage devices information is stored. It's also a string, with the device name, and, after a few spaces, the information telling whether it's a rotational disk or not:
```
	nvme0n1   not rotational
```
I haven't thought about another way to handle this, keeping in mind that a machine could have more than one storage disk.

And I also haven't written any tests for this new file.

Any tips on what to change, improve and add?