### PR TITLE
src: deploy: Refactor option parsing

### DIFF
--- a/documentation/man/features/deploy.rst
+++ b/documentation/man/features/deploy.rst
@@ -6,7 +6,7 @@ kw-deploy
 
 SYNOPSIS
 ========
-*kw* (*d* | *deploy*) [\--remote [<remote>:<port>] | \--local | \--vm]
+*kw* (*d* | *deploy*) [\--remote <remote>:<port> | \--local | \--vm]
                       [-r | \--reboot] [-m | \--modules] [-s | \--ls-line]
                       [-l | \--list] [(-u | \--uninstall) <kernel-name>[,...]]
                       [\--alert=(s | v | (sv | vs) | n)]
@@ -25,7 +25,7 @@ executed:
 3. Execute the operations that will update the target machine.
 
 You can specify the deploy target via command line by using the flag
-**\--remote [<remote>:<port>]** (e.g., **\--remote 172.16.254.1:22**); however,
+**\--remote <remote>:<port>** (e.g., **\--remote 172.16.254.1:22**); however,
 if you do it frequently you probably will prefer to add this information in
 your local **kworkflow.config**. See the example below::
 
@@ -51,7 +51,7 @@ This can be used with conjunction the **build** command by invoking ``kw bd``.
 
 OPTIONS
 =======
-\--remote [<remote>:<port>]:
+\--remote <remote>:<port>:
   Deploy the Kernel image and modules to a machine in
   the network.
 

--- a/src/kwio.sh
+++ b/src/kwio.sh
@@ -27,7 +27,7 @@ function alert_completion()
 
   while read -rN 1 option; do
     if [ "$option" == "v" ]; then
-      if command_exists "${configurations[visual_alert_command]} &"; then
+      if command_exists "${configurations[visual_alert_command]}"; then
         eval "${configurations[visual_alert_command]} &"
       else
         warning "The following command set in the visual_alert_command variable" \
@@ -36,7 +36,7 @@ function alert_completion()
         warning "Check if the necessary packages are installed."
       fi
     elif [ "$option" == "s" ]; then
-      if command_exists "${configurations[sound_alert_command]} &"; then
+      if command_exists "${configurations[sound_alert_command]}"; then
         eval "${configurations[sound_alert_command]} &"
       else
         warning "The following command set in the sound_alert_command variable" \

--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -371,3 +371,50 @@ function exit_msg()
   complain "$msg"
   exit "$err"
 }
+
+# This function parses command line arguments. Each option may be
+# followed by a one colon to indicate it has a required argument, and by
+# two colons to indicate it has an optional argument. If any errors are
+# found, this will print an error message to stderr indicating it.
+#
+# @short_options Short options to be accepted
+# @long_options Long options to be accepted
+# @{@:2} Arguments to be parsed
+#
+# Returns:
+# Parsed command line arguments.
+function kw_parse()
+{
+  local short_options="$1"
+  local long_options="$2"
+  shift 2
+
+  getopt -q --options "$short_options" \
+    --longoptions "$long_options" \
+    -- "$@"
+}
+
+# This function gets the error messages for a kw_parse call. The same
+# arguments passed to kw_parse should be passed to this function.
+#
+# @name Name to be prefixed in error messages
+# @short_options Short options to be accepted
+# @long_options Long options to be accepted
+# @{@:2} Arguments to be parsed
+#
+# Returns:
+# Error messages separated by a newline and prefixed with @name
+function kw_parse_get_errors()
+{
+  local name="$1"
+  local short_options="$2"
+  local long_options="$3"
+  shift 3
+
+  {
+    getopt --name "$name" \
+      --options "$short_options" \
+      --longoptions "$long_options" \
+      -- "$@" > /dev/null
+  } 2>&1
+}

--- a/src/vm.sh
+++ b/src/vm.sh
@@ -18,7 +18,9 @@ function vm_mount()
   qemu_img_path="${qemu_img_path:-${configurations[qemu_path_image]}}"
   mount_point_path="${mount_point_path:-${configurations[mount_point]}}"
 
-  [[ $(findmnt "$mount_point_path") ]] && return 125
+  if [[ -n "$(findmnt "$mount_point_path")" ]]; then
+    return 125 # ECANCELED
+  fi
 
   mkdir -p "$mount_point_path"
 

