### PR TITLE
src: mk.sh: Break into deploy.sh and build.sh

### DIFF
--- a/kw
+++ b/kw
@@ -82,9 +82,9 @@ function kw()
       ;;
     build | b)
       (
-        include "$KW_LIB_DIR/mk.sh"
+        include "$KW_LIB_DIR/build.sh"
 
-        mk_build '' "$@"
+        kernel_build '' "$@"
         local ret="$?"
         alert_completion "kw build" "$1"
         return "$ret"
@@ -92,7 +92,7 @@ function kw()
       ;;
     deploy | d)
       (
-        include "$KW_LIB_DIR/mk.sh"
+        include "$KW_LIB_DIR/deploy.sh"
 
         kernel_deploy "$@"
         local ret="$?"
@@ -102,9 +102,10 @@ function kw()
       ;;
     bd)
       (
-        include "$KW_LIB_DIR/mk.sh"
+        include "$KW_LIB_DIR/deploy.sh"
+        include "$KW_LIB_DIR/build.sh"
 
-        mk_build && kernel_deploy "$@"
+        kernel_build && kernel_deploy "$@"
         local ret="$?"
         alert_completion "kw db" "$1"
         return "$ret"
@@ -194,7 +195,7 @@ function kw()
       )
       ;;
     clear-cache)
-      include "$KW_LIB_DIR/mk.sh"
+      include "$KW_LIB_DIR/deploy.sh"
 
       cleanup
       ;;

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,0 +1,124 @@
+include "$KW_LIB_DIR/kwlib.sh"
+include "$KW_LIB_DIR/kwio.sh"
+include "$KW_LIB_DIR/kw_config_loader.sh"
+
+# This function retrieves and prints information related to the kernel that
+# will be compiled.
+# shellcheck disable=2120
+function build_info()
+{
+  local flag
+  local kernel_name
+  local kernel_version
+  local compiled_modules
+
+  flag="$1"
+  kernel_name=$(get_kernel_release "$flag")
+  kernel_version=$(get_kernel_version "$flag")
+
+  say "Kernel source information"
+  echo -e "\tName: $kernel_name"
+  echo -e "\tVersion: $kernel_version"
+
+  if [[ -f '.config' ]]; then
+    compiled_modules=$(grep -c '=m' .config)
+    echo -e "\tTotal modules to be compiled: $compiled_modules"
+  fi
+}
+
+# This function is responsible for manipulating kernel build operations such as
+# compile/cross-compile and menuconfig.
+#
+# @flag How to display a command, see `src/kwlib.sh` function `cmd_manager`
+# @raw_options String with all user options
+#
+# Return:
+# In case of successful return 0, otherwise, return 22 or 125.
+function kernel_build()
+{
+  local flag="$1"
+  shift 1
+  local raw_options="$*"
+  local PARALLEL_CORES=1
+  local CROSS_COMPILE=""
+  local command=""
+  local start
+  local end
+  local arch="${configurations[arch]}"
+  local menu_config="${configurations[menu_config]}"
+
+  if [[ "$1" == -h ]]; then
+    build_help
+    exit 0
+  fi
+
+  menu_config=${menu_config:-"nconfig"}
+  arch=${arch:-"x86_64"}
+
+  if ! is_kernel_root "$PWD"; then
+    complain "Execute this command in a kernel tree."
+    exit 125 # ECANCELED
+  fi
+
+  if [[ -n "${configurations[cross_compile]}" ]]; then
+    CROSS_COMPILE="CROSS_COMPILE=${configurations[cross_compile]}"
+  fi
+
+  IFS=' ' read -r -a options <<< "$raw_options"
+  for option in "${options[@]}"; do
+    case "$option" in
+      --info | -i)
+        build_info
+        exit
+        ;;
+      --menu | -n)
+        command="make ARCH=$arch $CROSS_COMPILE $menu_config"
+        cmd_manager "$flag" "$command"
+        exit
+        ;;
+      --doc | -d)
+        doc_type="${configurations[doc_type]}"
+        doc_type=${doc_type:='htmldocs'}
+        command="make $doc_type"
+        cmd_manager "$flag" "$command"
+        return
+        ;;
+      *)
+        complain "Invalid option: $option"
+        exit 22 # EINVAL
+        ;;
+    esac
+  done
+
+  if [ -x "$(command -v nproc)" ]; then
+    PARALLEL_CORES=$(nproc --all)
+  else
+    PARALLEL_CORES=$(grep -c ^processor /proc/cpuinfo)
+  fi
+
+  command="make -j$PARALLEL_CORES ARCH=$arch $CROSS_COMPILE"
+
+  start=$(date +%s)
+  cmd_manager "$flag" "$command"
+  ret="$?"
+  end=$(date +%s)
+
+  runtime=$((end - start))
+
+  if [[ "$ret" != 0 ]]; then
+    statistics_manager "build_failure" "$runtime"
+  else
+    statistics_manager "build" "$runtime"
+  fi
+
+  return "$ret"
+}
+
+function build_help()
+{
+  echo -e "kw build:\n" \
+    "  build - Build kernel \n" \
+    "  build [--menu|-n] - Open kernel menu config\n" \
+    "  build [--info|-i] - Display build information\n" \
+    "  build [--doc|-d]  - Build kernel documentation"
+}

--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -147,6 +147,40 @@ function find_kernel_root()
   echo "$kernel_root"
 }
 
