### PR TITLE
Refactor deploy

### DIFF
--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -303,13 +303,13 @@ function list_installed_kernels()
         return 125 # ECANCELED
       fi
 
-      . "$KW_PLUGINS_DIR/kernel_install/utils.sh" --source-only
+      include "$KW_PLUGINS_DIR/kernel_install/utils.sh"
       list_installed_kernels "$single_line" "${configurations[mount_point]}"
 
       vm_umount
       ;;
     2) # LOCAL_TARGET
-      . "$KW_PLUGINS_DIR/kernel_install/utils.sh" --source-only
+      include "$KW_PLUGINS_DIR/kernel_install/utils.sh"
       list_installed_kernels "$single_line"
       ;;
     3) # REMOTE_TARGET
@@ -362,8 +362,8 @@ function kernel_uninstall()
 
       # Local Deploy
       # We need to update grub, for this reason we to load specific scripts.
-      . "$KW_PLUGINS_DIR/kernel_install/$distro.sh" --source-only
-      . "$KW_PLUGINS_DIR/kernel_install/utils.sh" --source-only
+      include "$KW_PLUGINS_DIR/kernel_install/$distro.sh"
+      include "$KW_PLUGINS_DIR/kernel_install/utils.sh"
       # TODO: Rename kernel_uninstall in the plugin, this name is super
       # confusing
       kernel_uninstall "$reboot" 'local' "$kernels_target" "$flag"
@@ -574,8 +574,8 @@ function kernel_install()
         exit 95 # ENOTSUP
       fi
 
-      . "$KW_PLUGINS_DIR/kernel_install/utils.sh" --source-only
-      . "$KW_PLUGINS_DIR/kernel_install/$distro.sh" --source-only
+      include "$KW_PLUGINS_DIR/kernel_install/utils.sh"
+      include "$KW_PLUGINS_DIR/kernel_install/$distro.sh"
       install_kernel "$name" "$distro" "$kernel_img_name" "$reboot" "$arch_target" 'vm' "$flag"
       return "$?"
       ;;
@@ -593,8 +593,8 @@ function kernel_install()
         exit 1 # EPERM
       fi
 
-      . "$KW_PLUGINS_DIR/kernel_install/utils.sh" --source-only
-      . "$KW_PLUGINS_DIR/kernel_install/$distro.sh" --source-only
+      include "$KW_PLUGINS_DIR/kernel_install/utils.sh"
+      include "$KW_PLUGINS_DIR/kernel_install/$distro.sh"
       install_kernel "$name" "$distro" "$kernel_img_name" "$reboot" "$arch_target" 'local' "$flag"
       return "$?"
       ;;

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -436,11 +436,6 @@ function modules_install()
   local port
   local distro
 
-  if ! is_kernel_root "$PWD"; then
-    complain "Execute this command in a kernel tree."
-    exit 125 # ECANCELED
-  fi
-
   flag=${flag:-""}
 
   case "$target" in
@@ -499,11 +494,6 @@ function modules_install_to()
 
   flag=${flag:-""}
 
-  if ! is_kernel_root "$PWD"; then
-    complain "Execute this command in a kernel tree."
-    exit 125 # ECANCELED
-  fi
-
   local cmd="make INSTALL_MOD_PATH=$install_to modules_install"
   set +e
   cmd_manager "$flag" "$cmd"
@@ -534,11 +524,6 @@ function kernel_install()
   local remote
   local port
   local distro
-
-  if ! is_kernel_root "$PWD"; then
-    complain "Execute this command in a kernel tree."
-    exit 125 # ECANCELED
-  fi
 
   # We have to guarantee some default values values
   kernel_name=${kernel_name:-"nothing"}

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -45,7 +45,6 @@ function setUp()
 
   export preset_name="template_mkinitcpio.preset"
   export test_path="$PWD/$FAKE_KERNEL"
-  export KW_PLUGINS_DIR="$test_path"
   export KW_CACHE_DIR="$test_path"
   export KW_ETC_DIR="$PWD/$SAMPLES_DIR/etc"
   export DEPLOY_SCRIPT="$test_path/$kernel_install_path/deploy.sh"

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -637,20 +637,23 @@ function test_kernel_uninstall()
   }
 }
 
-function test_cleanup_after_deploy()
+function test_cleanup()
 {
   local output=""
   local cmd_remote="rm -rf $test_path/$LOCAL_TO_DEPLOY_DIR/*"
   local cmd_to_deploy="rm -rf $test_path/$LOCAL_REMOTE_DIR/*"
 
   declare -a expected_cmd=(
+    'Cleaning up temporary files...'
     "$cmd_to_deploy"
     "$cmd_remote"
+    'Exiting...'
   )
-
-  output=$(cleanup_after_deploy "TEST_MODE")
+  #shellcheck disable=SC2153
+  options_values[REMOTE]=1
+  output=$(cleanup "TEST_MODE")
   while read -r f; do
-    assertFalse "$ID (cmd: $count) - Expected \"${expected_cmd[$count]}\" to be \"${f}\"" \
+    assertFalse "$ID (cmd: $count) - Expected \"${f}\" to be \"${expected_cmd[$count]}\"" \
       '[[ ${expected_cmd[$count]} != ${f} ]]'
     ((count++))
   done <<< "$output"


### PR DESCRIPTION
This PR introduces a few refactorings to deploy.sh 

With the entry-point as the root of the file, I re-ordered the functions to follow the order upon which they are called in the entry-point, I believe this should make the file more readable and organized.
I also fixed a few minor issues such as few instances of file sourcing that weren't using the include function.

There were 3 functions for cleanup, they had a lot of overlap and were needlessly complicated so I merged them into one.

I also removed some unnecessary checks, the `is_kernel_root` check is done once in the entry-point function kernel_deploy so there is no need to remake this check in other functions later on

