### PR TITLE
src: diff: fix diff functionality

### DIFF
--- a/src/diff.sh
+++ b/src/diff.sh
@@ -103,10 +103,11 @@ function diff_side_by_side()
   local file_2="$2"
   local interactive="$3"
   local flag="$4"
-  local diff_cmd="diff -y --color=always --width=$columns"
+  local diff_cmd
   local columns
 
   columns=$(tput cols)
+  diff_cmd="diff -y --color=always --width=$columns"
   flag=${flag:-""}
 
   if [[ ! -f "$file_1" || ! -f "$file_2" ]]; then


### PR DESCRIPTION
As described in #386 `kw diff` was not working because of the order of
some variable assignments.

This fixes #386

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@usp.br>