### PR TITLE
shellcheck: SC2091: use eval

### DIFF
--- a/src/kwio.sh
+++ b/src/kwio.sh
@@ -25,7 +25,7 @@ function alert_completion()
     opts="${configurations[alert]}"
   fi
 
-  grep -o . <<< "$opts" | while read -r option; do
+  while read -rN 1 option; do
     if [ "$option" == "v" ]; then
       if command_exists "${configurations[visual_alert_command]} &"; then
         eval "${configurations[visual_alert_command]} &"
@@ -45,7 +45,7 @@ function alert_completion()
         warning "Check if the necessary packages are installed."
       fi
     fi
-  done
+  done <<< "$opts"
 }
 
 # Print colored message. This function verifies if stdout

--- a/tests/kwio_test.sh
+++ b/tests/kwio_test.sh
@@ -30,27 +30,32 @@ function test_alert_completion_options()
   configurations["alert"]="n"
 
   rm -f "$sound_file" "$visual_file"
-  $(alert_completion "" "--alert=vs")
+  alert_completion "" "--alert=vs"
+  wait "$!"
   [[ -f "$sound_file" && -f "$visual_file" ]]
   assertTrue "Alert's vs option didn't work." $?
 
   rm -f "$sound_file" "$visual_file"
-  $(alert_completion "" "--alert=sv")
+  alert_completion "" "--alert=sv"
+  wait "$!"
   [[ -f "$sound_file" && -f "$visual_file" ]]
   assertTrue "Alert's sv option didn't work." $?
 
   rm -f "$sound_file" "$visual_file"
-  $(alert_completion "" "--alert=s")
+  alert_completion "" "--alert=s"
+  wait "$!"
   [[ -f "$sound_file" && ! -f "$visual_file" ]]
   assertTrue "Alert's s option didn't work." $?
 
   rm -f "$sound_file" "$visual_file"
-  $(alert_completion "" "--alert=v")
+  alert_completion "" "--alert=v"
+  wait "$!"
   [[ ! -f "$sound_file" && -f "$visual_file" ]]
   assertTrue "Alert's v option didn't work." $?
 
   rm -f "$sound_file" "$visual_file"
-  $(alert_completion "" "--alert=n")
+  alert_completion "" "--alert=n"
+  wait "$!"
   [[ ! -f "$sound_file" && ! -f "$visual_file" ]]
   assertTrue "Alert's n option didn't work." $?
 
@@ -63,31 +68,36 @@ function test_alert_completition_validate_config_file_options()
 
   rm -f "$sound_file" "$visual_file"
   configurations["alert"]="vs"
-  $(alert_completion "" "")
+  alert_completion "" ""
+  wait "$!"
   [[ -f "$sound_file" && -f "$visual_file" ]]
   assertTrue "Alert's vs option didn't work." $?
 
   rm -f "$sound_file" "$visual_file"
   configurations["alert"]="sv"
-  $(alert_completion "" "")
+  alert_completion "" ""
+  wait "$!"
   [[ -f "$sound_file" && -f "$visual_file" ]]
   assertTrue "Alert's sv option didn't work." $?
 
   rm -f "$sound_file" "$visual_file"
   configurations["alert"]="s"
-  $(alert_completion "" "")
+  alert_completion "" ""
+  wait "$!"
   [[ -f "$sound_file" && ! -f "$visual_file" ]]
   assertTrue "Alert's s option didn't work." $?
 
   rm -f "$sound_file" "$visual_file"
   configurations["alert"]="v"
-  $(alert_completion "" "")
+  alert_completion "" ""
+  wait "$!"
   [[ ! -f "$sound_file" && -f "$visual_file" ]]
   assertTrue "Alert's v option didn't work." $?
 
   rm -f "$sound_file" "$visual_file"
   configurations["alert"]="n"
-  $(alert_completion "" "")
+  alert_completion "" ""
+  wait "$!"
   [[ ! -f "$sound_file" && ! -f "$visual_file" ]]
   assertTrue "Alert's n option didn't work." $?
 


### PR DESCRIPTION
SC2091: Remove surrounding $() to avoid executing output
(or use eval if intentional).
Signed-off-by: Alan Barzilay <alan.barzilay@gmail.com>