### PR TITLE
remote: bugfix for the use of ssh config files

### DIFF
--- a/src/remote.sh
+++ b/src/remote.sh
@@ -82,9 +82,10 @@ function cp_host2remote()
   local user=${5:-${configurations[ssh_user]}}
   local flag=${6:-"HIGHLIGHT_CMD"}
 
-  cmd_manager "$flag" "rsync -e 'ssh -p $port' -La $src $user@$remote:$dst --rsync-path='sudo rsync'"
   if [[ -v configurations['ssh_configfile'] && -v configurations['hostname'] ]]; then
     cmd_manager "$flag" "rsync -e 'ssh -F ${configurations['ssh_configfile']}' -La $src ${configurations['hostname']}:$dst --rsync-path='sudo rsync'"
+  else
+    cmd_manager "$flag" "rsync -e 'ssh -p $port' -La $src $user@$remote:$dst --rsync-path='sudo rsync'"
   fi
 
   cmd_remotely "chown -R root:root $dst" "$flag" "$remote" "$port" "$user"


### PR DESCRIPTION
cp_host2remote was working in such a way that if a ssh_configfile was
present, rsync would be used twice and fail since the first time it
would use the wrong parameters. By reintroducing the else clause this
bug is fixed

Signed-off-by: Alan Barzilay <alan.barzilay@gmail.com>