### PR TITLE
refactor and expand ssh

### DIFF
--- a/documentation/man/kw.rst
+++ b/documentation/man/kw.rst
@@ -17,7 +17,7 @@ Inglorious kernel developer workflow scripts
 
 SYNOPSIS
 ========
-**kw** *COMMAND* [*OPTION* ...] 
+**kw** *COMMAND* [*OPTION* ...]
 
 DESCRIPTION
 ===========
@@ -413,6 +413,10 @@ the **kw** code and provides the overall behavior for **kw**. Local
 **kworkflow.config** per project. In this section, we describe the possible
 fields you can specify in the configuration files.
 
+ssh_user=USER
+-------------
+Sets the user to be used by ssh. By default **kw** uses **root**.
+
 ssh_ip=IP
 ---------
 Sets the IP address to be used by ssh. By default **kw** uses **localhost**.
@@ -420,6 +424,14 @@ Sets the IP address to be used by ssh. By default **kw** uses **localhost**.
 ssh_port=PORT
 -------------
 Sets the ssh port. By default **kw** uses 2222.
+
+ssh_configfile=SSH_CONFIGURATION_FILE
+-------------------------------------
+Provides an optional SSH configuration file to be used by ssh. For more details see `man ssh_config`.
+
+hostname=HOSTNAME
+-----------------
+Sets the hostname to be used when an SSH configuration file is provided.
 
 arch=ARCHITECTURE
 -----------------

--- a/etc/kworkflow_template.config
+++ b/etc/kworkflow_template.config
@@ -15,6 +15,11 @@ ssh_ip=localhost
 # Default ssh port
 ssh_port=22
 
+# Optional ssh configuration file to be used
+#ssh_configfile=~/.ssh/config
+# Hostname of the target in ssh_configfile
+#hostname=
+
 # Specify the default architecture used by KW
 arch=x86_64
 

--- a/src/kw_config_loader.sh
+++ b/src/kw_config_loader.sh
@@ -36,6 +36,8 @@ function show_variables()
     [ssh_user]='SSH user'
     [ssh_ip]='SSH address'
     [ssh_port]='SSH port'
