### PR TITLE
Deploy small refactor

### DIFF
--- a/etc/kworkflow_template.config
+++ b/etc/kworkflow_template.config
@@ -6,6 +6,9 @@
 #? - USERKW will be replaced by the current user
 #? - SOUNDPATH will be replaced by kw's install path
 
+# Default ssh user
+ssh_user=root
+
 # Default ssh ip
 ssh_ip=localhost
 

--- a/src/kw_config_loader.sh
+++ b/src/kw_config_loader.sh
@@ -33,6 +33,7 @@ function show_variables()
   fi
 
   local -Ar ssh=(
+    [ssh_user]='SSH user'
     [ssh_ip]='SSH address'
     [ssh_port]='SSH port'
   )

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -97,15 +97,6 @@ function tearDown()
   rm -rf "$FAKE_KERNEL"
 }
 
-function test_expected_string()
-{
-  local msg="$1"
-  local expected="$2"
-  local target="$3"
-
-  assertEquals "$msg" "$target" "$expected"
-}
-
 # This test relies on kworkflow.config loaded during the setUp
 #
 # Output sequence of kernel_deploy in the TEST_MODE:
@@ -272,8 +263,8 @@ function test_kernel_install()
     return
   }
 
-  options_values['REMOTE_IP']='127.0.0.1'
-  options_values['REMOTE_PORT']=3333
+  remote_parameters['REMOTE_IP']='127.0.0.1'
+  remote_parameters['REMOTE_PORT']=3333
 
   output=$(kernel_install 1 'test' 'TEST_MODE' 3) # 3: REMOTE_TARGET
   compare_command_sequence expected_cmd[@] "$output" "$LINENO"

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -440,7 +440,7 @@ function test_kernel_modules()
   setupRemote
 
   ID=1
-  output=$(modules_install "TEST_MODE" "3" "127.0.0.1:3333")
+  output=$(modules_install "TEST_MODE" 3)
   while read -r f; do
     if [[ ${expected_cmd[$count]} != ${f} ]]; then
       fail "$count - Expected cmd \"${expected_cmd[$count]}\" to be \"${f}\""
@@ -449,12 +449,12 @@ function test_kernel_modules()
   done <<< "$output"
 
   ID=2
-  output=$(modules_install "TEST_MODE" "1" "")
+  output=$(modules_install "TEST_MODE" 1)
   expected_output="make INSTALL_MOD_PATH=/home/lala modules_install"
   assertEquals "$ID: " "$output" "$expected_output"
 
   ID=3
-  output=$(modules_install "TEST_MODE" "2" "")
+  output=$(modules_install "TEST_MODE" 2)
   expected_output="sudo -E make modules_install"
   assertEquals "$ID: " "$output" "$expected_output"
 
@@ -565,7 +565,7 @@ function test_list_remote_kernels()
 
   setupRemote
 
-  output=$(list_installed_kernels "TEST_MODE" "0" "3" "127.0.0.1:3333")
+  output=$(list_installed_kernels "TEST_MODE" 0 3)
   while read -r f; do
     if [[ ${expected_cmd[$count]} != ${f} ]]; then
       fail "$count - Expected cmd \"${expected_cmd[$count]}\" to be \"${f}\""
@@ -617,12 +617,14 @@ function test_kernel_uninstall()
 
   # List of kernels
   ID=1
-  output=$(kernel_uninstall "3" "0" "127.0.0.1:3333" "$kernel_list" "TEST_MODE")
+  options_values['REMOTE_IP']='127.0.0.1'
+  options_values['REMOTE_PORT']=3333
+  output=$(kernel_uninstall 3 0 "$kernel_list" "TEST_MODE")
   compare_command_sequence expected_cmd[@] "$output" "$ID"
 
   # Reboot
   ID=2
-  output=$(kernel_uninstall "3" "1" "127.0.0.1:3333" "$kernel_list" "TEST_MODE")
+  output=$(kernel_uninstall 3 1 "$kernel_list" "TEST_MODE")
   cmd="bash $remote_path/deploy.sh --uninstall_kernel 1 remote $kernel_list TEST_MODE"
   kernel_uninstall_cmd="ssh -p 3333 root@127.0.0.1 \"$cmd\""
   expected_cmd[4]="$kernel_uninstall_cmd"
