### PR TITLE
Manage installed kernels

### DIFF
--- a/documentation/man/features/deploy.rst
+++ b/documentation/man/features/deploy.rst
@@ -8,7 +8,8 @@ SYNOPSIS
 ========
 *kw* (*d* | *deploy*) [\--remote <remote>:<port> | \--local | \--vm]
                       [-r | \--reboot] [-m | \--modules] [-s | \--ls-line]
-                      [-l | \--list] [(-u | \--uninstall) <kernel-name>[,...]]
+                      [-l | \--list] [-a | \--list-all]
+                      [(-u | \--uninstall) <kernel-name>[,...]] [-f \--force]
                       [\--alert=(s | v | (sv | vs) | n)]
 
 DESCRIPTION
@@ -69,12 +70,19 @@ OPTIONS
 -l, \--list:
   List available kernels in a single column the target.
 
+-a, \--list-all:
+  List all available kernels, including the ones not installed by kw.
+
 -s, \--ls-line:
   List available kernels separated by comma.
 
 -u <kernel-name>[,...], \--uninstall <kernel-name>[,...]:
   Remove a single kernel or multiple kernels; for removing
   multiple kernels it is necessary to separate them with comma.
+
+-f, \--force:
+  Remove kernels even if they were not installed by kw (only valid with
+  \--uninstall or -u)
 
 \--alert=(s | v | (sv | vs) | n):
   Defines the alert behaviour upon the command completion.

--- a/documentation/man/features/deploy.rst
+++ b/documentation/man/features/deploy.rst
@@ -82,7 +82,9 @@ OPTIONS
 
 -f, \--force:
   Remove kernels even if they were not installed by kw (only valid with
-  \--uninstall or -u)
+  \--uninstall or -u). Trying to remove a kernel not directly managed by
+  kw can lead to system failures, and it is not recommended; only use it
+  if you are sure about what you are doing.
 
 \--alert=(s | v | (sv | vs) | n):
   Defines the alert behaviour upon the command completion.

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -47,6 +47,8 @@ function kernel_deploy()
   local end=0
   local runtime=0
   local ret=0
+  local list_all
+  local flag
 
   if [[ "$1" =~ -h|--help ]]; then
     deploy_help "$1"
@@ -59,18 +61,21 @@ function kernel_deploy()
     return 22 # EINVAL
   fi
 
+  flag="${options_values['TEST_MODE']}"
   target="${options_values['TARGET']}"
   reboot="${options_values['REBOOT']}"
   modules="${options_values['MODULES']}"
   single_line="${options_values['LS_LINE']}"
+  list_all="${options_values['LS_ALL']}"
   list="${options_values['LS']}"
   uninstall="${options_values['UNINSTALL']}"
+  uninstall_force="${options_values['UNINSTALL_FORCE']}"
   remote="${remote_parameters['REMOTE']}"
 
-  if [[ "$list" == 1 || "$single_line" == 1 ]]; then
+  if [[ "$list" == 1 || "$single_line" == 1 || "$list_all" == 1 ]]; then
     say "Available kernels:"
     start=$(date +%s)
-    list_installed_kernels "" "$single_line" "$target"
+    list_installed_kernels "$flag" "$single_line" "$target" "$list_all"
     end=$(date +%s)
 
     runtime=$((end - start))
@@ -80,7 +85,7 @@ function kernel_deploy()
 
   if [[ -n "$uninstall" ]]; then
     start=$(date +%s)
-    kernel_uninstall "$target" "$reboot" "$uninstall" "$flag"
+    kernel_uninstall "$target" "$reboot" "$uninstall" "$flag" "$uninstall_force"
     end=$(date +%s)
 
     runtime=$((end - start))
@@ -149,7 +154,8 @@ function parse_deploy_options()
   local remote
   local options
   local long_options='remote:,local,vm,reboot,modules,list,ls-line,uninstall:'
-  local short_options='r,m,l,s,u:'
+  long_options+=',list-all,force'
+  local short_options='r,m,l,s,u:,a,f'
 
   options="$(kw_parse "$short_options" "$long_options" "$@")"
 
