### PR TITLE
Implement package building and deploy

### DIFF
--- a/documentation/man/features/deploy.rst
+++ b/documentation/man/features/deploy.rst
@@ -8,7 +8,8 @@ SYNOPSIS
 ========
 *kw* (*d* | *deploy*) [\--remote <remote>:<port> | \--local | \--vm]
                       [-r | \--reboot] [-m | \--modules] [-s | \--ls-line]
-                      [-l | \--list] [(-u | \--uninstall) <kernel-name>[,...]]
+                      [-l | \--list] [-a | \--list-all]
+                      [(-u | \--uninstall) <kernel-name>[,...]] [-f \--force]
                       [\--alert=(s | v | (sv | vs) | n)]
 
 DESCRIPTION
@@ -72,12 +73,19 @@ OPTIONS
 -l, \--list:
   List available kernels in a single column the target.
 
+-a, \--list-all:
+  List all available kernels, including the ones not installed by kw.
+
 -s, \--ls-line:
   List available kernels separated by comma.
 
 -u <kernel-name>[,...], \--uninstall <kernel-name>[,...]:
   Remove a single kernel or multiple kernels; for removing
   multiple kernels it is necessary to separate them with comma.
+
+-f, \--force:
+  Remove kernels even if they were not installed by kw (only valid with
+  \--uninstall or -u)
 
 \--alert=(s | v | (sv | vs) | n):
   Defines the alert behaviour upon the command completion.

--- a/etc/kworkflow_template.config
+++ b/etc/kworkflow_template.config
@@ -90,3 +90,8 @@ disable_statistics_data_track=no
 #gui_on=systemctl isolate graphical.target
 # Set a specific command to deactivate the GUI
 #gui_off=systemctl isolate multi-user.target
+
+# Build and deploy using packages by default. Available options are no
+# and debian
+use_pkg=no
+

--- a/src/kw_config_loader.sh
+++ b/src/kw_config_loader.sh
@@ -52,6 +52,7 @@ function show_variables()
     [cross_compile]='Cross-compile name'
     [menu_config]='Kernel menu config'
     [doc_type]='Command to generate kernel-doc'
+    [use_pkg]='Use packaging for build and deploy'
   )
 
   local -Ar qemu=(

--- a/src/plugins/kernel_install/utils.sh
+++ b/src/plugins/kernel_install/utils.sh
@@ -85,7 +85,7 @@ function list_installed_kernels()
   output=$(echo "$output" | grep recovery -v | grep with | awk -F" " '{print $NF}')
 
   while read -r kernel; do
-    if [[ -f "$prefix/boot/vmlinuz-$kernel" ]]; then
+    if [[ -f "$prefix/boot/vmlinuz-$kernel" && ! "$kernel" =~ .*\.old$ ]]; then
       available_kernels+=("$kernel")
     fi
   done <<< "$output"

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -28,6 +28,15 @@ function root_id_mock()
   echo "0"
 }
 