--- a/tests/build_test.sh
+++ b/tests/build_test.sh
@@ -162,12 +162,12 @@ function test_build_info()
   )
 
   output=$(kernel_build 'TEST_MODE' '--info')
-  compare_command_sequence expected_cmd[@] "$output" "($LINENO)"
+  compare_command_sequence 'expected_cmd' "$output" "($LINENO)"
 
   cp "$original_dir/tests/samples/.config" .config
   expected_cmd[3]="$modules"
   output=$(kernel_build 'TEST_MODE' '--info')
-  compare_command_sequence expected_cmd[@] "$output" "($LINENO)"
+  compare_command_sequence 'expected_cmd' "$output" "($LINENO)"
   rm .config
 }
 

--- a/tests/checkpatch_wrapper_test.sh
+++ b/tests/checkpatch_wrapper_test.sh
@@ -124,7 +124,7 @@ function test_run_checkpatch_in_a_path()
   )
 
   output=$(execute_checkpatch "$patch_path" 'TEST_MODE' 2>&1)
-  compare_command_sequence expected_cmd[@] "$output" '1'
+  compare_command_sequence 'expected_cmd' "$output" '1'
 }
 
 function test_run_checkpatch_in_a_file()
@@ -145,7 +145,7 @@ function test_run_checkpatch_in_a_file()
   )
 
   output=$(execute_checkpatch "$patch_path" 'TEST_MODE' 2>&1)
-  compare_command_sequence expected_cmd[@] "$output" '1'
+  compare_command_sequence 'expected_cmd' "$output" '1'
 }
 
 invoke_shunit

--- a/tests/configm_test.sh
+++ b/tests/configm_test.sh
@@ -341,7 +341,7 @@ function test_get_config()
     return
   }
   output=$(echo 'y' | get_config "$NAME_1")
-  compare_command_sequence expected_output[@] "$output" "$LINENO"
+  compare_command_sequence 'expected_output' "$output" "$LINENO"
 
   # Case 2: There's no local .config file
   rm -f .config

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -270,7 +270,7 @@ function test_kernel_install()
   remote_parameters['REMOTE_PORT']=3333
 
   output=$(kernel_install 1 'test' 'TEST_MODE' 3) # 3: REMOTE_TARGET
-  compare_command_sequence expected_cmd[@] "$output" "$LINENO"
+  compare_command_sequence 'expected_cmd' "$output" "$LINENO"
 
   # Update values
   # NOTICE: I added one extra space in the below line for match what we
@@ -289,7 +289,7 @@ function test_kernel_install()
   )
 
   output=$(kernel_install "0" "test" "TEST_MODE" "3" "127.0.0.1:3333")
-  compare_command_sequence expected_cmd[@] "$output" "$LINENO"
+  compare_command_sequence 'expected_cmd' "$output" "$LINENO"
 
   # We want to test an corner case described by the absence of mkinitcpio
   cd "$original" || {
@@ -361,7 +361,7 @@ function test_kernel_install_x86_64()
   )
 
   output=$(kernel_install "1" "test" "TEST_MODE" "3" "127.0.0.1:3333")
-  compare_command_sequence expected_cmd[@] "$output" "$LINENO"
+  compare_command_sequence 'expected_cmd' "$output" "$LINENO"
 
   # Test kernel image infer
   configurations['kernel_img_name']=''
@@ -522,7 +522,7 @@ function test_kernel_install_local()
   }
 
   output=$(kernel_install "1" "test" "TEST_MODE" "2")
-  compare_command_sequence expected_cmd[@] "$output" "$LINENO"
+  compare_command_sequence 'expected_cmd' "$output" "$LINENO"
 
   # Make sure that we are not running as a root user
   alias id='root_id_mock;true'
@@ -649,7 +649,7 @@ function test_kernel_uninstall()
   options_values['REMOTE_IP']='127.0.0.1'
   options_values['REMOTE_PORT']=3333
   output=$(kernel_uninstall 3 0 "$kernel_list" "TEST_MODE")
-  compare_command_sequence expected_cmd[@] "$output" "$ID"
+  compare_command_sequence 'expected_cmd' "$output" "$ID"
 
   # Reboot
   ID=2