@@ -159,12 +165,15 @@ function parse_deploy_options()
     return 22 # EINVAL
   fi
 
+  options_values['TEST_MODE']='SILENT'
   options_values['UNINSTALL']=''
+  options_values['UNINSTALL_FORCE']=''
   options_values['MODULES']=0
   options_values['LS_LINE']=0
   options_values['LS']=0
   options_values['REBOOT']=0
   options_values['MENU_CONFIG']='nconfig'
+  options_values['LS_ALL']=''
 
   remote_parameters['REMOTE']=''
 
@@ -219,6 +228,10 @@ function parse_deploy_options()
         options_values['LS']=1
         shift
         ;;
+      --list-all | -a)
+        options_values['LS_ALL']=1
+        shift
+        ;;
       --ls-line | -s)
         options_values['LS_LINE']=1
         shift
@@ -231,7 +244,15 @@ function parse_deploy_options()
         options_values['UNINSTALL']+="$2"
         shift 2
         ;;
+      --force | -f)
+        options_values['UNINSTALL_FORCE']=1
+        shift
+        ;;
       --) # End of options, beginning of arguments
+        shift
+        ;;
+      TEST_MODE)
+        options_values['TEST_MODE']='TEST_MODE'
         shift
         ;;
       *)
@@ -263,13 +284,17 @@ function parse_deploy_options()
 #   available kernels in a single line separated by commas. If it gets 0 it
 #   will display each kernel name by line.
 # @target Target can be 1 (VM_TARGET), 2 (LOCAL_TARGET), and 3 (REMOTE_TARGET)
+# @all If this option is set to one, this will list all kernels
+#   availble. If not, will list only kernels that were installed by kw.
 function list_installed_kernels()
 {
   local flag="$1"
   local single_line="$2"
   local target="$3"
+  local all="$4"
   local remote
   local port
+  local cmd
 
   flag=${flag:-"SILENT"}
 
@@ -283,16 +308,16 @@ function list_installed_kernels()
       fi
 
       include "$KW_PLUGINS_DIR/kernel_install/utils.sh"
-      list_installed_kernels "$single_line" "${configurations[mount_point]}"
+      list_installed_kernels "$flag" "$single_line" "${configurations[mount_point]}" "$all"
 
       vm_umount
       ;;
     2) # LOCAL_TARGET
       include "$KW_PLUGINS_DIR/kernel_install/utils.sh"
-      list_installed_kernels "$single_line"
+      list_installed_kernels "$flag" "$single_line" '' "$all"
       ;;
     3) # REMOTE_TARGET
-      local cmd="bash $REMOTE_KW_DEPLOY/deploy.sh --list_kernels $single_line"
+      cmd="bash $REMOTE_KW_DEPLOY/deploy.sh --list_kernels '$flag' '$single_line' '' '$all'"
       remote="${remote_parameters['REMOTE_IP']}"
       port="${remote_parameters['REMOTE_PORT']}"
 
@@ -312,6 +337,8 @@ function list_installed_kernels()
 #         installation.
 # @kernels_target List containing kernels to be uninstalled
 # @flag How to display a command, see `src/kwlib.sh` function `cmd_manager`
+# @force If this value is equal to 1, try to uninstall kernels even if they are
+#        not managed by kw
 #
 # Return:
 # Return 0 if everything is correct or an error in case of failure
@@ -321,6 +348,7 @@ function kernel_uninstall()
   local reboot="$2"
   local kernels_target="$3"
   local flag="$4"
+  local force="$5"
   local distro
   local remote
   local port
@@ -345,7 +373,7 @@ function kernel_uninstall()
       include "$KW_PLUGINS_DIR/kernel_install/utils.sh"
       # TODO: Rename kernel_uninstall in the plugin, this name is super
       # confusing