+    [ssh_configfile]='SSH configuration file'
+    [hostname]='Hostname of the target in the SSH configuration file'
   )
 
   local -Ar build=(

--- a/src/kw_config_loader.sh
+++ b/src/kw_config_loader.sh
@@ -104,11 +104,8 @@ function show_variables()
 function parse_configuration()
 {
   local config_path="$1"
-  local filename
 
-  filename="$(basename "$config_path")"
-
-  if [ ! -f "$config_path" ] || [ "$filename" != kworkflow.config ]; then
+  if [ ! -f "$config_path" ]; then
     return 22 # 22 means Invalid argument - EINVAL
   fi
   # shellcheck disable=SC2162

--- a/src/plugins/subsystems/drm/drm.sh
+++ b/src/plugins/subsystems/drm/drm.sh
@@ -226,7 +226,7 @@ function gui_control()
       remote=$(get_based_on_delimiter "$remote" "@" 2)
 
       cmd_remotely "$gui_control_cmd" "$flag" "$remote" "$port"
-      cmd_remotely "$bind_control_cmd" "$flag" "$remote" "$port" "root" "1"
+      cmd_remotely "$bind_control_cmd" "$flag" "$remote" "$port" "" "1"
       ;;
   esac
 }

--- a/src/remote.sh
+++ b/src/remote.sh
@@ -35,10 +35,10 @@ declare -gA remote_parameters
 function cmd_remotely()
 {
   local command="$1"
-  local flag="$2"
-  local remote="$3"
-  local port="$4"
-  local user="$5"
+  local flag=${2:-"HIGHLIGHT_CMD"}
+  local remote=${3:-${configurations[ssh_ip]}}
+  local port=${4:-${configurations[ssh_port]}}
+  local user=${5:-${configurations[ssh_user]}}
   local bash_code="$6"
   local composed_cmd=""
 
@@ -46,12 +46,6 @@ function cmd_remotely()
     warning "No command specified"
     exit 22
   fi
-
-  # Set default values if not specified
-  remote=${remote:-"localhost"}
-  port=${port:-"22"}
-  user=${user:-"root"}
-  flag=${flag:-"HIGHLIGHT_CMD"}
 
   composed_cmd="ssh -p $port $user@$remote"
   if [[ -v configurations['ssh_configfile'] && -v configurations['hostname'] ]]; then
@@ -81,20 +75,12 @@ function cmd_remotely()
 #   more options see `src/kwlib.sh` function `cmd_manager`
 function cp_host2remote()
 {
-  local src="$1"
-  local dst="$2"
-  local remote="$3"
-  local port="$4"
-  local user="$5"
-  local flag="$6"
-
-  src=${src:-"$KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR/*"}
-
-  dst=${dst:-"$REMOTE_KW_DEPLOY"}
-  remote=${remote:-"localhost"}
-  port=${port:-"22"}
-  user=${user:-"root"}
-  flag=${flag:-"HIGHLIGHT_CMD"}
+  local src=${1:-"$KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR/*"}
+  local dst=${2:-"$REMOTE_KW_DEPLOY"}
+  local remote=${3:-${configurations[ssh_ip]}}
+  local port=${4:-${configurations[ssh_port]}}
+  local user=${5:-${configurations[ssh_user]}}
+  local flag=${6:-"HIGHLIGHT_CMD"}
 
   cmd_manager "$flag" "rsync -e 'ssh -p $port' -La $src $user@$remote:$dst"
   if [[ -v configurations['ssh_configfile'] && -v configurations['hostname'] ]]; then
@@ -114,17 +100,12 @@ function cp_host2remote()
 # subshell and save it to a variable.
 function which_distro()
 {
-  local remote="$1"
-  local port="$2"
-  local user="$3"
-  local flag="$4"
+  local remote=${1:-${configurations[ssh_ip]}}
+  local port=${2:-${configurations[ssh_port]}}
+  local user=${3:-${configurations[ssh_user]}}
+  local flag=${4:-"SILENT"}
 
   cmd="cat /etc/os-release | grep -w ID | cut -d = -f 2"
-  remote=${remote:-"localhost"}
-  port=${port:-"22"}
-  user=${user:-"root"}
-  flag=${flag:-"SILENT"}
-
   cmd_remotely "$cmd" "$flag" "$remote" "$port" "$user"
 }
 

--- a/src/remote.sh
+++ b/src/remote.sh
@@ -53,10 +53,17 @@ function cmd_remotely()
   user=${user:-"root"}
   flag=${flag:-"HIGHLIGHT_CMD"}
 
-  composed_cmd="ssh -p $port $user@$remote \"$command\""
-  if [[ "$bash_code" == 1 ]]; then
-    composed_cmd="ssh -p $port $user@$remote '$command'"
+  composed_cmd="ssh -p $port $user@$remote"
+  if [[ -v configurations['ssh_configfile'] && -v configurations['hostname'] ]]; then
+    composed_cmd="ssh -F ${configurations['ssh_configfile']} ${configurations['hostname']}"
   fi
+
+  if [[ "$bash_code" == 1 ]]; then
+    composed_cmd="$composed_cmd '$command'"
+  else
+    composed_cmd="$composed_cmd \"$command\""
+  fi
+
   cmd_manager "$flag" "$composed_cmd"
 }
 
@@ -90,6 +97,9 @@ function cp_host2remote()
   flag=${flag:-"HIGHLIGHT_CMD"}
 
   cmd_manager "$flag" "rsync -e 'ssh -p $port' -La $src $user@$remote:$dst"
+  if [[ -v configurations['ssh_configfile'] && -v configurations['hostname'] ]]; then
+    cmd_manager "$flag" "rsync -e 'ssh -F ${configurations['ssh_configfile']}' -La $src ${configurations['hostname']}:$dst --rsync-path='sudo rsync'"
+  fi
 }
 
 # Access the target device and query the distro name.

--- a/src/remote.sh
+++ b/src/remote.sh
@@ -53,9 +53,9 @@ function cmd_remotely()
   fi
 
   if [[ "$bash_code" == 1 ]]; then
-    composed_cmd="$composed_cmd '$command'"
+    composed_cmd="$composed_cmd 'sudo bash -c '\''$command'\'"
   else
-    composed_cmd="$composed_cmd \"$command\""
+    composed_cmd="$composed_cmd sudo \"$command\""
   fi
 
   cmd_manager "$flag" "$composed_cmd"
@@ -82,10 +82,12 @@ function cp_host2remote()
   local user=${5:-${configurations[ssh_user]}}
   local flag=${6:-"HIGHLIGHT_CMD"}
 
-  cmd_manager "$flag" "rsync -e 'ssh -p $port' -La $src $user@$remote:$dst"
+  cmd_manager "$flag" "rsync -e 'ssh -p $port' -La $src $user@$remote:$dst --rsync-path='sudo rsync'"
   if [[ -v configurations['ssh_configfile'] && -v configurations['hostname'] ]]; then
     cmd_manager "$flag" "rsync -e 'ssh -F ${configurations['ssh_configfile']}' -La $src ${configurations['hostname']}:$dst --rsync-path='sudo rsync'"
   fi
+
+  cmd_remotely "chown -R root:root $dst" "$flag" "$remote" "$port" "$user"
 }
 
 # Access the target device and query the distro name.

