### PR TITLE
Make kw compliant with XDG Base Directory Specification

### DIFF
--- a/kw
+++ b/kw
@@ -1,11 +1,31 @@
 #!/bin/bash
 
-# Note: the following line should not be modified, and neither the token should
-# be repeated in this file because It will be replaced during installation with
-# the respective installation prefix.
-KW_INSTALL_PREFIX=${KW_INSTALL_PREFIX:-"##KW_INSTALL_PREFIX_TOKEN##"}
-
 KWORKFLOW=${KWORKFLOW:-"kw"}
+
+# Global paths
+
+# Kw shell files
+KW_LIB_DIR="${KW_LIB_DIR:-"$HOME/.local/lib"}/$KWORKFLOW"
+KW_PLUGINS_DIR="${KW_PLUGINS_DIR:-"$KW_LIB_DIR/plugins"}"
+
+# Share files
+KW_SHARE_DIR="${XDG_DATA_HOME:-"$HOME/.local/share"}/$KWORKFLOW"
+KW_DOC_DIR="$KW_SHARE_DIR/doc"
+KW_MAN_DIR="$KW_SHARE_DIR/man"
+KW_SOUND_DIR="$KW_SHARE_DIR/sound"
+
+# User specific data files (currently this collapses with the share dir,
+# but would not for a system-wide installation)
+KW_DATA_DIR="${XDG_DATA_HOME:-"$HOME/.local/share"}/$KWORKFLOW"
+
+# Configuration files
+KW_ETC_DIR="${XDG_CONFIG_HOME:-"$HOME/.config"}/$KWORKFLOW"
+
+# Cache folder
+KW_CACHE_DIR="${XDG_CACHE_HOME:-"$HOME/.cache"}/$KWORKFLOW"
+
+# State files
+KW_STATE_DIR="${XDG_STATE_HOME:-"$HOME/.local/state"}/$KWORKFLOW"
 
 ##BEGIN-DEV-MODE##
 KW_BIN="$(readlink -f "${BASH_SOURCE[0]}")"
@@ -13,19 +33,15 @@ KW_BASE_DIR="$(dirname "${KW_BIN}")"
 if [ -f "${KW_BASE_DIR}/src/kwlib.sh" ]; then
   # running from source directory
   KW_LIB_DIR="${KW_BASE_DIR}/src"
-  KW_INSTALL_PREFIX="${KW_BASE_DIR}"
+  # KW_DATA_DIR # use default data folder
+  KW_DOC_DIR="${KW_BASE_DIR}/documentation"
+  KW_MAN_DIR="${KW_BASE_DIR}/documentation/man"
+  KW_SOUND_DIR="${KW_BASE_DIR}/sound"
+  KW_ETC_DIR="${KW_BASE_DIR}/etc"
+  KW_PLUGINS_DIR="${KW_LIB_DIR}/plugins"
+  # KW_CACHE_DIR # use default cache folder
 fi
 ##END-DEV-MODE##
-
-# Global paths
-KW_LIB_DIR=${KW_LIB_DIR:-"$KW_INSTALL_PREFIX/lib/kw"}
-KW_SHARE_DOC_DIR=${KW_SHARE_DIR:-"$KW_INSTALL_PREFIX/share/doc/kw/"}
-KW_SHARE_MAN_DIR=${KW_SHARE_DIR:-"$KW_INSTALL_PREFIX/share/man"}
-KW_SHARE_SOUND_DIR=${KW_SHARE_DIR:-"$KW_INSTALL_PREFIX/share/sound/kw"}
-KW_ETC_DIR=${KW_ETC_DIR:-"$KW_INSTALL_PREFIX/etc/kw"}
-KW_DATA_DIR=${KW_DATA_DIR:-"$HOME/.kw"}
-KW_PLUGINS_DIR=${KW_PLUGINS_DIR:-"$KW_LIB_DIR/plugins"}
-KW_CACHE_DIR="$HOME/.cache/kw"
 
 # Export external variables required by kworkflow
 export KWORKFLOW

--- a/src/help.sh
+++ b/src/help.sh
@@ -40,7 +40,7 @@ function kworkflow_man()
 {
   feature="$1"
   flag=${2:-'SILENT'}
-  doc="$KW_SHARE_MAN_DIR"
+  doc="$KW_MAN_DIR"
 
   if [[ -z "$feature" ]]; then
     feature='kw'

--- a/src/init.sh
+++ b/src/init.sh
@@ -29,7 +29,7 @@ function init_kw()
 
   if [[ -f "$config_file_template" ]]; then
     cp "$config_file_template" "$PWD/$name"
-    sed -i -e "s/USERKW/$USER/g" -e "s,SOUNDPATH,$KW_SHARE_SOUND_DIR,g" -e "/^#?.*/d" \
+    sed -i -e "s/USERKW/$USER/g" -e "s,SOUNDPATH,$KW_SOUND_DIR,g" -e "/^#?.*/d" \
       "$PWD/$name"
   else
     complain "No such: $config_file_template"

--- a/tests/help_test.sh
+++ b/tests/help_test.sh
@@ -12,7 +12,7 @@ function test_kworkflow_help()
 
 function test_kworkflow_man()
 {
-  export KW_SHARE_MAN_DIR="$SHUNIT_TMPDIR"
+  export KW_MAN_DIR="$SHUNIT_TMPDIR"
   touch "$SHUNIT_TMPDIR/kw.1"
   expect="man -l $SHUNIT_TMPDIR/kw.1"
   output=$(kworkflow_man '' 'TEST_MODE')

--- a/tests/init_test.sh
+++ b/tests/init_test.sh
@@ -8,11 +8,11 @@ FAKE_CONFIG_PATH="$FAKE_DIR/.config"
 
 function setUp()
 {
-  export KW_ETC_DIR="tests/samples"
-  export KW_SHARE_SOUND_DIR="tests/samples/share/sound/kw"
+  export KW_ETC_DIR='tests/samples'
+  export KW_SOUND_DIR='tests/samples/share/sound/kw'
   export HOME="$FAKE_DIR"
-  export USER="kw_test"
-  export KWORKFLOW="kw_dir_test"
+  export USER='kw_test'
+  export KWORKFLOW='kw_dir_test'
   export PWD="$FAKE_CONFIG_PATH/$KWORKFLOW"
   mkdir -p "$FAKE_DIR"
   mkdir -p "$FAKE_CONFIG_PATH/$KWORKFLOW"
@@ -35,8 +35,8 @@ function test_init_kw()
 
   assertEquals "($LINENO): USERKW wasn't updated to $USER" "$USER" "$kworkflow_content"
 
-  kworkflow_content=$(grep "$KW_SHARE_SOUND_DIR" -o "$path_config" | head -n 1)
-  assertEquals "($LINENO): SOUNDPATH wasn't updated to $KW_SHARE_SOUND_DIR" "$KW_SHARE_SOUND_DIR" "$kworkflow_content"
+  kworkflow_content=$(grep "$KW_SOUND_DIR" -o "$path_config" | head -n 1)
+  assertEquals "($LINENO): SOUNDPATH wasn't updated to $KW_SOUND_DIR" "$KW_SOUND_DIR" "$kworkflow_content"
 
   output=$(init_kw --force)
   if [[ ! -f "$path_config.old" ]]; then


### PR DESCRIPTION
Make kw compliant with XDG Base Directory Specification

User customizations should now be done with the XDG_*_HOME environmental
variables, instead of PREFIX. This also fixes some problems with
DEV-MODE: corrects the paths to documentation, cache and data folders.

Closes: #296 and #385

This is still a draft: another commit should implement some transitional installation from the previous directory scheme to this one.