### PR TITLE
shellcheck: Fix warning related to arrays

### DIFF
--- a/src/plugins/kernel_install/utils.sh
+++ b/src/plugins/kernel_install/utils.sh
@@ -36,7 +36,7 @@ function cmd_manager()
 
 function ask_yN()
 {
-  local message=$@
+  local message="$*"
 
   read -r -p "$message [y/N] " response
   if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]; then

--- a/src/plugins/subsystems/drm/drm.sh
+++ b/src/plugins/subsystems/drm/drm.sh
@@ -126,7 +126,7 @@ function convert_module_info()
 {
   local unload="$1"
   shift
-  local raw_modules_str="$@"
+  local raw_modules_str="$*"
   local parameters_str=""
   local final_command=""
   local remove_flag=""
@@ -343,7 +343,7 @@ function get_supported_mode_per_connector()
 
 function drm_parser_options()
 {
-  local raw_options="$@"
+  local raw_options="$*"
   local flag=0
   local remote
 

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -240,11 +240,15 @@ function assert_equals_helper()
 {
   local msg="$1"
   local line="$2"
+  # See bugs section in github.com/koalaman/shellcheck/wiki/SC2178
+  # shellcheck disable=SC2178
   local expected="$3"
   local target="$4"
 
   line=${line:-'Unknown line'}
 
+  # See bugs section in github.com/koalaman/shellcheck/wiki/SC2178
+  # shellcheck disable=2128
   assertEquals "line $line: $msg" "$target" "$expected"
 }
 


### PR DESCRIPTION
Some files were left out of commit db3b26d0. This commit includes those.

Closes: #318

Signed-off-by: João Seckler <jseckler@riseup.net>