--- a/tests/drm_plugin_test.sh
+++ b/tests/drm_plugin_test.sh
@@ -22,6 +22,7 @@ function setUp()
 function tearDown()
 {
   configurations=()
+  configurations[ssh_user]=juca
 
   rm -rf "$TMP_TEST_DIR"
 }
@@ -65,9 +66,9 @@ function test_gui_control()
   tearDown # We want to test the default cases first
   # REMOTE = 3
   ID=1
-  ssh_part='ssh -p 8888 root@127.0.0.1'
-  full_turn_on_gui_cmd="$ssh_part \"$gui_on_cmd\""
-  full_bind_cmd="$ssh_part '$bind_cmd'"
+  ssh_part="ssh -p 8888 juca@127.0.0.1"
+  full_turn_on_gui_cmd="$ssh_part sudo \"$gui_on_cmd\""
+  full_bind_cmd="$ssh_part 'sudo bash -c '\''$bind_cmd'\'"
 
   declare -a expected_cmd_seq=(
     "$full_turn_on_gui_cmd"
@@ -78,8 +79,8 @@ function test_gui_control()
   compare_command_sequence expected_cmd_seq[@] "$output" "$ID"
 
   ID=2
-  full_turn_off_gui_cmd="$ssh_part \"$gui_off_cmd\""
-  full_unbind_cmd="$ssh_part '$unbind_cmd'"
+  full_turn_off_gui_cmd="$ssh_part sudo \"$gui_off_cmd\""
+  full_unbind_cmd="$ssh_part 'sudo bash -c '\''$unbind_cmd'\'"
 
   declare -a expected_cmd_seq=(
     "$full_turn_off_gui_cmd"
@@ -94,9 +95,9 @@ function test_gui_control()
   parse_configuration "$KW_CONFIG_SAMPLE"
 
   gui_off_cmd='turn off'
-  ssh_part='ssh -p 22 root@localhost'
-  full_turn_off_gui_cmd="$ssh_part \"$gui_off_cmd\""
-  full_unbind_cmd="$ssh_part '$unbind_cmd'"
+  ssh_part="ssh -p 3333 juca@127.0.0.1"
+  full_turn_off_gui_cmd="$ssh_part sudo \"$gui_off_cmd\""
+  full_unbind_cmd="$ssh_part 'sudo bash -c '\''$unbind_cmd'\'"
 
   declare -a expected_cmd_seq=(
     "$full_turn_off_gui_cmd"
@@ -108,8 +109,8 @@ function test_gui_control()
 
   ID=4
   gui_on_cmd='turn on'
-  full_turn_on_gui_cmd="$ssh_part \"$gui_on_cmd\""
-  full_bind_cmd="$ssh_part '$bind_cmd'"
+  full_turn_on_gui_cmd="$ssh_part sudo \"$gui_on_cmd\""
+  full_bind_cmd="$ssh_part 'sudo bash -c '\''$bind_cmd'\'"
 
   declare -a expected_cmd_seq=(
     "$full_turn_on_gui_cmd"
@@ -161,7 +162,8 @@ function test_get_supported_mode_per_connector()
 function test_module_control()
 {
   local ID
-  local default_ssh="ssh -p 22 root@localhost"
+  local default_ssh
+  default_ssh="ssh -p 3333 juca@127.0.0.1 sudo"
 
   ID=1
   expected="sudo bash -c \"modprobe  amdgpu\""

--- a/tests/kw_config_loader_test.sh
+++ b/tests/kw_config_loader_test.sh
@@ -25,7 +25,7 @@ function test_parse_configuration_success_exit_code()
 
 function test_parser_configuration_failed_exit_code()
 {
-  parse_configuration tests/kw_config_loader_test.sh
+  parse_configuration tests/foobarpotato
   assertTrue "kw loaded an unsupported file" "[ 22 -eq $? ]"
 }
 

--- a/tests/remote_test.sh
+++ b/tests/remote_test.sh
@@ -113,6 +113,7 @@ function test_cmd_remote()
   local user="kw"
   local flag="TEST_MODE"
   local ID
+  parse_configuration "$SAMPLES_DIR/kworkflow_template.config"
 
   ID=1
   expected_command="ssh -p $port $user@$remote \"$command\""

--- a/tests/samples/kworkflow_drm_plugin.config
+++ b/tests/samples/kworkflow_drm_plugin.config
@@ -1,3 +1,4 @@
+ssh_user=juca
 ssh_ip=127.0.0.1
 ssh_port=3333
 arch=arm

--- a/tests/samples/kworkflow_template.config
+++ b/tests/samples/kworkflow_template.config
@@ -6,14 +6,33 @@
 #? - USERKW will be replaced by the current user
 #? - SOUNDPATH will be replaced by kw's install path
 
+# Default ssh user
+ssh_user=root
+
 # Default ssh ip
 ssh_ip=localhost
 
 # Default ssh port
-ssh_port=2222
+ssh_port=22
+
+# Optional ssh configuration file to be used
+#ssh_configfile=~/.ssh/config
+# Hostname of the target in ssh_configfile
+#hostname=
 
 # Specify the default architecture used by KW
 arch=x86_64
+
+# Use this flag as a way to indicate to kw the kernel image name. If this
+# option is not specified, kw will try to infer the correct file inside
+# arch/*/boot/.
+kernel_img_name=bzImage
+
+# Specify cross-compile name
+#cross_compile=aarch64-linux-gnu-
+
+# Default kernel menu config option
+menu_config=nconfig
 
 # Defines the virtualization tool that should be used by kw. Current, we only
 # support QEMU
@@ -40,6 +59,10 @@ alert=n
 # the background)
 sound_alert_command=paplay SOUNDPATH/complete.wav
 
+# Generate kernel-doc, user can use any option currently available in the
+# Kernel (e.g., pdfdocs, latexdocs, cleandocs, etc.)
+doc_type=htmldocs
+
 # Command to run for visual completion alert (This command will be executed in
 # the background)
 # Note: You may use $COMMAND, which will be replaced by the kw command
@@ -49,3 +72,21 @@ sound_alert_command=paplay SOUNDPATH/complete.wav
 #       in your favorite OS or replaces it for your preferred notification
 #       tool.
 visual_alert_command=notify-send -i checkbox -t 10000 "kw" "Command: \\"$COMMAND\\" completed!"
+
+# Sometimes it could be bothersome to pass the same parameter for kw deploy;
+# here, you can set the default target. We define `vm` as the default, but
+# you can also use `local` and `remote`.
+default_deploy_target=vm
+
+# If you want to reboot your target machine after the deploy gets done, you can
+# change the option `reboot_after_deploy` from "no" to "yes".
+reboot_after_deploy=no
+
+# Disable kw statistics collection, if you disable this data collection the
+# `statistics` options will be disabled as well. Add "yes" for disabling it.
+disable_statistics_data_track=no
+
+# Set a specific command to activate the GUI
+#gui_on=systemctl isolate graphical.target
+# Set a specific command to deactivate the GUI
+#gui_off=systemctl isolate multi-user.target

--- a/tests/samples/kworkflow_x86.config
+++ b/tests/samples/kworkflow_x86.config
@@ -1,3 +1,4 @@
+ssh_user=root
 ssh_ip=localhost
 ssh_port=22
 arch=x86_64


### PR DESCRIPTION
the current ssh configuration options in kw are really limited, to
expand them this commit introduces the option for the user to input a
ssh configuration file. This way we can allow the user to configure ssh
however it wants with minimal code added to kw.

These limitation were blocking some of my work so I had to tackle them.

Another change this commit introduces is the refactoring of the functions `cmd_remotely` and `cphost2remote` to use sudo instead of the root user. Doing a ssh operation as root is a major security risk, one that our end-users may not want or even be able to take. 


maybe the last 3 commits should be squashed as one, I initially made them separate commits mostly to be able to partially revert them more easily while I was testing