### PR TITLE
shellcheck: Fix warnings related to arrays

### DIFF
--- a/kw
+++ b/kw
@@ -121,7 +121,7 @@ function kw()
         include "$KW_LIB_DIR/kw_config_loader.sh"
         include "$KW_LIB_DIR/remote.sh"
 
-        kw_ssh $@
+        kw_ssh "$@"
       )
       ;;
     vars)
@@ -142,7 +142,7 @@ function kw()
       (
         include "$KW_LIB_DIR/get_maintainer_wrapper.sh"
 
-        execute_get_maintainer $@
+        execute_get_maintainer "$@"
       )
       ;;
     configm | g)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -52,7 +52,7 @@ function get_external_scripts()
   echo
 
   mkdir -p "$PATH_TO_TESTS_EXTERNALS"
-  for url in ${DOWNLOAD_URLS[@]}; do
+  for url in "${DOWNLOAD_URLS[@]}"; do
     download_stuff "${!url}" "$PATH_TO_TESTS_EXTERNALS" "$OVERWRITE"
     if [[ "$?" -eq 113 ]]; then
       return 113 # Host unreachable errno
@@ -189,7 +189,7 @@ elif [[ "$1" == "list" ]]; then
     say "$index) ${test_name}"
   done
 elif [[ "$1" == "test" ]]; then
