### PR TITLE
shellcheck: SC2053: Quote the rhs of =

### DIFF
--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -433,7 +433,7 @@ function test_kernel_modules()
   ID=1
   output=$(modules_install "TEST_MODE" 3)
   while read -r f; do
-    if [[ ${expected_cmd[$count]} != ${f} ]]; then
+    if [[ ${expected_cmd[$count]} != "${f}" ]]; then
       fail "$count - Expected cmd \"${expected_cmd[$count]}\" to be \"${f}\""
     fi
     ((count++))
@@ -558,7 +558,7 @@ function test_list_remote_kernels()
 
   output=$(list_installed_kernels "TEST_MODE" 0 3)
   while read -r f; do
-    if [[ ${expected_cmd[$count]} != ${f} ]]; then
+    if [[ ${expected_cmd[$count]} != "${f}" ]]; then
       fail "$count - Expected cmd \"${expected_cmd[$count]}\" to be \"${f}\""
     fi
     ((count++))

--- a/tests/kw_config_loader_test.sh
+++ b/tests/kw_config_loader_test.sh
@@ -38,7 +38,7 @@ function assertConfigurations()
   for k in "${!configurations_ref[@]}"; do
     if [[ ${expected_configurations_ref[$k]+token} != token ]]; then
       fail "Did not expect setting \"$k\"."
-    elif [[ ${configurations_ref[$k]} != ${expected_configurations_ref[$k]} ]]; then
+    elif [[ ${configurations_ref[$k]} != "${expected_configurations_ref[$k]}" ]]; then
       fail "Expected setting \"${k}\" to be \"${expected_configurations_ref[$k]}\" (found \"${configurations_ref[$k]}\")."
     fi
   done
@@ -106,7 +106,7 @@ function test_parse_configuration_standard_config()
     [mount_point]="/home/USERKW/p/mount"
     [alert]="n"
     [sound_alert_command]="paplay SOUNDPATH/complete.wav"
-    [visual_alert_command]="notify-send -i checkbox -t 10000 \"kw\" \"Command: \\\\\"\$COMMAND\\\\\" completed!\""
+    [visual_alert_command]="notify-send -i checkbox -t 10000 \"kw\" \"Command: \\\"\$COMMAND\\\" completed!\""
     [default_deploy_target]="vm"
     [reboot_after_deploy]="no"
     [disable_statistics_data_track]="no"

--- a/tests/remote_test.sh
+++ b/tests/remote_test.sh
@@ -265,7 +265,7 @@ function test_prepare_remote_dir()
   setupMockFunctions
   output=$(prepare_remote_dir "$remote" "$port" "$user" "$flag")
   while read -r cmd; do
-    if [[ ${expected_cmd_sequence[$count]} != ${cmd} ]]; then
+    if [[ ${expected_cmd_sequence[$count]} != "${cmd}" ]]; then
       fail "Expected command \"${expected_cmd_sequence[$count]}\" to be \"${cmd}\")"
     fi
     ((count++))
@@ -296,7 +296,7 @@ function test_generate_tarball()
   ID=2
   output=$(tar -taf "$FAKE_KW/$LOCAL_TO_DEPLOY_DIR/$tarball_name" | sort -d)
   while read -r f; do
-    if [[ ${expected_files[$count]} != ${f} ]]; then
+    if [[ ${expected_files[$count]} != "${f}" ]]; then
       fail "$ID - Expected file \"${expected_files[$count]}\" to be \"${f}\""
     fi
     ((count++))


### PR DESCRIPTION
SC2053: Quote the rhs of = in to prevent glob matching.
Fixes part of #375

There is actually one test failing and I have no idea what to do about it since its just bash being obtuse, any ideas are welcome:

```
Running test [kw_config_loader_test]
=========================================================
test_parse_configuration_success_exit_code
test_parser_configuration_failed_exit_code
test_parse_configuration_output
test_parse_configuration_standard_config
ASSERT:Expected setting "visual_alert_command" to be "notify-send -i checkbox -t 10000 "kw" "Command: \"$COMMAND\" completed!"" (found "notify-send -i checkbox -t 10000 "kw" "Command: \"$COMMAND\" completed!"").
test_parse_configuration_files_loading_order
test_show_variables_completeness
test_show_variables_correctness

Ran 7 tests.

FAILED (failures=1)
```