-      kernel_uninstall "$reboot" 'local' "$kernels_target" "$flag"
+      kernel_uninstall '' "$reboot" 'local' "$kernels_target" "$flag" "$force"
       ;;
     3) # REMOTE_TARGET
       remote="${remote_parameters['REMOTE_IP']}"
@@ -357,7 +385,7 @@ function kernel_uninstall()
       # TODO
       # It would be better if `cmd_remotely` handle the extra space added by
       # line break with `\`; this may allow us to break a huge line like this.
-      local cmd="bash $REMOTE_KW_DEPLOY/deploy.sh --uninstall_kernel $reboot remote $kernels_target $flag"
+      local cmd="bash $REMOTE_KW_DEPLOY/deploy.sh --uninstall_kernel '' '$reboot' remote '$kernels_target' '$flag' '$force'"
       cmd_remotely "$cmd" "$flag" "$remote" "$port"
       ;;
   esac
@@ -586,7 +614,8 @@ function deploy_help()
     '  deploy (--remote <remote>:<port> | --local | --vm) - choose target' \
     '  deploy (--reboot | -r) - reboot machine after deploy' \
     '  deploy (--modules | -m) - install only modules' \
-    '  deploy (--uninstall | -u) <kernel-name>,... - uninstall given kernels' \
+    '  deploy (--uninstall | -u) [(--force | -f)] <kernel-name>,... - uninstall given kernels' \
     '  deploy (--list | -l) - list kernels' \
-    '  deploy (--ls-line | -s) - list kernels separeted by commas'
+    '  deploy (--ls-line | -s) - list kernels separeted by commas' \
+    '  deploy (--list-all | -a) - list all available kernels'
 }

--- a/src/plugins/kernel_install/utils.sh
+++ b/src/plugins/kernel_install/utils.sh
@@ -85,7 +85,7 @@ function list_installed_kernels()
   output=$(echo "$output" | grep recovery -v | grep with | awk -F" " '{print $NF}')
 
   while read -r kernel; do
-    if [[ -f "$prefix/boot/vmlinuz-$kernel" ]]; then
+    if [[ -f "$prefix/boot/vmlinuz-$kernel" && ! "$kernel" =~ .*\.old$ ]]; then
       available_kernels+=("$kernel")
     fi
   done <<< "$output"

--- a/src/plugins/kernel_install/utils.sh
+++ b/src/plugins/kernel_install/utils.sh
@@ -1,3 +1,6 @@
+declare -g REMOTE_KW_DEPLOY="/root/kw_deploy"
+declare -g INSTALLED_KERNELS_PATH="$REMOTE_KW_DEPLOY/INSTALLED_KERNELS"
+
 # ATTENTION:
 # This function follows the cmd_manager signature (src/kwlib.sh) because we
 # share the specific distro in the kw main code. However, when we deploy for a
@@ -51,15 +54,23 @@ function ask_yN()
 #   available kernels in a single line separated by commas. If it gets 0 it
 #   will display each kernel name by line.
 # @prefix Set a base prefix for searching for kernels.