@@ -658,7 +658,7 @@ function test_kernel_uninstall()
   kernel_uninstall_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"$cmd\""
   expected_cmd[7]="$kernel_uninstall_cmd"
 
-  compare_command_sequence expected_cmd[@] "$output" "$ID"
+  compare_command_sequence 'expected_cmd' "$output" "$ID"
 
   # Single kernel
   ID=3
@@ -667,7 +667,7 @@ function test_kernel_uninstall()
   kernel_uninstall_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"$cmd\""
   expected_cmd[7]="$kernel_uninstall_cmd"
 
-  compare_command_sequence expected_cmd[@] "$output" "$ID"
+  compare_command_sequence 'expected_cmd' "$output" "$ID"
 
   cd "$original" || {
     fail "($LINENO) It was not possible to move back from temp directory"

--- a/tests/device_test.sh
+++ b/tests/device_test.sh
@@ -37,7 +37,7 @@ function test_get_cpu()
   assertEquals "($LINENO)" 'Virtual' "${device_info_data['cpu_model']}"
 
   output=$(get_cpu "$LOCAL_TARGET" 'TEST_MODE')
-  compare_command_sequence expected_cmd[@] "$output" "$LINENO"
+  compare_command_sequence 'expected_cmd' "$output" "$LINENO"
 
   declare -a expected_cmd=(
     "ssh -p 2222 john@127.0.0.1 sudo \"lscpu | grep 'Model name:' | sed -r 's/Model name:\s+//g' | cut -d' ' -f1\""
@@ -47,7 +47,7 @@ function test_get_cpu()
   device_options['ip']='127.0.0.1'
   device_options['port']='2222'
   output=$(get_cpu "$REMOTE_TARGET" 'TEST_MODE')
-  compare_command_sequence expected_cmd[@] "$output" "$LINENO"
+  compare_command_sequence 'expected_cmd' "$output" "$LINENO"
 }
 
 function test_get_disk()
@@ -79,7 +79,7 @@ function test_get_motherboard()
   )
 
   output=$(get_motherboard "$LOCAL_TARGET" 'TEST_MODE')
-  compare_command_sequence expected_cmd[@] "$output" "$LINENO"
+  compare_command_sequence 'expected_cmd' "$output" "$LINENO"
 }
 
 function test_get_chassis()
@@ -129,7 +129,7 @@ function test_display_data()
   device_info_data['motherboard_vendor']='Vendor'
   device_info_data['motherboard_name']='ABC123'
   output=$(show_data)
-  compare_command_sequence expected_cmd[@] "$output" "$LINENO"
+  compare_command_sequence 'expected_cmd' "$output" "$LINENO"
 }
 
 invoke_shunit

--- a/tests/diff_test.sh
+++ b/tests/diff_test.sh
@@ -20,7 +20,7 @@ function test_diff_side_by_side()
 
   ID=1
   output=$(diff_side_by_side "$file_1" "$file_2" 1 'TEST_MODE')
-  compare_command_sequence expected_cmd[@] "$output" "$ID"
+  compare_command_sequence 'expected_cmd' "$output" "$ID"
 
   ID=2
   diff_cmd="diff -y --color=always --width=$columns $file_1 $file_2"
@@ -29,7 +29,7 @@ function test_diff_side_by_side()
   )
 
   output=$(diff_side_by_side "$file_1" "$file_2" 0 'TEST_MODE')
-  compare_command_sequence expected_cmd[@] "$output" "$ID"
+  compare_command_sequence 'expected_cmd' "$output" "$ID"
 
   ID=3
   output=$(diff_side_by_side 'an_invalid_file' "$file_2" 0 'TEST_MODE')

--- a/tests/drm_plugin_test.sh
+++ b/tests/drm_plugin_test.sh
@@ -76,7 +76,7 @@ function test_gui_control()
   )
 
   output=$(gui_control 'ON' '3' '127.0.0.1:8888' 'TEST_MODE')
-  compare_command_sequence expected_cmd_seq[@] "$output" "$ID"
+  compare_command_sequence 'expected_cmd_seq' "$output" "$ID"
 
   ID=2
   full_turn_off_gui_cmd="$ssh_part sudo \"$gui_off_cmd\""
