### PR TITLE
shellcheck: disable SC2001, SC1090, SC1091, SC2120

### DIFF
--- a/.github/workflows/shellcheck_reviewdog.yml
+++ b/.github/workflows/shellcheck_reviewdog.yml
@@ -16,4 +16,4 @@ jobs:
           fail_on_error: true
           path: "."
           pattern: "*.sh"
-          shellcheck_flags: "--external-sources --shell=bash --exclude=SC2016,SC2181,SC2034,SC2154"
+          shellcheck_flags: "--external-sources --shell=bash --exclude=SC2016,SC2181,SC2034,SC2154,SC2001,SC1090,SC1091,SC2120"


### PR DESCRIPTION
SC2001: See if you can use ${variable//search/replace} instead

As previsously discussed, it is possible to make this substitutions only
with echo but we believe using sed to be a more readable solution and
easier to be understood. This hability from echo is not very well known.

SC1090: Can't follow non-constant source. Use a directive to specify location.
SC1091: Not following: (error message here)

Since we use KW_LIB_DIR when importing files, shellcheck can't follow
most imports. These combined with our use of the include function makes
these 2 error codes rather useless for our use case, we only get false
positives

SC2120: foo references arguments, but none are ever passed.

Once again shellcheck can't follow imports so it doesn't realize that
sometimes we do pass arguments to a function (e.g. a test especific
parameter)


Signed-off-by: Alan Barzilay <alan.barzilay@gmail.com>