+# @all List all available kernels, not only the ones installed by kw
 function list_installed_kernels()
 {
-  local single_line="$1"
-  local prefix="$2"
+  local flag="$1"
+  local single_line="$2"
+  local prefix="$3"
+  local all="$4"
   local output
   local ret
   local super=0
   local available_kernels=()
   local grub_cfg=""
+  local -a managed_kernels
+  local cmd
+
+  cmd_manager "$flag" "sudo mkdir -p $REMOTE_KW_DEPLOY"
+  cmd_manager "$flag" "sudo touch $INSTALLED_KERNELS_PATH"
 
   grub_cfg="$prefix/boot/grub/grub.cfg"
 
@@ -85,20 +96,27 @@ function list_installed_kernels()
   output=$(echo "$output" | grep recovery -v | grep with | awk -F" " '{print $NF}')
 
   while read -r kernel; do
-    if [[ -f "$prefix/boot/vmlinuz-$kernel" && ! "$kernel" =~ .*\.old$ ]]; then
+    if [[ -f "$prefix/boot/vmlinuz-$kernel" ]]; then
+      if [[ -z "$all" ]]; then
+        [[ "$kernel" =~ .*\.old$ ]] && continue
+        cmd="sudo grep -q '$kernel' '$INSTALLED_KERNELS_PATH'"
+        cmd_manager 'SILENT' "$cmd" || continue
+      fi
       available_kernels+=("$kernel")
     fi
   done <<< "$output"
 
-  echo
+  if [[ "${#available_kernels[@]}" -eq 0 ]]; then
+    echo 'None of the installed kernels are managed by kw.' \
+      'Pass --list-all|-a to see all installed kernels'
+    return 0
+  fi
 
   if [[ "$single_line" != 1 ]]; then
     printf '%s\n' "${available_kernels[@]}"
   else
-    echo -n "${available_kernels[0]}"
-    available_kernels=("${available_kernels[@]:1}")
-    printf ',%s' "${available_kernels[@]}"
-    echo ""
+    local IFS=','
+    echo "${available_kernels[*]}"
   fi
 
   return 0
@@ -280,14 +298,27 @@ function do_uninstall()
 
 function kernel_uninstall()
 {
-  local reboot="$1"
-  local local_deploy="$2"
-  local kernel="$3"
-  local flag="$4"
+  local flag="$1"
+  local reboot="$2"
+  local local_deploy="$3"
+  local kernel="$4"
+  local flag="$5"
+  local force="$6"
+  local cmd
+
+  cmd_manager "$flag" "sudo mkdir -p '$REMOTE_KW_DEPLOY'"
+  cmd_manager "$flag" "sudo touch '$INSTALLED_KERNELS_PATH'"
 
   if [[ -z "$kernel" ]]; then
     echo "Invalid argument"
     exit 22 #EINVAL
+  fi
+
+  cmd="sudo grep -q '$kernel' '$INSTALLED_KERNELS_PATH'"
+
+  if ! cmd_manager '' "$cmd" && [[ -z "$force" ]]; then
+    echo 'Kernel not managed by kw. Use --force/-f to uninstall anyway.'
+    exit 22 # EINVAL
   fi
 
   IFS=', ' read -r -a kernel_names <<< "$kernel"
@@ -298,7 +329,9 @@ function kernel_uninstall()
 
   # Each distro script should implement update_boot_loader
   echo "update_boot_loader $kernel $local_deploy $flag"
-  update_boot_loader "$kernel" "$local_deploy" "$flag"
+  update_boot_loader "$kernel" "$local_deploy" '' '' '' '' "$flag"
+
+  cmd_manager "$flag" "sudo sed -i '/$kernel/d' '$INSTALLED_KERNELS_PATH'"
 
   # Reboot
   reboot_machine "$reboot" "$local_deploy"
@@ -369,6 +402,10 @@ function install_kernel()
 
   # Each distro has their own way to update their bootloader
   eval "update_$distro""_boot_loader $name $target $flag"
+
+  # Registering a new kernel
+  cmd="sudo tee -a '$INSTALLED_KERNELS_PATH' > /dev/null"
+  echo "$name" | cmd_manager "$flag" "$cmd"
 
   # Reboot
   if [[ "$target" != 'vm' && "$reboot" == "1" ]]; then

--- a/src/plugins/kernel_install/utils.sh
+++ b/src/plugins/kernel_install/utils.sh
@@ -61,16 +61,45 @@ function list_installed_kernels()
   local single_line="$2"
   local prefix="$3"
   local all="$4"
-  local output
-  local ret
-  local super=0
-  local available_kernels=()
-  local grub_cfg=""
-  local -a managed_kernels
+  local -a available_kernels=()
   local cmd
 
   cmd_manager "$flag" "sudo mkdir -p $REMOTE_KW_DEPLOY"
   cmd_manager "$flag" "sudo touch $INSTALLED_KERNELS_PATH"
+
+  if [[ -n "$all" ]]; then
+    if [[ -d "$prefix/boot/grub/" ]]; then
+      list_installed_kernels_based_on_grub "$prefix" 'available_kernels'
+    else
+      echo "Could not find grub installed. Cannot list all installed kernels"
+      return 95 # ENOTSUP
+    fi
+  else
+    readarray -t available_kernels < "$INSTALLED_KERNELS_PATH"
+    if [[ "${#available_kernels[@]}" -eq 0 ]]; then
+      echo 'None of the installed kernels are managed by kw.' \
+        'Pass --list-all|-a to see all installed kernels'
+      return 0
+    fi
+  fi
+
+  if [[ "$single_line" != 1 ]]; then
+    printf '%s\n' "${available_kernels[@]}"
+  else
+    local IFS=','
+    echo "${available_kernels[*]}"
+  fi
+
+  return 0
+}
+
+list_installed_kernels_based_on_grub()
+{
+  local prefix="$1"
+  local -n _available_kernels="$2"
+  local grub_cfg
+  local output
+  local super=0
 
   grub_cfg="$prefix/boot/grub/grub.cfg"
 
@@ -97,29 +126,9 @@ function list_installed_kernels()
 
   while read -r kernel; do
     if [[ -f "$prefix/boot/vmlinuz-$kernel" ]]; then
-      if [[ -z "$all" ]]; then
-        [[ "$kernel" =~ .*\.old$ ]] && continue
-        cmd="sudo grep -q '$kernel' '$INSTALLED_KERNELS_PATH'"
-        cmd_manager 'SILENT' "$cmd" || continue
-      fi
-      available_kernels+=("$kernel")
+      _available_kernels+=("$kernel")
     fi
   done <<< "$output"
-
-  if [[ "${#available_kernels[@]}" -eq 0 ]]; then
-    echo 'None of the installed kernels are managed by kw.' \
-      'Pass --list-all|-a to see all installed kernels'
-    return 0
-  fi
-
-  if [[ "$single_line" != 1 ]]; then
-    printf '%s\n' "${available_kernels[@]}"
-  else
-    local IFS=','
-    echo "${available_kernels[*]}"
-  fi
-
-  return 0
 }
 
 function reboot_machine()
@@ -404,6 +413,9 @@ function install_kernel()
   eval "update_$distro""_boot_loader $name $target $flag"
 
   # Registering a new kernel
+  # See shellcheck warning SC2024: sudo doesn't affect redirects. That
+  # is why we use tee. Also note that the stdin is passed to the eval
+  # inside cmd_manager.
   cmd="sudo tee -a '$INSTALLED_KERNELS_PATH' > /dev/null"
   echo "$name" | cmd_manager "$flag" "$cmd"
 

--- a/tests/plugins/kernel_install/utils_test.sh
+++ b/tests/plugins/kernel_install/utils_test.sh
@@ -52,37 +52,26 @@ function test_ask_yN()
 
 function test_human_list_installed_kernels()
 {
-  local count=0
-
   declare -a expected_out=(
     "" # Extra espace in the beginning
-    "5.5.0-rc2-VKMS+"
-    "5.6.0-rc2-AMDGPU+"
-    "linux"
+    '5.5.0-rc2-VKMS+'
+    '5.6.0-rc2-AMDGPU+'
+    'linux'
   )
 
-  output=$(list_installed_kernels "0" "$SHUNIT_TMPDIR")
-  while read -r out; do
-    assertEquals "$count - Expected kernel list" "${expected_out[$count]}" "$out"
-    ((count++))
-  done <<< "$output"
+  output=$(list_installed_kernels '0' "$SHUNIT_TMPDIR")
+  compare_command_sequence expected_out[@] "$output" "$LINENO"
 }
 
 function test_command_list_installed_kernels()
 {
-  local count=0
-
   declare -a expected_out=(
-    "" # Extra espace in the beginning
-    "5.5.0-rc2-VKMS+,5.6.0-rc2-AMDGPU+,linux"
+    '' # Extra espace in the beginning
+    '5.5.0-rc2-VKMS+,5.6.0-rc2-AMDGPU+,linux'
   )
 
-  output=$(list_installed_kernels "1" "$SHUNIT_TMPDIR")
-  while read -r out; do
-    assertEquals "$count - Expected kernel list" "${expected_out[$count]}" "$out"
-    ((count++))
-  done <<< "$output"
-
+  output=$(list_installed_kernels '1' "$SHUNIT_TMPDIR")
+  compare_command_sequence expected_out[@] "$output" "$LINENO"
 }
 
 function test_reboot_machine()

--- a/tests/plugins/kernel_install/utils_test.sh
+++ b/tests/plugins/kernel_install/utils_test.sh
@@ -6,6 +6,24 @@
 
 declare -r TEST_ROOT_PATH="$PWD"
 
+function oneTimeSetUp()
+{
+  declare -g REMOTE_KW_DEPLOY="$PWD/tests/samples"
+  declare -g INSTALLED_KERNELS_PATH="$REMOTE_KW_DEPLOY/INSTALLED_KERNELS"
+
+  # Mocking the sudo function
+  function sudo()
+  {
+    eval "$*"
+  }
+  export -f sudo
+}
+
+function oneTimeTearDown()
+{
+  rm -f "$INSTALLED_KERNELS_PATH"
+}
+
 function setUp()
 {
   local current_path="$PWD"
@@ -53,25 +71,49 @@ function test_ask_yN()
 function test_human_list_installed_kernels()
 {
   declare -a expected_out=(
-    "" # Extra espace in the beginning
+    "sudo mkdir -p $REMOTE_KW_DEPLOY"
+    "sudo touch $INSTALLED_KERNELS_PATH"
     '5.5.0-rc2-VKMS+'
     '5.6.0-rc2-AMDGPU+'
     'linux'
   )
 
-  output=$(list_installed_kernels '0' "$SHUNIT_TMPDIR")
-  compare_command_sequence expected_out[@] "$output" "$LINENO"
+  printf '%s\n' "${expected_out[@]}" > "$INSTALLED_KERNELS_PATH"
+
+  output=$(list_installed_kernels 'TEST_MODE' '0' "$SHUNIT_TMPDIR")
+  compare_command_sequence 'expected_out' "$output" "$LINENO"
 }
 
 function test_command_list_installed_kernels()
 {
   declare -a expected_out=(
-    '' # Extra espace in the beginning
+    "sudo mkdir -p $REMOTE_KW_DEPLOY"
+    "sudo touch $INSTALLED_KERNELS_PATH"
     '5.5.0-rc2-VKMS+,5.6.0-rc2-AMDGPU+,linux'
   )
 
-  output=$(list_installed_kernels '1' "$SHUNIT_TMPDIR")
-  compare_command_sequence expected_out[@] "$output" "$LINENO"
+  printf '%s\n' "${expected_out[@]/,/$'\n'}" > "$INSTALLED_KERNELS_PATH"
+
+  output=$(list_installed_kernels 'TEST_MODE' '1' "$SHUNIT_TMPDIR")
+  compare_command_sequence 'expected_out' "$output" "$LINENO"
+}
+
+function test_list_unmanaged_kernels()
+{
+  local output
+  local expected
+
+  echo -n '' > "$INSTALLED_KERNELS_PATH"
+
+  expected=(
+    "sudo mkdir -p $REMOTE_KW_DEPLOY"
+    "sudo touch $INSTALLED_KERNELS_PATH"
+    '5.5.0-rc2-VKMS+,5.5.0-rc2-VKMS+.old,5.6.0-rc2-AMDGPU+,linux'
+  )
+
+  # arguments: $flag $single_line $prefix $all
+  output=$(list_installed_kernels 'TEST_MODE' "1" "$SHUNIT_TMPDIR" "1")
+  compare_command_sequence 'expected' "$output" "($LINENO)"
 }
 
 function test_reboot_machine()
@@ -87,6 +129,60 @@ function test_reboot_machine()
 
   output=$(reboot_machine '1' 'local' 'TEST_MODE')
   assert_equals_helper 'Disable reboot in a non-local machine' "$LINENO" 'sudo -E reboot' "$output"
+}
+
+function test_kernel_uninstall_unmanaged()
+{
+  local output
+  local -a expected
+
+  expected=(
+    "sudo mkdir -p '$REMOTE_KW_DEPLOY'"
+    "sudo touch '$INSTALLED_KERNELS_PATH'"
+    "sudo grep -q 'kname' '$INSTALLED_KERNELS_PATH'"
+    'Kernel not managed by kw. Use --force/-f to uninstall anyway.'
+  )
+  # Test unmanaged
+  output=$(kernel_uninstall 'TEST_MODE' '0' 'local' 'kname' 'TEST_MODE' '')
+  compare_command_sequence 'expected' "$output" "$LINENO"
+}
+
+function test_kernel_uninstall_managed()
+{
+  local target='xpto'
+  local prefix="./test"
+  local kernelpath="/boot/vmlinuz-$target"
+  local initrdpath="/boot/initrd.img-$target"
+  local modulespath="/lib/modules/$target"
+  local libpath="/var/lib/initramfs-tools/$target"
+
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
+
+  local -a cmd_sequence=(
+    "sudo mkdir -p '$REMOTE_KW_DEPLOY'"
+    "sudo touch '$INSTALLED_KERNELS_PATH'"
+    "sudo grep -q 'xpto' '$INSTALLED_KERNELS_PATH'"
+    "Removing: $target"
+    "Can't find $kernelpath"
+    "Can't find $kernelpath.old"
+    "Can't find $initrdpath"
+    "Can't find $modulespath"
+    "Can't find $libpath"
+    "update_boot_loader xpto local TEST_MODE"
+    "grub-mkconfig -o /boot/grub/grub.cfg"
+    "sudo sed -i '/xpto/d' '$INSTALLED_KERNELS_PATH'"
+  )
+
+  output=$(kernel_uninstall 'TEST_MODE' 0 'local' 'xpto' 'TEST_MODE' '1')
+  compare_command_sequence 'cmd_sequence' "$output" "$LINENO"
+
+  cd "$TEST_ROOT_PATH" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
 }
 
 function test_do_uninstall_cmd_sequence()
@@ -283,6 +379,7 @@ function test_install_kernel_remote()
     "cp -v vmlinuz-$name $path_prefix/boot/vmlinuz-$name"
     'generate_debian_temporary_root_file_system_mock'
     'update_debian_boot_loader_mock'
+    "sudo tee -a '$INSTALLED_KERNELS_PATH' > /dev/null"
     'reboot'
   )
   output=$(install_kernel "$name" 'debian' "$kernel_image_name" "$reboot" "$architecture" "$target" 'TEST_MODE')