@@ -88,7 +88,7 @@ function test_gui_control()
   )
 
   output=$(gui_control 'OFF' '3' '127.0.0.1:8888' 'TEST_MODE')
-  compare_command_sequence expected_cmd_seq[@] "$output" "$ID"
+  compare_command_sequence 'expected_cmd_seq' "$output" "$ID"
 
   ID=3
   # Test with config file
@@ -105,7 +105,7 @@ function test_gui_control()
   )
 
   output=$(gui_control 'OFF' '3' '' 'TEST_MODE')
-  compare_command_sequence expected_cmd_seq[@] "$output" "$ID"
+  compare_command_sequence 'expected_cmd_seq' "$output" "$ID"
 
   ID=4
   gui_on_cmd='turn on'
@@ -118,7 +118,7 @@ function test_gui_control()
   )
 
   output=$(gui_control 'ON' '3' '' 'TEST_MODE')
-  compare_command_sequence expected_cmd_seq[@] "$output" "$ID"
+  compare_command_sequence 'expected_cmd_seq' "$output" "$ID"
 }
 
 function test_get_supported_mode_per_connector()
@@ -156,7 +156,7 @@ function test_get_supported_mode_per_connector()
 
   export SYSFS_CLASS_DRM="$FAKE_DRM_SYSFS"
   output=$(get_supported_mode_per_connector 2)
-  compare_command_sequence expected_output[@] "$output" "$ID"
+  compare_command_sequence 'expected_output' "$output" "$ID"
 }
 
 function test_module_control()
@@ -213,7 +213,7 @@ function test_module_control()
   output=$(module_control "UNLOAD" "3" "" "amdgpu;vkms" "TEST_MODE")
   assertEquals "$ID - Load modules with parameters" "$expected" "$output"
 }
-#compare_command_sequence expected_cmd[@] "$output" "$ID"
+#compare_command_sequence 'expected_cmd' "$output" "$ID"
 
 function test_convert_module_info()
 {

--- a/tests/kwlib_test.sh
+++ b/tests/kwlib_test.sh
@@ -392,4 +392,31 @@ function test_exit_msg()
   assertEquals "($LINENO) We expected 3 as a return" 3 "$ret"
 }
 
+function test_kw_parse()
+{
+  local long_options='xpto:,foo,bar'
+  local short_options='x:,f,b'
+  local out
+  local expected
+
+  out="$(kw_parse "$short_options" "$long_options" --xpto 1 --foo --bar biz)"
+  expected=" --xpto '1' --foo --bar -- 'biz'"
+  assertEquals "($LINENO)" "$expected" "$out"
+}
+
+function test_kw_parse_get_errors()
+{
+  local long_options='xpto:,foo,bar'
+  local short_options='x:,f,b'
+  local out
+  local -a expected_output
+
+  out="$(kw_parse_get_errors 'kw' "$short_options" "$long_options" --fee --bar biz --xpto)"
+  expected_output=(
+    "kw: unrecognized option '--fee'"
+    "kw: option '--xpto' requires an argument"
+  )
+  compare_command_sequence 'expected_output' "$out" "$LINENO"
+}
+
 invoke_shunit

--- a/tests/plugins/kernel_install/arch_test.sh
+++ b/tests/plugins/kernel_install/arch_test.sh
@@ -43,7 +43,7 @@ function test_generate_arch_temporary_root_file_system()
   )
 
   output=$(generate_arch_temporary_root_file_system "$name" 'local' 'TEST_MODE' '')
-  compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
+  compare_command_sequence 'cmd_sequence' "$output" "$LINENO"
 
   # Remote
   declare -a cmd_sequence=(
@@ -52,7 +52,7 @@ function test_generate_arch_temporary_root_file_system()
   )
 
   output=$(generate_arch_temporary_root_file_system "$name" 'remote' 'TEST_MODE' '')
-  compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
+  compare_command_sequence 'cmd_sequence' "$output" "$LINENO"
 
   # VM
   sudo_cmd=''
@@ -62,7 +62,7 @@ function test_generate_arch_temporary_root_file_system()
   )
 
   output=$(generate_arch_temporary_root_file_system "$name" 'vm' 'TEST_MODE' '')
-  compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
+  compare_command_sequence 'cmd_sequence' "$output" "$LINENO"
 }
 
 invoke_shunit

