### PR TITLE
src: kw_include: Disambiguate files with same name

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -250,7 +250,7 @@ function synchronize_files()
   cmd_output_manager "cp $app_name $binpath" "$verbose"
   ASSERT_IF_NOT_EQ_ZERO "The command 'cp $app_name $binpath' failed" "$?"
 
-  sed -i -e "s,##KW_INSTALL_PREFIX_TOKEN##,$PREFIX/,g" "$binpath/$app_name"
+  sed -i -e "s,##KW_INSTALL_PREFIX_TOKEN##,$PREFIX,g" "$binpath/$app_name"
   sed -i -e "/##BEGIN-DEV-MODE##/,/##END-DEV-MODE##/ d" "$binpath/$app_name"
 
   # Lib files

--- a/src/kw_include.sh
+++ b/src/kw_include.sh
@@ -10,8 +10,6 @@ function include()
   local filepath="$1"
   local varname
 
-  varname=$(basename "$filepath" .sh)
-
   if [[ ! -e "$filepath" ]]; then
     echo "File $filepath could not be found, check your file path."
     return 2 # ENOENT
@@ -22,7 +20,11 @@ function include()
     return 1 # EPERM
   fi
 
-  varname=${varname^^}_IMPORTED # capitalize and append "_IMPORTED"
+  varname="$(realpath "$filepath")"
+  varname="${varname#"$KW_LIB_DIR/"}" # leave path until KW_LIB_DIR
+  varname="${varname//\//_}"          # change bars to underlines
+  varname="${varname%.*}"             # remove extension
+  varname="${varname^^}_IMPORTED"     # capitalize and append "_IMPORTED"
 
   if [[ -v "${varname}" ]]; then
     return 0

--- a/tests/kw_include_test.sh
+++ b/tests/kw_include_test.sh
@@ -2,6 +2,11 @@
 
 include './tests/utils.sh'
 
+function oneTimeSetUp()
+{
+  KW_LIB_DIR="$PWD/src"
+}
+
 function test_include()
 {
   include ./src/kwio.sh
@@ -22,6 +27,25 @@ function test_include_wrong_path()
   output=$(include ./src/batata.sh)
   ret="$?"
   assertEquals "($LINENO)" 2 "$ret"
+}
+
+function test_include_same_name()
+{
+  local test1_output
+  local test2_output
+  local test1_expected
+  local test2_expected
+
+  include 'tests/samples/include_test'
+  include 'tests/samples/include_test_dir/include_test'
+
+  test1_output=$(test1)
+  test2_output=$(test2)
+  test1_expected='output of test1'
+  test2_expected='output of test2'
+
+  assertEquals "($LINENO)" "${test1_output}" "${test1_expected}"
+  assertEquals "($LINENO)" "${test2_output}" "${test2_expected}"
 }
 
 invoke_shunit

--- a/tests/samples/include_test
+++ b/tests/samples/include_test
@@ -1,0 +1,4 @@
+function test1()
+{
+  echo 'output of test1'
+}

--- a/tests/samples/include_test_dir/include_test
+++ b/tests/samples/include_test_dir/include_test
@@ -1,0 +1,4 @@
+function test2()
+{
+  echo 'output of test2'
+}


### PR DESCRIPTION
Previously, files with the same name but in different folders couldn't
be included concomitantly, because the include manager would use the
same variable to keep track of which file was already included. This
commit introduces a method for creating such variable that is based on
the path of the file, not only its name.

Signed-off-by: João Seckler <jseckler@riseup.net>