@@ -305,6 +402,7 @@ function test_install_kernel_local()
     "$sudo_cmd cp -v arch/$architecture/boot/$kernel_image_name $path_prefix/boot/vmlinuz-$name"
     'generate_debian_temporary_root_file_system_mock'
     'update_debian_boot_loader_mock'
+    "sudo tee -a '$INSTALLED_KERNELS_PATH' > /dev/null"
     "$sudo_cmd reboot"
   )
 
@@ -335,6 +433,7 @@ function test_install_kernel_vm()
     'generate_debian_temporary_root_file_system_mock'
     "vm_umount"
     'update_debian_boot_loader_mock'
+    "sudo tee -a '$INSTALLED_KERNELS_PATH' > /dev/null"
   )
 
   cd "$SHUNIT_TMPDIR" || {

--- a/tests/plugins/kernel_install/utils_test.sh
+++ b/tests/plugins/kernel_install/utils_test.sh
@@ -78,7 +78,7 @@ function test_human_list_installed_kernels()
     'linux'
   )
 
-  printf '%s\n' "${expected_out[@]}" > "$INSTALLED_KERNELS_PATH"
+  printf '%s\n' "${expected_out[@]:2}" > "$INSTALLED_KERNELS_PATH"
 
   output=$(list_installed_kernels 'TEST_MODE' '0' "$SHUNIT_TMPDIR")
   compare_command_sequence 'expected_out' "$output" "$LINENO"