--- a/tests/plugins/kernel_install/utils_test.sh
+++ b/tests/plugins/kernel_install/utils_test.sh
@@ -120,7 +120,7 @@ function test_do_uninstall_cmd_sequence()
   )
 
   output=$(do_uninstall "$target" "$prefix" "$TEST_MODE")
-  compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
+  compare_command_sequence 'cmd_sequence' "$output" "$LINENO"
 
   # Good sequence
   cd "$SHUNIT_TMPDIR" || {
@@ -144,7 +144,7 @@ function test_do_uninstall_cmd_sequence()
   )
 
   output=$(do_uninstall "$target" "$prefix" 'TEST_MODE')
-  compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
+  compare_command_sequence 'cmd_sequence' "$output" "$LINENO"
 
   # Partial sequence
   rm "$kernelpath.old"
@@ -161,7 +161,7 @@ function test_do_uninstall_cmd_sequence()
   )
 
   output=$(do_uninstall "$target" "$prefix" 'TEST_MODE')
-  compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
+  compare_command_sequence 'cmd_sequence' "$output" "$LINENO"
 
   cd "$TEST_ROOT_PATH" || {
     fail "($LINENO) It was not possible to move back from temp directory"
@@ -213,7 +213,7 @@ function test_vm_update_boot_loader_debian()
 
   output=$(vm_update_boot_loader "$name" 'debian' "$cmd_grub" "$cmd_init" "$setup_grub" "$grub_install" 'TEST_MODE')
 
-  compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
+  compare_command_sequence 'cmd_sequence' "$output" "$LINENO"
 }
 
 function test_vm_update_boot_loader_arch()
@@ -250,7 +250,7 @@ function test_vm_update_boot_loader_arch()
 
   output=$(vm_update_boot_loader "$name" 'arch' "$cmd_grub" "$cmd_init" "$setup_grub" "$grub_install" 'TEST_MODE')
 
-  compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
+  compare_command_sequence 'cmd_sequence' "$output" "$LINENO"
 }
 
 # Mock funtions for install tests
@@ -297,7 +297,7 @@ function test_install_kernel_remote()
     'reboot'
   )
   output=$(install_kernel "$name" 'debian' "$kernel_image_name" "$reboot" "$architecture" "$target" 'TEST_MODE')
-  compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
+  compare_command_sequence 'cmd_sequence' "$output" "$LINENO"
 }
 
 function test_install_kernel_local()
@@ -320,7 +320,7 @@ function test_install_kernel_local()
   )
 
   output=$(install_kernel "$name" 'debian' "$kernel_image_name" "$reboot" "$architecture" "$target" 'TEST_MODE')
-  compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
+  compare_command_sequence 'cmd_sequence' "$output" "$LINENO"
 }
 
 function test_install_kernel_vm()
@@ -357,7 +357,7 @@ function test_install_kernel_vm()
   alias vm_umount='vm_umount'
 
   output=$(install_kernel "$name" 'debian' "$kernel_image_name" "$reboot" "$architecture" "$target" 'TEST_MODE')
-  compare_command_sequence cmd_sequence[@] "$output" "$LINENO"
+  compare_command_sequence 'cmd_sequence' "$output" "$LINENO"
 
   cd "$TEST_ROOT_PATH" || {
     fail "($LINENO) It was not possible to move back from temp directory"

--- a/tests/pomodoro_test.sh
+++ b/tests/pomodoro_test.sh
@@ -44,7 +44,7 @@ function test_register_timebox()
   register_timebox '433222557'
 
   output=$(cat "$POMODORO_LOG_FILE")
-  compare_command_sequence expected_content[@] "$output" "($LINENO)"
+  compare_command_sequence 'expected_content' "$output" "($LINENO)"
 }
 
 function test_remove_completed_timebox()
@@ -66,7 +66,7 @@ function test_remove_completed_timebox()
 
   remove_completed_timebox '433222557'
   output=$(cat "$POMODORO_LOG_FILE")
-  compare_command_sequence expected_content[@] "$output" "($LINENO)"
+  compare_command_sequence 'expected_content' "$output" "($LINENO)"
 
   remove_completed_timebox '933222557'
   output=$(cat "$POMODORO_LOG_FILE")
