### PR TITLE
Shellcheck and Quote errors

### DIFF
--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -208,7 +208,7 @@ function is_a_patch()
   )
 
   for expected_str in "${PATCH_EXPECTED_STRINGS[@]}"; do
-    if [[ ! "$file_content" =~ "$expected_str" ]]; then
+    if [[ ! "$file_content" =~ $expected_str ]]; then
       return 1
     fi
   done

--- a/src/pomodoro.sh
+++ b/src/pomodoro.sh
@@ -287,8 +287,8 @@ function show_active_pomodoro_timebox()
     timebox=$(calculate_missing_time "$timebox" "$diff_time")
 
     say "Started at: $timestamp_to_date"
-    say "- Elapsed time:" $(sec_to_format "$diff_time")
-    say "- You still have" $(sec_to_format "$timebox")
+    say "- Elapsed time:" "$(sec_to_format "$diff_time")"
+    say "- You still have" "$(sec_to_format "$timebox")"
   done < "$POMODORO_LOG_FILE"
 }
 


### PR DESCRIPTION
This PR fixes 2 different shellcheck errors. Fixes part of #375 

SC2046: Quote this to prevent word splitting

SC2076: Remove quotes from right-hand side of =~ to match as a regex rather than literally