### PR TITLE
src: deploy: Fix kw clear-cache

### DIFF
--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -389,14 +389,12 @@ function cleanup()
   local flag=${1:-'SILENT'}
   say 'Cleaning up temporary files...'
 
-  if [[ -v options_values['REMOTE'] ]]; then
-    if [[ -d "$KW_CACHE_DIR/$LOCAL_REMOTE_DIR" ]]; then
-      cmd_manager "$flag" "rm -rf $KW_CACHE_DIR/$LOCAL_REMOTE_DIR/*"
-    fi
+  if [[ -d "$KW_CACHE_DIR/$LOCAL_REMOTE_DIR" ]]; then
+    cmd_manager "$flag" "rm -rf $KW_CACHE_DIR/$LOCAL_REMOTE_DIR/"*
+  fi
 
-    if [[ -d "$KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR" ]]; then
-      cmd_manager "$flag" "rm -rf $KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR/*"
-    fi
+  if [[ -d "$KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR" ]]; then
+    cmd_manager "$flag" "rm -rf $KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR/"*
   fi
 
   say 'Exiting...'


### PR DESCRIPTION
Function cleanup inside src/deploy.sh was not deleting anything because
of quoted star globs. This patch unquotes those.

Signed-off-by: João Seckler <jseckler@riseup.net>