### PR TITLE
shellcheck: SC2206: quote to prevent word splitting

### DIFF
--- a/src/get_maintainer_wrapper.sh
+++ b/src/get_maintainer_wrapper.sh
@@ -11,11 +11,11 @@ function print_files_authors()
   if [[ -d $FILE_OR_DIR ]]; then
     for file in "$FILE_OR_DIR"/*; do
       if [[ -f $file ]]; then
-        files+=($file)
+        files+=("$file")
       fi
     done
   elif [[ -f $FILE_OR_DIR ]]; then
-    files+=($FILE_OR_DIR)
+    files+=("$FILE_OR_DIR")
   fi
 
   local printed_authors_separator=false

--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -349,6 +349,7 @@ function store_statistics_data()
 function command_exists()
 {
   local command="$1"
+  #shellcheck disable=SC2206 #FIXME: see issue #388
   local package=($command)
 
   if [[ -x "$(command -v "${package[@]}")" ]]; then


### PR DESCRIPTION
SC2206 -- Quote to prevent word splitting/globbing, or split robustly with
mapfile or read -a.
Fixes part of #375 

Signed-off-by: Alan Barzilay <alan.barzilay@gmail.com>