@@ -92,7 +92,7 @@ function test_command_list_installed_kernels()
     '5.5.0-rc2-VKMS+,5.6.0-rc2-AMDGPU+,linux'
   )
 
-  printf '%s\n' "${expected_out[@]/,/$'\n'}" > "$INSTALLED_KERNELS_PATH"
+  printf '%s\n' "${expected_out[-1]/,/$'\n'}" > "$INSTALLED_KERNELS_PATH"
 
   output=$(list_installed_kernels 'TEST_MODE' '1' "$SHUNIT_TMPDIR")
   compare_command_sequence 'expected_out' "$output" "$LINENO"
@@ -101,7 +101,8 @@ function test_command_list_installed_kernels()
 function test_list_unmanaged_kernels()
 {
   local output
-  local expected
+  local -a expected
+  local -a available_kernels=()
 
   echo -n '' > "$INSTALLED_KERNELS_PATH"
 
@@ -114,6 +115,23 @@ function test_list_unmanaged_kernels()
   # arguments: $flag $single_line $prefix $all
   output=$(list_installed_kernels 'TEST_MODE' "1" "$SHUNIT_TMPDIR" "1")
   compare_command_sequence 'expected' "$output" "($LINENO)"
+
+  rm -rf "$SHUNIT_TMPDIR/boot/grub"
+
+  expected[2]='Could not find grub installed. Cannot list all installed kernels'
+  output=$(list_installed_kernels 'TEST_MODE' "1" "$SHUNIT_TMPDIR" "1")
+  compare_command_sequence 'expected' "$output" "($LINENO)"
+}
+
+function test_list_kernels_based_on_grub()
+{
+  local output
+  local expected_str
+  local -a available_kernels=()
+
+  list_installed_kernels_based_on_grub "$SHUNIT_TMPDIR" 'available_kernels'
+  expected_str='5.5.0-rc2-VKMS+ 5.5.0-rc2-VKMS+.old 5.6.0-rc2-AMDGPU+ linux'
+  assertEquals "($LINENO)" "$expected_str" "${available_kernels[*]}"
 }
 
 function test_reboot_machine()