@@ -631,7 +633,7 @@ function test_kernel_uninstall()
 
   # Single kernel
   ID=3
-  output=$(kernel_uninstall "3" "1" "127.0.0.1:3333" "$single_kernel" "TEST_MODE")
+  output=$(kernel_uninstall 3 1 "$single_kernel" "TEST_MODE")
   cmd="bash $remote_path/deploy.sh --uninstall_kernel 1 remote $single_kernel TEST_MODE"
   kernel_uninstall_cmd="ssh -p 3333 root@127.0.0.1 \"$cmd\""
   expected_cmd[4]="$kernel_uninstall_cmd"

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -120,45 +120,45 @@ function test_kernel_deploy()
     return
   }
 
-  # From kworkflow.config file we expect 0 0 1 127.0.0.1:3333 0 0
+  # From kworkflow.config file we expect 0 0 1 127.0.0.1 3333 0 0
   ID=1
   output=$(kernel_deploy test_mode)
-  expected_result="0 0 1 127.0.0.1:3333 0 0"
+  expected_result="0 0 1 127.0.0.1 3333 0 0"
   assertEquals "($ID) Pure config:" "$expected_result" "$output"
 
   ID=2
   output=$(kernel_deploy test_mode --modules)
-  expected_result="0 1 1 127.0.0.1:3333 0 0"
+  expected_result="0 1 1 127.0.0.1 3333 0 0"
   assertEquals "($ID) Modules:" "$expected_result" "$output"
 
   ID=3
   output=$(kernel_deploy test_mode --reboot)
-  expected_result="1 0 1 127.0.0.1:3333 0 0"
+  expected_result="1 0 1 127.0.0.1 3333 0 0"
   assertEquals "($ID) Reboot: " "$expected_result" "$output"
 
   ID=4
   output=$(kernel_deploy test_mode --reboot --modules)
-  expected_result="1 1 1 127.0.0.1:3333 0 0"
+  expected_result="1 1 1 127.0.0.1 3333 0 0"
   assertEquals "($ID) Reboot, Modules:" "$expected_result" "$output"
 
   ID=5
   output=$(kernel_deploy test_mode --local --reboot --modules)
-  expected_result="1 1 2 127.0.0.1:3333 0 0"
+  expected_result="1 1 2 127.0.0.1 3333 0 0"
   assertEquals "($ID) Local, Reboot, Modules" "$expected_result" "$output"
 
   ID=6
   output=$(kernel_deploy test_mode --remote --reboot)
-  expected_result="1 0 3 127.0.0.1:3333 0 0"
+  expected_result="1 0 3 127.0.0.1 3333 0 0"
   assertEquals "($ID) Remote, Reboot" "$expected_result" "$output"
 
   ID=7
   output=$(kernel_deploy test_mode --remote 192.168.0.10 --reboot)
-  expected_result="1 0 3 192.168.0.10:22 0 0"
+  expected_result="1 0 3 192.168.0.10 22 0 0"
   assertEquals "($ID) Remote: 192.168.0.10, Reboot" "$expected_result" "$output"
 
   ID=8
   output=$(kernel_deploy test_mode --remote 192.168.0.10:1287)
-  expected_result="0 0 3 192.168.0.10:1287 0 0"
+  expected_result="0 0 3 192.168.0.10 1287 0 0"
   assertEquals "($ID) Remote: 192.168.0.10:1287" "$expected_result" "$output"
 
   # Test some invalid parameters
@@ -272,7 +272,10 @@ function test_kernel_install()
     return
   }
 
-  output=$(kernel_install "1" "test" "TEST_MODE" "3" "127.0.0.1:3333")
+  options_values['REMOTE_IP']='127.0.0.1'
+  options_values['REMOTE_PORT']=3333
+
+  output=$(kernel_install 1 'test' 'TEST_MODE' 3) # 3: REMOTE_TARGET
   compare_command_sequence expected_cmd[@] "$output" "$LINENO"
 
   # Update values

