### PR TITLE
shellcheck: SC2125: globs are literal in assignments

### DIFF
--- a/src/plugins/kernel_install/utils.sh
+++ b/src/plugins/kernel_install/utils.sh
@@ -125,7 +125,7 @@ function install_modules()
   local ret
 
   if [[ -z "$module_target" ]]; then
-    module_target=*.tar
+    module_target='*.tar'
   fi
 
   cmd_manager "$flag" "tar -C /lib/modules -xf $module_target"


### PR DESCRIPTION
Brace expansions and globs are literal in assignments.
Quote it or use an array.
Signed-off-by: Alan Barzilay <alan.barzilay@gmail.com>