--- a/tests/samples/boot/grub/grub.cfg
+++ b/tests/samples/boot/grub/grub.cfg
@@ -22,6 +22,17 @@ submenu 'Advanced options for Arch Linux' $menuentry_id_option 'gnulinux-advance
 		echo	'Loading initial ramdisk ...'
 		initrd	/boot/initramfs-5.5.0-rc2-VKMS+.img
 	}
+	menuentry 'Arch Linux, with Linux 5.5.0-rc2-VKMS+.old' --class arch --class gnu-linux --class gnu --class os $menuentry_id_option 'gnulinux-5.5.0-rc2-VKMS+.old' {
+		load_video
+		set gfxpayload=keep
+		insmod gzio
+		insmod part_msdos
+		insmod ext2
+		set root='hd0,msdos1'
+		linux	/boot/vmlinuz-5.5.0-rc2-VKMS+.old root=UUID= rw  loglevel=3 quiet
+		echo	'Loading initial ramdisk ...'
+		initrd	/boot/initramfs-5.5.0-rc2-VKMS+.old.img
+	}
 	menuentry 'Arch Linux, with Linux 5.6.0-rc2-AMDGPU+' --class arch --class gnu-linux --class gnu --class os $menuentry_id_option 'gnulinux-5.6.0-rc2-AMDGPU+' {
 		load_video
 		set gfxpayload=keep


### PR DESCRIPTION
With this commit kw keeps track of kernels it installed, and by default
will only list and uninstall those. Two new options for kw deploy are
added: --force will remove kernels even if they were not installed by
kw, and --all will list all installed kernels, even if they were not
installed by kw.

Closes: #187 