--- a/tests/drm_plugin_test.sh
+++ b/tests/drm_plugin_test.sh
@@ -28,34 +28,29 @@ function tearDown()
 
 function test_drm_manager()
 {
-  local ID
+  local output
 
   parse_configuration "$TMP_TEST_DIR/kworkflow.config"
 
-  ID=1
   output=$(drm_manager test_mode --remote --gui-on)
-  expected_result="3 1 0 127.0.0.1:3333"
-  assertEquals "($ID) Remote and --gui-on:" "$expected_result" "$output"
+  expected_result='3 1 0 127.0.0.1 3333'
+  assertEquals "($LINENO) Remote and --gui-on:" "$expected_result" "$output"
 
-  ID=2
   output=$(drm_manager test_mode --remote --gui-off)
-  expected_result="3 0 1 127.0.0.1:3333"
-  assertEquals "($ID) Remote and --gui-off:" "$expected_result" "$output"
+  expected_result='3 0 1 127.0.0.1 3333'
+  assertEquals "($LINENO) Remote and --gui-off:" "$expected_result" "$output"
 
-  ID=3
   output=$(drm_manager test_mode --gui-on)
-  expected_result="3 1 0 127.0.0.1:3333"
-  assertEquals "($ID) just --gui-on:" "$expected_result" "$output"
+  expected_result='3 1 0 127.0.0.1 3333'
+  assertEquals "($LINENO) just --gui-on:" "$expected_result" "$output"
 
-  ID=4
   output=$(drm_manager test_mode --gui-off)
-  expected_result="3 0 1 127.0.0.1:3333"
-  assertEquals "($ID) just --gui-off:" "$expected_result" "$output"
+  expected_result='3 0 1 127.0.0.1 3333'
+  assertEquals "($LINENO) just --gui-off:" "$expected_result" "$output"
 
   # Invalid options
-  ID=5
   output=$(drm_manager test_mode --vm --gui-on)
-  assertEquals "($ID) Should not accept --vm:" "$?" "22"
+  assertEquals "($LINENO) Should not accept --vm:" "$?" 22
 }
 
 function test_gui_control()

--- a/tests/kw_config_loader_test.sh
+++ b/tests/kw_config_loader_test.sh
@@ -60,6 +60,7 @@ function test_parse_configuration_output()
     [cross_compile]="aarch64-linux-gnu-"
     [virtualizer]="libvirt"
     [qemu_path_image]="/home/xpto/p/virty.qcow2"
+    [ssh_user]='juca'
     [ssh_ip]="127.0.0.1"
     [ssh_port]="3333"
     [mount_point]="/home/lala"
@@ -99,6 +100,7 @@ function test_parse_configuration_standard_config()
     [qemu_path_image]="/home/USERKW/p/virty.qcow2"
     [qemu_hw_options]="-enable-kvm -daemonize -smp 2 -m 1024"
     [qemu_net_options]="-nic user,hostfwd=tcp::2222-:22,smb=/home/USERKW"
+    [ssh_user]='root'
     [ssh_ip]="localhost"
     [ssh_port]="22"
     [mount_point]="/home/USERKW/p/mount"

--- a/tests/remote_test.sh
+++ b/tests/remote_test.sh
@@ -69,20 +69,33 @@ function test_populate_remote_info()
   # Force an unspected error
   configurations=()
 
+  populate_remote_info 'localhost'
+  assertEquals "($LINENO) Expected localhost" 'localhost' "${remote_parameters['REMOTE_IP']}"
+  assertEquals "($LINENO) Expected 22" 22 "${remote_parameters['REMOTE_PORT']}"
+  assertEquals "($LINENO) Expected root" 'root' "${remote_parameters['REMOTE_USER']}"
+
   populate_remote_info 'localhost:6789'
   assertEquals "($LINENO) Expected localhost" 'localhost' "${remote_parameters['REMOTE_IP']}"
   assertEquals "($LINENO) Expected 6789" 6789 "${remote_parameters['REMOTE_PORT']}"
+  assertEquals "($LINENO) Expected root" 'root' "${remote_parameters['REMOTE_USER']}"
 
   populate_remote_info 'localhost'
   assertEquals "($LINENO) Expected localhost" 'localhost' "${remote_parameters['REMOTE_IP']}"
   assertEquals "($LINENO) Expected 22" 22 "${remote_parameters['REMOTE_PORT']}"