+# Get the kernel release based on the command kernelrelease.
+#
+# @flag How to display a command, the default value is
+#   "SILENT". For more options see `src/kwlib.sh` function `cmd_manager`
+#
+# Note: Make sure that you called is_kernel_root before trying to execute this
+# function.
+function get_kernel_release()
+{
+  local flag="$1"
+  local cmd='make kernelrelease'
+
+  flag=${flag:-'SILENT'}
+
+  cmd_manager "$flag" "$cmd"
+}
+
+# Get the kernel version name.
+#
+# @flag How to display a command, the default value is
+#   "SILENT". For more options see `src/kwlib.sh` function `cmd_manager`
+#
+# Note: Make sure that you called is_kernel_root before trying to execute this
+# function.
+function get_kernel_version()
+{
+  local flag="$1"
+  local cmd='make kernelversion'
+
+  flag=${flag:-'SILENT'}
+
+  cmd_manager "$flag" "$cmd"
+}
+
 # Checks if the given path is a patch file
 #
 # @FILE_PATH The argument is the path

--- a/tests/build_test.sh
+++ b/tests/build_test.sh
@@ -1,0 +1,122 @@
+include './src/build.sh'
+include './tests/utils.sh'
+
+function get_kernel_release_mock()
+{
+  echo '5.4.0-rc7-test'
+}
+
+function get_kernel_version_mock()
+{
+  echo '5.4.0-rc7'
+}
+
+oneTimeSetUp()
+{
+  original_dir="$PWD"
+  FAKE_KERNEL="$SHUNIT_TMPDIR"
+  mk_fake_kernel_root "$FAKE_KERNEL"
+
+  parse_configuration "$KW_CONFIG_SAMPLE"
+
+  if [ -x "$(command -v nproc)" ]; then
+    PARALLEL_CORES=$(nproc --all)
+  else
+    PARALLEL_CORES=$(grep -c ^processor /proc/cpuinfo)
+  fi
+  export PARALLEL_CORES
+
+  shopt -s expand_aliases
+  alias get_kernel_release='get_kernel_release_mock'
+  alias get_kernel_version='get_kernel_version_mock'
+
+}
+
+setUp()
+{
+  # In this case we actually want to exit, since all tests below rely on
+  # being in a kernel root
+  cd "$FAKE_KERNEL" ||
+    {
+      fail 'Was not able to move into fake kernel directory'
+      exit
+    }
+}
+
+tearDown()
+{
+  cd "$original_dir" || fail 'Was not able to move back to original directory'
+}
+
+function test_kernel_build()
+{
+  local ID
+  local expected_result
+
+  output=$(kernel_build 'TEST_MODE' '--menu')
+  expected_result="make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- nconfig"
+  assertEquals "($LINENO)" "$expected_result" "$output"
+
+  output=$(kernel_build 'TEST_MODE' '--doc')
+  expected_result="make htmldocs"
+  assertEquals "($LINENO)" "$expected_result" "$output"
+
+  output=$(kernel_build 'TEST_MODE' '--notvalid')
+  ret="$?"
+  assertEquals "($LINENO)" "$ret" "22"
+
+  output=$(kernel_build 'TEST_MODE' | head -1) # Remove statistics output
+  expected_result="make -j$PARALLEL_CORES ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-"
+  assertEquals "($LINENO)" "$expected_result" "${output}"
+
+  cd "$original_dir" ||
+    {
+      fail 'Was not able to move back to original directory'
+      return
+    }
+
+  output=$(kernel_build 'TEST_MODE')
+  ret="$?"
+  assertEquals "($LINENO) We expected an error" "125" "$ret"
+
+  configurations=()
+  cp "$KW_CONFIG_SAMPLE_X86" "$FAKE_KERNEL/kworkflow.config"
+  parse_configuration "$FAKE_KERNEL/kworkflow.config"
+
+  cd "$FAKE_KERNEL" ||
+    {
+      fail 'Was not able to move into temporary directory'
+      return
+    }
+
+  output=$(kernel_build 'TEST_MODE' | head -1) # Remove statistics output
+  expected_result="make -j$PARALLEL_CORES ARCH=x86_64 "
+  assertEquals "($LINENO)" "$expected_result" "${output}"
+
+}
+
+function test_build_info()
+{
+  local release='5.4.0-rc7-test'
+  local version='5.4.0-rc7'
+  local release_output="Name: $release"
+  local version_output="Version: $version"
+  local modules='Total modules to be compiled: 5'
+
+  declare -a expected_cmd=(
+    'Kernel source information'
+    "$release_output"
+    "$version_output"
+  )
+
+  output=$(kernel_build 'TEST_MODE' '--info')
+  compare_command_sequence expected_cmd[@] "$output" "($LINENO)"
+
+  cp "$original_dir/tests/samples/.config" .config
+  expected_cmd[3]="$modules"
+  output=$(kernel_build 'TEST_MODE' '--info')
+  compare_command_sequence expected_cmd[@] "$output" "($LINENO)"
+  rm .config
+}
+
+invoke_shunit


### PR DESCRIPTION
Commands related to kernel compiling and installation were in one single
file, src/mk.sh, and it has gotten too big. This commit splits this file
into src/deploy.sh (installation) and src/build.sh (compilation). It
also moves some common functions to src/kwlib.sh and changes the name of
some functions (e.g. mk_build becomes kernel_build) since there is no
reference to "mk" anymore.

The test file tests/mk_test.sh is also split accordingly. The resulting
file tests/build_test.sh is refactored.

Signed-off-by: João Seckler <jseckler@riseup.net>