### PR TITLE
tests: fix message on compare_command_sequence

### DIFF
--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -230,7 +230,7 @@ function compare_command_sequence()
 
   while read -r f; do
     if [[ "${expected[$count]}" != "${f}" ]]; then
-      fail "($ID) $count - Expected cmd \"${expected[$count]}\" to be \"${f}\""
+      fail "($ID) $count - Expected cmd \"${f}\" to be \"${expected[$count]}\""
     fi
     ((count++))
   done <<< "$result_to_compare"


### PR DESCRIPTION
I spent a few hours pulling my hair trying to understand why my tests were failing. Turns out the command and expected command are reversed in the  `compare_command_sequence`, this PR fixes this