@@ -143,7 +143,7 @@ function test_show_active_pomodoro_timebox()
   )
 
   output=$(show_active_pomodoro_timebox)
-  compare_command_sequence expected_content[@] "$output" "($LINENO)"
+  compare_command_sequence 'expected_content' "$output" "($LINENO)"
 }
 
 function test_pomodoro_parser()
@@ -262,15 +262,15 @@ function test_register_tag()
   register_tag 'tag 2'
   output=$(cat "$KW_POMODORO_TAG_LIST")
 
-  compare_command_sequence expected_content[@] "$output" "($LINENO)"
+  compare_command_sequence 'expected_content' "$output" "($LINENO)"
 
   # Try to register the same tag
   register_tag 'tag 2'
-  compare_command_sequence expected_content[@] "$output" "($LINENO)"
+  compare_command_sequence 'expected_content' "$output" "($LINENO)"
 
   # Try to register an empty tag
   register_tag ''
-  compare_command_sequence expected_content[@] "$output" "($LINENO)"
+  compare_command_sequence 'expected_content' "$output" "($LINENO)"
 }
 
 function test_is_tag_already_registered()

--- a/tests/statistics_test.sh
+++ b/tests/statistics_test.sh
@@ -51,7 +51,7 @@ function test_statistics()
 
   configurations[disable_statistics_data_track]='yes'
   output=$(statistics --)
-  compare_command_sequence expected_cmd[@] "$output" "$LINENO"
+  compare_command_sequence 'expected_cmd' "$output" "$LINENO"
 
   configurations[disable_statistics_data_track]='no'
 
@@ -166,7 +166,7 @@ function test_day_statistics()
   assertEquals "($LINENO)" "$msg2" "$day_data"
 
   day_data=$(day_statistics 2020/05/27 | tail -n 2)
-  compare_command_sequence may_27_2020[@] "$day_data" "$LINENO"
+  compare_command_sequence 'may_27_2020' "$day_data" "$LINENO"
 }
 
 function test_week_statistics()
@@ -181,7 +181,7 @@ function test_week_statistics()
   assertEquals "($LINENO)" "$msg" "$week_data"
 
   week_data=$(week_statistics 2020/05/25 | tail -n 2)
-  compare_command_sequence may_27_2020[@] "$week_data" "$LINENO"
+  compare_command_sequence 'may_27_2020' "$week_data" "$LINENO"
 }
 
 function test_month_statistics()
@@ -194,7 +194,7 @@ function test_month_statistics()
   assertEquals "($LINENO)" "$msg" "$month_data"
 
   month_data=$(month_statistics 2020/05 | tail -n 2)
-  compare_command_sequence may_27_2020[@] "$month_data" "$LINENO"
+  compare_command_sequence 'may_27_2020' "$month_data" "$LINENO"
 
   mkdir -p "$base_statistics/04"
   msg='Sorry, kw does not have any record for 2020/04'
@@ -213,7 +213,7 @@ function test_year_statistics()
   assertEquals "($LINENO)" "$msg" "$year_data"
 
   year_data=$(year_statistics 2020 | tail -n 2)
-  compare_command_sequence may_27_2020[@] "$year_data" "$LINENO"
+  compare_command_sequence 'may_27_2020' "$year_data" "$LINENO"
 
   declare -a expected_cmd=(
     'Deploy             1 00:00:21 00:00:21 00:00:21'
@@ -224,7 +224,7 @@ function test_year_statistics()
   )
 
   year_data=$(year_statistics 2021 | tail -n 5)
-  compare_command_sequence expected_cmd[@] "$year_data" "$LINENO"
+  compare_command_sequence 'expected_cmd' "$year_data" "$LINENO"
 }
 
 invoke_shunit

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -216,12 +216,13 @@ function mk_fake_boot()
 # This function expects an array of string with the command sequence and a
 # string containing the output.
 #