+function oneTimeSetUp()
+{
+  function sudo()
+  {
+    eval "$*"
+  }
+  export -f sudo
+}
+
 function setUp()
 {
   local create_mkinitcpio="$1"
@@ -50,6 +59,8 @@ function setUp()
   export DEPLOY_SCRIPT="$test_path/$kernel_install_path/deploy.sh"
   export KW_PLUGINS_DIR="$PWD/src/plugins/"
   export modules_path="$test_path/$kernel_install_path/lib/modules"
+
+  KW_LIB_DIR="$PWD/$SAMPLES_DIR"
 
   mkdir "$test_path/$LOCAL_TO_DEPLOY_DIR"
   mkdir "$test_path/$LOCAL_REMOTE_DIR"
@@ -98,7 +109,6 @@ function tearDown()
 
 function test_modules_install_to()
 {
-  local ID
   local original="$PWD"
 
   # Copy test.preset to remote
@@ -109,11 +119,10 @@ function test_modules_install_to()
     return
   }
 
-  ID=1
   output=$(modules_install_to "$test_path" "TEST_MODE")
 
   if [[ "$output" != "$make_install_cmd" ]]; then
-    fail "$ID - Expected \"$output\" to be \"$make_install_cmd\""
+    fail "$LINENO - Expected \"$output\" to be \"$make_install_cmd\""
   fi
 
   cd "$original" || {
@@ -344,24 +353,16 @@ function test_kernel_modules()
 
   setupRemote
 
-  ID=1
   output=$(modules_install "TEST_MODE" 3)
-  while read -r f; do
-    if [[ ${expected_cmd[$count]} != "${f}" ]]; then
-      fail "$count - Expected cmd \"${f}\" to be \"${expected_cmd[$count]}\""
-    fi
-    ((count++))
-  done <<< "$output"
+  compare_command_sequence 'expected_cmd' "$output" "$LINENO"
 
-  ID=2
   output=$(modules_install "TEST_MODE" 1)
   expected_output="make INSTALL_MOD_PATH=/home/lala modules_install"
-  assertEquals "$ID: " "$output" "$expected_output"
+  assertEquals "$LINENO: " "$output" "$expected_output"
 
-  ID=3
   output=$(modules_install "TEST_MODE" 2)
   expected_output="sudo -E make modules_install"
-  assertEquals "$ID: " "$output" "$expected_output"
+  assertEquals "$LINENO: " "$output" "$expected_output"
 
   cd "$original" || {
     fail "($LINENO) It was not possible to move back from temp directory"
@@ -371,7 +372,6 @@ function test_kernel_modules()
 
 function test_kernel_modules_local()
 {
-  local ID
   local original="$PWD"
   local cmd="sudo -E make modules_install"
 
@@ -379,9 +379,8 @@ function test_kernel_modules_local()
     fail "($LINENO) It was not possible to move to temporary directory"
     return
   }
-  ID=1
   output=$(modules_install "TEST_MODE" "2")
-  assertFalse "$ID - Expected $output to be $cmd" '[[ "$cmd" != "$output" ]]'
+  assertFalse "$LINENO - Expected $output to be $cmd" '[[ "$cmd" != "$output" ]]'
   cd "$original" || {
     fail "($LINENO) It was not possible to move back from temp directory"
     return
@@ -398,12 +397,14 @@ function test_kernel_install_local()
   local cmd_update_initramfs="sudo -E update-initramfs -c -k test"
   local cmd_update_grub="sudo -E grub-mkconfig -o /boot/grub/grub.cfg"
   local cmd_reboot="sudo -E reboot"
+  local cmd_register_kernel="sudo tee -a '$REMOTE_KW_DEPLOY/MANAGED_KERNELS' > /dev/null"
   local msg=""
 
   declare -a expected_cmd=(
     "$cmd_cp_kernel_img"
     "$cmd_update_initramfs"
     "$cmd_update_grub"
+    "$cmd_register_kernel"
     "$cmd_reboot"
   )
 
@@ -459,7 +460,7 @@ function test_list_remote_kernels()
   local rsync_utils="$rsync_cmd $kernel_install_path/utils.sh $remote_access:$remote_path/ --rsync-path='sudo rsync'"
   local cmd_chown_utils="$ssh_cmd $remote_access sudo \"chown -R root:root $remote_path/\""
 
-  local remote_list_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"bash /root/kw_deploy/deploy.sh --list_kernels 0\""
+  local remote_list_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"bash /root/kw_deploy/deploy.sh --list_kernels '' '0' '' ''\""
 
   declare -a expected_cmd=(
     "$dir_kw_deploy"
@@ -480,12 +481,7 @@ function test_list_remote_kernels()
   setupRemote
 
   output=$(list_installed_kernels "TEST_MODE" 0 3)
-  while read -r f; do
-    if [[ ${expected_cmd[$count]} != "${f}" ]]; then
-      fail "$count - Expected cmd \"${f}\" to be \"${expected_cmd[$count]}\""
-    fi
-    ((count++))
-  done <<< "$output"
+  compare_command_sequence 'expected_cmd' "$output" "$LINENO"
 
   cd "$original" || {
     fail "($LINENO) It was not possible to move back from temp directory"
@@ -508,7 +504,7 @@ function test_kernel_uninstall()
   local dir_kw_deploy="$ssh_cmd $remote_access sudo \"mkdir -p $remote_path\""
 
   # Rsync script command
-  local cmd="bash $remote_path/deploy.sh --uninstall_kernel 0 remote $kernel_list TEST_MODE"
+  local cmd="bash $remote_path/deploy.sh --uninstall_kernel '' '0' remote '$kernel_list' 'TEST_MODE' ''"
 
   local rsync_debian="$rsync_cmd $kernel_install_path/debian.sh $remote_access:$remote_path/distro_deploy.sh --rsync-path='sudo rsync'"
   local cmd_chown_debian="$ssh_cmd $remote_access sudo \"chown -R root:root $remote_path/distro_deploy.sh\""
@@ -540,25 +536,22 @@ function test_kernel_uninstall()
   setupRemote
 
   # List of kernels
-  ID=1
   options_values['REMOTE_IP']='127.0.0.1'
   options_values['REMOTE_PORT']=3333
   output=$(kernel_uninstall 3 0 "$kernel_list" "TEST_MODE")
   compare_command_sequence 'expected_cmd' "$output" "$ID"
 
   # Reboot
-  ID=2
   output=$(kernel_uninstall 3 1 "$kernel_list" "TEST_MODE")
-  cmd="bash $remote_path/deploy.sh --uninstall_kernel 1 remote $kernel_list TEST_MODE"
+  cmd="bash $remote_path/deploy.sh --uninstall_kernel '' '1' remote '$kernel_list' 'TEST_MODE' ''"
   kernel_uninstall_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"$cmd\""
   expected_cmd[7]="$kernel_uninstall_cmd"
 
   compare_command_sequence 'expected_cmd' "$output" "$ID"
 
   # Single kernel
-  ID=3
   output=$(kernel_uninstall 3 1 "$single_kernel" "TEST_MODE")
-  cmd="bash $remote_path/deploy.sh --uninstall_kernel 1 remote $single_kernel TEST_MODE"
+  cmd="bash $remote_path/deploy.sh --uninstall_kernel '' '1' remote '$single_kernel' 'TEST_MODE' ''"
   kernel_uninstall_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"$cmd\""
   expected_cmd[7]="$kernel_uninstall_cmd"
 
@@ -585,11 +578,7 @@ function test_cleanup()
   #shellcheck disable=SC2153
   options_values[REMOTE]=1
   output=$(cleanup "TEST_MODE")
-  while read -r f; do
-    assertFalse "$ID (cmd: $count) - Expected \"${f}\" to be \"${expected_cmd[$count]}\"" \
-      '[[ ${expected_cmd[$count]} != ${f} ]]'
-    ((count++))
-  done <<< "$output"
+  compare_command_sequence 'expected_cmd' "$output" "$LINENO"
 }
 
 function test_parse_deploy_options()
@@ -681,6 +670,16 @@ function test_parse_deploy_options()
   declare -gA options_values
   parse_deploy_options -s
   assertEquals "($LINENO)" '1' "${options_values['LS_LINE']}"
+
+  unset options_values
+  declare -gA options_values
+  parse_deploy_options --list-all
+  assertEquals "($LINENO)" '1' "${options_values['LS_ALL']}"
+
+  unset options_values
+  declare -gA options_values
+  parse_deploy_options -a
+  assertEquals "($LINENO)" '1' "${options_values['LS_ALL']}"
 
   unset options_values
   declare -gA options_values

--- a/tests/kw_config_loader_test.sh
+++ b/tests/kw_config_loader_test.sh
@@ -37,9 +37,9 @@ function assertConfigurations()
   # check if configurations is contained in expected_configurations
   for k in "${!configurations_ref[@]}"; do
     if [[ ${expected_configurations_ref[$k]+token} != token ]]; then
-      fail "Did not expect setting \"$k\"."
+      fail "($LINENO) Did not expect setting \"$k\"."
     elif [[ ${configurations_ref[$k]} != "${expected_configurations_ref[$k]}" ]]; then
-      fail "Expected setting \"${k}\" to be \"${expected_configurations_ref[$k]}\" (found \"${configurations_ref[$k]}\")."
+      fail "($LINENO) Expected setting \"${k}\" to be \"${expected_configurations_ref[$k]}\" (found \"${configurations_ref[$k]}\")."
     fi
   done
 
@@ -55,20 +55,20 @@ function assertConfigurations()
 function test_parse_configuration_output()
 {
   declare -A expected_configurations=(
-    [arch]="arm64"
-    [kernel_img_name]="Image"
-    [cross_compile]="aarch64-linux-gnu-"
-    [virtualizer]="libvirt"
-    [qemu_path_image]="/home/xpto/p/virty.qcow2"
+    [arch]='arm64'
+    [kernel_img_name]='Image'
+    [cross_compile]='aarch64-linux-gnu-'
+    [virtualizer]='libvirt'
+    [qemu_path_image]='/home/xpto/p/virty.qcow2'
     [ssh_user]='juca'
-    [ssh_ip]="127.0.0.1"
-    [ssh_port]="3333"
-    [mount_point]="/home/lala"
-    [default_deploy_target]="vm"
-    [reboot_after_deploy]="no"
-    [gui_on]="turn on"
-    [gui_off]="turn off"
-    [doc_type]="htmldocs"
+    [ssh_ip]='127.0.0.1'
+    [ssh_port]='3333'
+    [mount_point]='/home/lala'
+    [default_deploy_target]='vm'
+    [reboot_after_deploy]='no'
+    [gui_on]='turn on'
+    [gui_off]='turn off'
+    [doc_type]='htmldocs'
   )
 
   cp tests/samples/kworkflow.config "$TMP_DIR/"
@@ -93,24 +93,25 @@ function test_parse_configuration_standard_config()
 {
 
   declare -A expected_configurations=(
-    [arch]="x86_64"
-    [kernel_img_name]="bzImage"
-    [menu_config]="nconfig"
-    [virtualizer]="qemu-system-x86_64"
-    [qemu_path_image]="/home/USERKW/p/virty.qcow2"
-    [qemu_hw_options]="-enable-kvm -daemonize -smp 2 -m 1024"
-    [qemu_net_options]="-nic user,hostfwd=tcp::2222-:22,smb=/home/USERKW"
+    [arch]='x86_64'
+    [kernel_img_name]='bzImage'
+    [menu_config]='nconfig'
+    [virtualizer]='qemu-system-x86_64'
+    [qemu_path_image]='/home/USERKW/p/virty.qcow2'
+    [qemu_hw_options]='-enable-kvm -daemonize -smp 2 -m 1024'
+    [qemu_net_options]='-nic user,hostfwd=tcp::2222-:22,smb=/home/USERKW'
     [ssh_user]='root'
-    [ssh_ip]="localhost"
-    [ssh_port]="22"
-    [mount_point]="/home/USERKW/p/mount"
-    [alert]="n"
-    [sound_alert_command]="paplay SOUNDPATH/bell.wav"
+    [ssh_ip]='localhost'
+    [ssh_port]='22'
+    [mount_point]='/home/USERKW/p/mount'
+    [alert]='n'
+    [sound_alert_command]='paplay SOUNDPATH/bell.wav'
     [visual_alert_command]="notify-send -i checkbox -t 10000 \"kw\" \"Command: \\\"\$COMMAND\\\" completed!\""
-    [default_deploy_target]="vm"
-    [reboot_after_deploy]="no"
-    [disable_statistics_data_track]="no"
-    [doc_type]="htmldocs"
+    [default_deploy_target]='vm'
+    [reboot_after_deploy]='no'
+    [disable_statistics_data_track]='no'
+    [doc_type]='htmldocs'
+    [use_pkg]='no'
   )
 
   parse_configuration "$TMP_DIR/kworkflow.config"

--- a/tests/plugins/kernel_install/utils_test.sh
+++ b/tests/plugins/kernel_install/utils_test.sh
@@ -52,37 +52,26 @@ function test_ask_yN()
 
 function test_human_list_installed_kernels()
 {
-  local count=0
-
   declare -a expected_out=(
     "" # Extra espace in the beginning
-    "5.5.0-rc2-VKMS+"
-    "5.6.0-rc2-AMDGPU+"
-    "linux"
+    '5.5.0-rc2-VKMS+'
+    '5.6.0-rc2-AMDGPU+'
+    'linux'
   )
 
-  output=$(list_installed_kernels "0" "$SHUNIT_TMPDIR")
-  while read -r out; do
-    assertEquals "$count - Expected kernel list" "${expected_out[$count]}" "$out"
-    ((count++))
-  done <<< "$output"
+  output=$(list_installed_kernels '0' "$SHUNIT_TMPDIR")
+  compare_command_sequence expected_out[@] "$output" "$LINENO"
 }
 
 function test_command_list_installed_kernels()
 {
-  local count=0
-
   declare -a expected_out=(
-    "" # Extra espace in the beginning
-    "5.5.0-rc2-VKMS+,5.6.0-rc2-AMDGPU+,linux"
+    '' # Extra espace in the beginning
+    '5.5.0-rc2-VKMS+,5.6.0-rc2-AMDGPU+,linux'
   )
 
-  output=$(list_installed_kernels "1" "$SHUNIT_TMPDIR")
-  while read -r out; do
-    assertEquals "$count - Expected kernel list" "${expected_out[$count]}" "$out"
-    ((count++))
-  done <<< "$output"
-
+  output=$(list_installed_kernels '1' "$SHUNIT_TMPDIR")
+  compare_command_sequence expected_out[@] "$output" "$LINENO"
 }
 
 function test_reboot_machine()

--- a/tests/plugins/kernel_install/utils_test.sh
+++ b/tests/plugins/kernel_install/utils_test.sh
@@ -6,6 +6,23 @@
 
 declare -r TEST_ROOT_PATH="$PWD"
 
+function oneTimeSetUp()
+{
+  declare -g REMOTE_KW_DEPLOY="$PWD/tests/samples"
+
+  # Mocking the sudo function
+  function sudo()
+  {
+    eval "$*"
+  }
+  export -f sudo
+}
+
+function oneTimeTearDown()
+{
+  rm -f "$REMOTE_KW_DEPLOY/MANAGED_KERNELS"
+}
+
 function setUp()
 {
   local current_path="$PWD"
@@ -53,25 +70,54 @@ function test_ask_yN()
 function test_human_list_installed_kernels()
 {
   declare -a expected_out=(
-    "" # Extra espace in the beginning
+    "sudo mkdir -p '$REMOTE_KW_DEPLOY'"
+    "sudo touch '$REMOTE_KW_DEPLOY/MANAGED_KERNELS'"
+    ''
+    ''
+    ''
     '5.5.0-rc2-VKMS+'
     '5.6.0-rc2-AMDGPU+'
     'linux'
   )
 
-  output=$(list_installed_kernels '0' "$SHUNIT_TMPDIR")
-  compare_command_sequence expected_out[@] "$output" "$LINENO"
+  printf '%s\n' "${expected_out[@]}" > "$REMOTE_KW_DEPLOY/MANAGED_KERNELS"
+
+  output=$(list_installed_kernels 'TEST_MODE' '0' "$SHUNIT_TMPDIR")
+  compare_command_sequence 'expected_out' "$output" "$LINENO"
 }
 
 function test_command_list_installed_kernels()
 {
   declare -a expected_out=(
-    '' # Extra espace in the beginning
+    "sudo mkdir -p '$REMOTE_KW_DEPLOY'"
+    "sudo touch '$REMOTE_KW_DEPLOY/MANAGED_KERNELS'"
+    ''
+    ''
+    ''
     '5.5.0-rc2-VKMS+,5.6.0-rc2-AMDGPU+,linux'
   )
 
-  output=$(list_installed_kernels '1' "$SHUNIT_TMPDIR")
-  compare_command_sequence expected_out[@] "$output" "$LINENO"
+  printf '%s\n' "${expected_out[@]/,/$'\n'}" > "$REMOTE_KW_DEPLOY/MANAGED_KERNELS"
+
+  output=$(list_installed_kernels 'TEST_MODE' '1' "$SHUNIT_TMPDIR")
+  compare_command_sequence 'expected_out' "$output" "$LINENO"
+}
+
+function test_list_unmanaged_kernels()
+{
+  local output
+  local expected
+
+  echo -n '' > "$REMOTE_KW_DEPLOY/MANAGED_KERNELS"
+
+  expected=(
+    "sudo mkdir -p '$REMOTE_KW_DEPLOY'"
+    "sudo touch '$REMOTE_KW_DEPLOY/MANAGED_KERNELS'"
+    '5.5.0-rc2-VKMS+,5.5.0-rc2-VKMS+.old,5.6.0-rc2-AMDGPU+,linux'
+  )
+
+  output=$(list_installed_kernels 'TEST_MODE' "1" "$SHUNIT_TMPDIR" "1")
+  compare_command_sequence 'expected' "$output" "($LINENO)"
 }
 
 function test_reboot_machine()
@@ -87,6 +133,60 @@ function test_reboot_machine()
 
   output=$(reboot_machine '1' 'local' 'TEST_MODE')
   assert_equals_helper 'Disable reboot in a non-local machine' "$LINENO" 'sudo -E reboot' "$output"
+}
+
+function test_kernel_uninstall_unmanaged()
+{
+  local output
+  local -a expected
+
+  expected=(
+    "sudo mkdir -p '$REMOTE_KW_DEPLOY'"
+    "sudo touch '$REMOTE_KW_DEPLOY/MANAGED_KERNELS'"
+    "sudo grep -q 'kname' '$REMOTE_KW_DEPLOY/MANAGED_KERNELS'"
+    'Kernel not managed by kw. Use --force/-f to uninstall anyway.'
+  )
+  # Test unmanaged
+  output=$(kernel_uninstall 'TEST_MODE' '0' 'local' 'kname' 'TEST_MODE' '')
+  compare_command_sequence 'expected' "$output" "$LINENO"
+}
+
+function test_kernel_uninstall_managed()
+{
+  local target='xpto'
+  local prefix="./test"
+  local kernelpath="/boot/vmlinuz-$target"
+  local initrdpath="/boot/initrd.img-$target"
+  local modulespath="/lib/modules/$target"
+  local libpath="/var/lib/initramfs-tools/$target"
+
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
+
+  local -a cmd_sequence=(
+    "sudo mkdir -p '$REMOTE_KW_DEPLOY'"
+    "sudo touch '$REMOTE_KW_DEPLOY/MANAGED_KERNELS'"
+    "sudo grep -q 'xpto' '$REMOTE_KW_DEPLOY/MANAGED_KERNELS'"
+    "Removing: $target"
+    "Can't find $kernelpath"
+    "Can't find $kernelpath.old"
+    "Can't find $initrdpath"
+    "Can't find $modulespath"
+    "Can't find $libpath"
+    "update_boot_loader xpto local TEST_MODE"
+    "grub-mkconfig -o /boot/grub/grub.cfg"
+    "sudo sed -i '/xpto/d' '$REMOTE_KW_DEPLOY/MANAGED_KERNELS'"
+  )
+
+  output=$(kernel_uninstall 'TEST_MODE' 0 'local' 'xpto' 'TEST_MODE' '1')
+  compare_command_sequence 'cmd_sequence' "$output" "$LINENO"
+
+  cd "$TEST_ROOT_PATH" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 function test_do_uninstall_cmd_sequence()
@@ -283,6 +383,7 @@ function test_install_kernel_remote()
     "cp -v vmlinuz-$name $path_prefix/boot/vmlinuz-$name"
     'generate_debian_temporary_root_file_system_mock'
     'update_debian_boot_loader_mock'
+    "sudo tee -a '$REMOTE_KW_DEPLOY/MANAGED_KERNELS' > /dev/null"
     'reboot'
   )
   output=$(install_kernel "$name" 'debian' "$kernel_image_name" "$reboot" "$architecture" "$target" 'TEST_MODE')
@@ -305,6 +406,7 @@ function test_install_kernel_local()
     "$sudo_cmd cp -v arch/$architecture/boot/$kernel_image_name $path_prefix/boot/vmlinuz-$name"
     'generate_debian_temporary_root_file_system_mock'
     'update_debian_boot_loader_mock'
+    "sudo tee -a '$REMOTE_KW_DEPLOY/MANAGED_KERNELS' > /dev/null"
     "$sudo_cmd reboot"
   )
 
@@ -335,6 +437,7 @@ function test_install_kernel_vm()
     'generate_debian_temporary_root_file_system_mock'
     "vm_umount"
     'update_debian_boot_loader_mock'
+    "sudo tee -a '$REMOTE_KW_DEPLOY/MANAGED_KERNELS' > /dev/null"
   )
 
   cd "$SHUNIT_TMPDIR" || {

--- a/tests/samples/boot/grub/grub.cfg
+++ b/tests/samples/boot/grub/grub.cfg
@@ -22,6 +22,17 @@ submenu 'Advanced options for Arch Linux' $menuentry_id_option 'gnulinux-advance
 		echo	'Loading initial ramdisk ...'
 		initrd	/boot/initramfs-5.5.0-rc2-VKMS+.img
 	}
+	menuentry 'Arch Linux, with Linux 5.5.0-rc2-VKMS+.old' --class arch --class gnu-linux --class gnu --class os $menuentry_id_option 'gnulinux-5.5.0-rc2-VKMS+.old' {
+		load_video
+		set gfxpayload=keep
+		insmod gzio
+		insmod part_msdos
+		insmod ext2
+		set root='hd0,msdos1'
+		linux	/boot/vmlinuz-5.5.0-rc2-VKMS+.old root=UUID= rw  loglevel=3 quiet
+		echo	'Loading initial ramdisk ...'
+		initrd	/boot/initramfs-5.5.0-rc2-VKMS+.old.img
+	}
 	menuentry 'Arch Linux, with Linux 5.6.0-rc2-AMDGPU+' --class arch --class gnu-linux --class gnu --class os $menuentry_id_option 'gnulinux-5.6.0-rc2-AMDGPU+' {
 		load_video
 		set gfxpayload=keep


### PR DESCRIPTION
This PR introduces to kw the ability to handle packages. This is still work in progress. The following steps include:

 - Include configuration options for package building and deploying (`build_as_package`, etc)
 - In `kw b --pkg`, parse the command line and accept types of packages (debian, rpm, etc)
 - In `kw d --pkg`, parse the command line and accept a path to a package
 - Handle uninstallation of package
 - Check if `kw d --list` is listing package-installed kernels properly
 - A tutorial on using packages