+  assertEquals "($LINENO) Expected root" 'root' "${remote_parameters['REMOTE_USER']}"
+
+  populate_remote_info 'ada@localhost:3773'
+  assertEquals "($LINENO) Expected localhost" 'localhost' "${remote_parameters['REMOTE_IP']}"
+  assertEquals "($LINENO) Expected 3773" 3773 "${remote_parameters['REMOTE_PORT']}"
+  assertEquals "($LINENO) Expected ada" 'ada' "${remote_parameters['REMOTE_USER']}"
 
   # Let's check with a config file information
   parse_configuration "$KW_CONFIG_SAMPLE"
 
-  populate_remote_info
+  populate_remote_info ''
   assertEquals "($LINENO) Expected 127.0.0.1" '127.0.0.1' "${remote_parameters['REMOTE_IP']}"
   assertEquals "($LINENO) Expected 3333" 3333 "${remote_parameters['REMOTE_PORT']}"
+  assertEquals "($LINENO) Expected juca" 'juca' "${remote_parameters['REMOTE_USER']}"
 
   # Let's check a failure case
   remote_parameters=()

--- a/tests/remote_test.sh
+++ b/tests/remote_test.sh
@@ -61,38 +61,35 @@ function oneTimeTearDown()
   unset KW_CACHE_DIR
 }
 
-function test_get_remote_info()
+function test_populate_remote_info()
 {
-  local ID
+  local ret
+  local output
 
   # Force an unspected error
   configurations=()
 
-  ID=0
-  output=$(get_remote_info)
-  ret="$?"
-  assertEquals "($ID) We did not load kworkflow.config, we expect an error" "22" "$ret"
-  setUp
+  populate_remote_info 'localhost:6789'
+  assertEquals "($LINENO) Expected localhost" 'localhost' "${remote_parameters['REMOTE_IP']}"
+  assertEquals "($LINENO) Expected 6789" 6789 "${remote_parameters['REMOTE_PORT']}"
 
-  ID=1
-  output=$(get_remote_info "localhost:6789")
-  ret="$?"
-  assertEquals "($ID) Expected 0" "0" "$ret"
-  assertEquals "($ID) Expected localhost:6789" "localhost:6789" "$output"
+  populate_remote_info 'localhost'
+  assertEquals "($LINENO) Expected localhost" 'localhost' "${remote_parameters['REMOTE_IP']}"
+  assertEquals "($LINENO) Expected 22" 22 "${remote_parameters['REMOTE_PORT']}"
 
-  ID=2
-  output=$(get_remote_info "localhost")
-  ret="$?"
-  assertEquals "($ID) Expected 0" "0" "$ret"
-  assertEquals "($ID) Expected localhost:22" "localhost:22" "$output"
-
+  # Let's check with a config file information
   parse_configuration "$KW_CONFIG_SAMPLE"
 
-  ID=3
-  output=$(get_remote_info)
+  populate_remote_info
+  assertEquals "($LINENO) Expected 127.0.0.1" '127.0.0.1' "${remote_parameters['REMOTE_IP']}"
+  assertEquals "($LINENO) Expected 3333" 3333 "${remote_parameters['REMOTE_PORT']}"
+
+  # Let's check a failure case
+  remote_parameters=()
+  configurations=()
+  populate_remote_info > /dev/null
   ret="$?"
-  assertEquals "($ID) Expected 0" "0" "$ret"
-  assertEquals "($ID) Expected 127.0.0.1:3333" "127.0.0.1:3333" "$output"
+  assertEquals "($LINENO) We did not load kworkflow.config, we expect an error" 22 "$ret"
 }
 
 function test_cmd_remote()

--- a/tests/samples/kworkflow.config
+++ b/tests/samples/kworkflow.config
@@ -1,3 +1,4 @@
+ssh_user=juca
 ssh_ip=127.0.0.1
 ssh_port=3333
 arch=arm64


### PR DESCRIPTION
I was working on adding the basic support for ChromeOS, and I started to hit multiple limitations in our deploy. In summary, we need to refactor many things around deploy, and one of them is how we handle IP, port, and users. This PR starts by refactoring how we handle IPs and ports. Next, it adds basic support for reading the user name from the configuration file. For the user part, most of this work was triggered by https://github.com/kworkflow/kworkflow/pull/355, which highlighted that we do not enable users to set users that they want.