-# @expected Command sequence as an array
+# @_expected Name of the array variable containing expected strings
 # @result_to_compare A raw output from the string
 # @ID An ID identification
 function compare_command_sequence()
 {
-  declare -a expected=("${!1}")
+  # This variable name must be unique
+  local -n _expected="$1"
   local result_to_compare="$2"
   local ID="$3"
   local count=0
@@ -229,9 +230,9 @@ function compare_command_sequence()
   ID=${ID:-0}
 
   while read -r f; do
-    if [[ "${expected[$count]}" != "${f}" ]]; then
+    if [[ "${_expected[$count]}" != "${f}" ]]; then
       fail "($ID) $count
-Expected: \"${expected[$count]}\"
+Expected: \"${_expected[$count]}\"
 but got:  \"${f}\"
 "
     fi

--- a/tests/vm_test.sh
+++ b/tests/vm_test.sh
@@ -16,7 +16,6 @@ function tearDown()
 
 function test_vm_mount()
 {
-  local ID
   local mount_point="$SHUNIT_TMPDIR/lala"
   local qemu_path="/any/path"
   local -r current_path="$PWD"
@@ -42,38 +41,38 @@ function test_vm_mount()
     return
   }
 
-  ID=1
-  output=$(vm_mount "TEST_MODE")
+  output=$(
+    function findmnt()
+    {
+      echo "anything"
+    }
+    vm_mount "TEST_MODE"
+  )
   ret="$?"
   expected_ret="125"
-  assertEquals "($ID) - Expected 125" "$expected_ret" "$ret"
+  assertEquals "($LINENO) - Expected 125" "$expected_ret" "$ret"
 
-  ID=2
   output=$(vm_mount "TEST_MODE" "$qemu_path" "$mount_point")
   ret="$?"
-  assertTrue "($ID)" "$ret"
+  assertTrue "($LINENO)" "$ret"
 
-  ID=3
   output=$(vm_mount "TEST_MODE" "$qemu_path" "$mount_point")
-  compare_command_sequence 'expected_cmd' "$output" "$ID"
+  compare_command_sequence 'expected_cmd' "$output" "$LINENO"
 
   load_configuration "$KW_CONFIG_SAMPLE"
 
-  ID=4
   say_msg="Mount ${configurations[qemu_path_image]} in $mount_point"
   guestmount_cmd="guestmount -a ${configurations[qemu_path_image]} -i $mount_point 2>&1"
   expected_cmd[0]="$say_msg"
   expected_cmd[1]="$guestmount_cmd"
 
   output=$(vm_mount "TEST_MODE" "" "$mount_point")
-  compare_command_sequence 'expected_cmd' "$output" "$ID"
+  compare_command_sequence 'expected_cmd' "$output" "$LINENO"
 
   cd "$current_path" || {
     fail "($LINENO) It was not possible to move back from temp directory"
     return
   }
-
-  tearDown
 }
 
 function test_vm_umount()

--- a/tests/vm_test.sh
+++ b/tests/vm_test.sh
@@ -55,7 +55,7 @@ function test_vm_mount()
 
   ID=3
   output=$(vm_mount "TEST_MODE" "$qemu_path" "$mount_point")
-  compare_command_sequence expected_cmd[@] "$output" "$ID"
+  compare_command_sequence 'expected_cmd' "$output" "$ID"
 
   load_configuration "$KW_CONFIG_SAMPLE"
 
@@ -66,7 +66,7 @@ function test_vm_mount()
   expected_cmd[1]="$guestmount_cmd"
 
   output=$(vm_mount "TEST_MODE" "" "$mount_point")
-  compare_command_sequence expected_cmd[@] "$output" "$ID"
+  compare_command_sequence 'expected_cmd' "$output" "$ID"
 
   cd "$current_path" || {
     fail "($LINENO) It was not possible to move back from temp directory"
@@ -113,7 +113,7 @@ function test_vm_umount()
 
   ID=3
   output=$(vm_umount "TEST_MODE" "" "$mount_point")
-  compare_command_sequence expected_cmd[@] "$output" "$ID"
+  compare_command_sequence 'expected_cmd' "$output" "$ID"
 
   cd "$current_path" || {
     fail "($LINENO) It was not possible to move back from temp directory"


### PR DESCRIPTION
Use getopt to simplify the parsing of options for kw deploy. This
implies one change of behaviour: getopt accepts abbreviations of options,
as long as there is no ambiguity. For example, now --rem is accepted
and is equivalent to --remote.

Signed-off-by: João Seckler <jseckler@riseup.net>