### PR TITLE
Improve `zsh` compatibility and setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -109,14 +109,14 @@ function remove_kw_from_PATH_variable()
 
 function update_path()
 {
-  local new_path=""
+  local shellrc=${1:-".bashrc"}
 
   IFS=':' read -ra ALL_PATHS <<< "$PATH"
   for path in "${ALL_PATHS[@]}"; do
     [[ "$path" -ef "$binpath" ]] && return
   done
 
-  echo "PATH=$HOME/.local/bin:\$PATH # kw" >> "$HOME/.bashrc"
+  safe_append "PATH=$HOME/.local/bin:\$PATH # kw" "$HOME/$shellrc"
 }
 
 function update_current_bash()
@@ -305,6 +305,7 @@ function synchronize_files()
 
       safe_append "$zshcomp" "$HOME/.zshrc"
       append_bashcompletion ".zshrc"
+      update_path ".zshrc"
     else
       warning "Unable to find a .zshrc file."
     fi

--- a/setup.sh
+++ b/setup.sh
@@ -300,8 +300,10 @@ function synchronize_files()
   if command_exists "zsh"; then
     # Add tabcompletion to zshrc
     if [[ -f "$HOME/.zshrc" || -L "$HOME/.zshrc" ]]; then
-      echo "# Enable bash completion for zsh" >> "$HOME/.zshrc"
-      echo "autoload bashcompinit && bashcompinit" >> "$HOME/.zshrc"
+      local zshcomp=$'# Enable bash completion for zsh\n'
+      zshcomp+='autoload bashcompinit && bashcompinit'
+
+      safe_append "$zshcomp" "$HOME/.zshrc"
       append_bashcompletion ".zshrc"
     else
       warning "Unable to find a .zshrc file."
@@ -318,9 +320,16 @@ function synchronize_files()
 function append_bashcompletion()
 {
   local shellrc="$1"
+  local msg="# $app_name"$'\n'"source $libdir/$BASH_AUTOCOMPLETE.sh"
 
-  echo "# $app_name" >> "$HOME/$shellrc"
-  echo "source $libdir/$BASH_AUTOCOMPLETE.sh" >> "$HOME/$shellrc"
+  safe_append "$msg" "$HOME/$shellrc"
+}
+
+function safe_append()
+{
+  if [[ $(grep -c -x "$1" "$2") == 0 ]]; then
+    printf "%s\n" "$1" >> "$2"
+  fi
 }
 
 function update_version()


### PR DESCRIPTION
This PR adds `safe_append` which is then used to avoid polluting files during setup.
It also updates path for zsh users.

This fixes #309 