-  strip_path ${@:2}
+  strip_path "${*:2}"
   run_tests
 elif [[ "$1" == "prepare" ]]; then
   if [[ "$#" -gt 1 && ("$2" == "--force-update" || "$2" == "-f") ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -67,7 +67,7 @@ function check_dependencies()
     cmd="apt install $package_list"
   else
     warning "Unfortunately, we do not have official support for your distro (yet)"
-    warning "Please, try to find the following packages: ${arch_packages[@]}"
+    warning "Please, try to find the following packages: ${arch_packages[*]}"
     return 0
   fi
 

--- a/src/config_manager.sh
+++ b/src/config_manager.sh
@@ -109,7 +109,7 @@ function basic_config_validations()
   local target="$1"
   local force="$2"
   local operation="$3" && shift 3
-  local message="$@"
+  local message="$*"
   local -r dot_configs_dir="$KW_DATA_DIR/configs/configs"
 
   if [[ ! -f "$dot_configs_dir/$target" ]]; then
@@ -217,7 +217,7 @@ function execute_config_manager()
         exit 22 # EINVAL
       fi
       # Shift name and get '-d'
-      shift 2 && description_config="$@"
+      shift 2 && description_config="$*"
       save_config_file "$force" "$name_config" "$description_config"
       ;;
     --list | -l)

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -528,7 +528,7 @@ function deploy_help()
 # output is the remote info as IP:PORT
 function get_remote_info()
 {
-  ip="$@"
+  ip="$1"
 
   if [[ -z "$ip" ]]; then
     ip=${configurations[ssh_ip]}
@@ -564,7 +564,7 @@ function get_remote_info()
 #
 function deploy_parser_options()
 {
-  local raw_options="$@"
+  local raw_options="$*"
   local uninstall=0
   local enable_collect_param=0
   local remote

--- a/src/diff.sh
+++ b/src/diff.sh
@@ -6,7 +6,7 @@ declare -gA diff_options
 
 function diff_manager()
 {
-  local files_paths=${@: -2}
+  local files_paths=${*: -2}
   local interactive
   local target_1
   local target_2
@@ -62,7 +62,7 @@ function diff_manager()
 # In case of successful return 0, otherwise, return 22.
 function diff_parser_options()
 {
-  local raw_options="$@"
+  local raw_options="$*"
 
   diff_options["INTERACTIVE"]=1
   diff_options["HELP"]=0

--- a/src/get_maintainer_wrapper.sh
+++ b/src/get_maintainer_wrapper.sh
@@ -20,7 +20,7 @@ function print_files_authors()
 
   local printed_authors_separator=false
 
-  for file in ${files[@]}; do
+  for file in "${files[@]}"; do
     authors=$(grep -oE "MODULE_AUTHOR *\(.*\)" "$file" |
       sed -E "s/(MODULE_AUTHOR *\( *\"|\" *\))//g" |
       sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/, /g')
@@ -55,7 +55,7 @@ function print_files_authors()
 #   present in the patch
 function execute_get_maintainer()
 {
-  local raw_options="$@"
+  local raw_options="$*"
   local FILE_OR_DIR
   local print_authors=false
   local update_patch=false

--- a/src/kwio.sh
+++ b/src/kwio.sh
@@ -58,11 +58,11 @@ function alert_completion()
 #shellcheck disable=SC2059
 function colored_print()
 {
-  local message="${@:2}"
+  local message="${*:2}"
   local colored_format="${!1}"
 
   if [[ $# -ge 2 && $2 = "-n" ]]; then
-    message="${@:3}"
+    message="${*:3}"
     if [ -t 1 ]; then
       printf "$colored_format" "$message"
     else
@@ -112,7 +112,7 @@ function success()
 # yourself in the code.
 function ask_yN()
 {
-  local message=$@
+  local message="$*"
 
   read -r -p "$message [y/N] " response
   if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]; then

--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -101,7 +101,7 @@ function cmd_manager()
 # True if given dir is a kernel tree root and false otherwise.
 function is_kernel_root()
 {
-  local -r DIR="$@"
+  local -r DIR="$*"
 
   # The following files are some of the files expected to be at a linux
   # tree root and not expected to change. Their presence (or abscense)
@@ -122,7 +122,7 @@ function is_kernel_root()
 # an empty string if no root was found.
 function find_kernel_root()
 {
-  local -r FILE_OR_DIR="$@"
+  local -r FILE_OR_DIR="$*"
   local current_dir
   local kernel_root=""
 
@@ -189,7 +189,7 @@ function get_kernel_version()
 # True if given path is a patch file and false otherwise.
 function is_a_patch()
 {
-  local -r FILE_PATH="$@"
+  local -r FILE_PATH="$*"
   local file_content
 
   if [[ ! -f "$FILE_PATH" ]]; then
@@ -351,7 +351,7 @@ function command_exists()
   local command="$1"
   local package=($command)
 
-  if [[ -x "$(command -v "$package")" ]]; then
+  if [[ -x "$(command -v "${package[@]}")" ]]; then
     return 0
   fi
   return 22 # EINVAL

--- a/src/pomodoro.sh
+++ b/src/pomodoro.sh
@@ -294,7 +294,7 @@ function show_active_pomodoro_timebox()
 
 function pomodoro_parser()
 {
-  local raw_options="$@"
+  local raw_options="$*"
   local time_scale
   local time_value
   local timer=0

--- a/src/remote.sh
+++ b/src/remote.sh
@@ -233,7 +233,7 @@ function generate_tarball()
 # output is the remote info as IP:PORT
 function get_remote_info()
 {
-  ip="$@"
+  ip="$1"
 
   if [[ -z "$ip" ]]; then
     ip=${configurations[ssh_ip]}
@@ -269,7 +269,7 @@ function get_remote_info()
 #   attempt to execute a command or script on the remote host.
 function kw_ssh()
 {
-  local opts="$@"
+  local opts="$*"
   local port="${configurations[ssh_port]}"
   local target="${configurations[ssh_ip]}"
   local script_path
@@ -281,7 +281,7 @@ function kw_ssh()
 
   # Mandatory parameter
   if [ -z "$target" ]; then
-    complain "Invalid argument: $@"
+    complain "Invalid argument: $*"
     complain "Take a look at the config file, something is wrong in the ssh_ip"
     exit 22 # EINVAL
   fi
@@ -299,7 +299,7 @@ function kw_ssh()
 
       opts="\"bash -s\" -- < $script_path"
     else
-      complain "Invalid arguments: $@"
+      complain "Invalid arguments: $*"
       exit 22 # EINVAL
     fi
   fi


### PR DESCRIPTION
This commit fixes all cases where an array is treated like a string.
Mostly the error SC2124.

Signed-off-by: João Seckler <jseckler@riseup.net>