### PR TITLE
Improve bash_autocomplete file

### DIFF
--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -4,10 +4,10 @@ function _kw_autocomplete()
   COMPREPLY=()
   current_command="${COMP_WORDS[COMP_CWORD]}"
   previous_command="${COMP_WORDS[COMP_CWORD - 1]}"
-  kw_options="explore e build b bi init new n ssh s clear-cache
+  kw_options="explore e bd build b init ssh s clear-cache
                 mount mo umount um vars up u codestyle c configm g
                 maintainers m deploy d help h version statistics
-                pomodoro p drm diff --version -v"
+                pomodoro p drm diff df --version -v man"
 
   # By default, autocomplete with kw_options
   if [[ ${previous_command} == kw ]]; then

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -11,7 +11,7 @@ function _kw_autocomplete()
 
   # By default, autocomplete with kw_options
   if [[ ${previous_command} == kw ]]; then
-    COMPREPLY=($(compgen -W "${kw_options}" -- "${current_command}"))
+    COMPREPLY=("$(compgen -W "${kw_options}" -- "${current_command}")")
     return 0
   fi
 


### PR DESCRIPTION
This PR fixes two minor things in src/bash_autocomplete.sh: it removes options from `kw_options` that are not supported by kw, and adds the ones that are supported and were missing. It also fixes [SC2207](https://github.com/koalaman/shellcheck/wiki/SC2207).