### PR TITLE
Add option to get .config file to configm

### DIFF
--- a/documentation/man/features/configm.rst
+++ b/documentation/man/features/configm.rst
@@ -39,6 +39,13 @@ OPTIONS
   will remove the config file from kw management. The user can suppress this
   warning by using ``-f``.
 
+\--fetch [(-o | --output) <filename>] [-f | --force]:
+  This option fetches a .config file from a target machine to your current
+  directory. If another .config is found in this directory, then it will ask you
+  whether you want to replace it or not. If you use the force option, the
+  .config file will be overwritten without any warnings. By using the output
+  option, you can specify the config file name.
+
 EXAMPLES
 ========
 For these examples, we suppose the fields in your **kworkflow.config** file are

--- a/documentation/man/features/configm.rst
+++ b/documentation/man/features/configm.rst
@@ -6,10 +6,10 @@ kw-configm
 
 SYNOPSIS
 ========
-| *kw* (*g* | *configm*) [\--save <name> [-d <description>] [-f]]
+| *kw* (*g* | *configm*) [(-s | \--save) <name> [(-d | \--description) <description>] [-f | \--force]]
 | *kw* (*g* | *configm*) [-l | \--list]
-| *kw* (*g* | *configm*) [\--get <name> [-f]]
-| *kw* (*g* | *configm*) [(-rm | \--remove) <name> [-f]]
+| *kw* (*g* | *configm*) [\--get <name> [-f | \--force]]
+| *kw* (*g* | *configm*) [(-r | \--remove) <name> [-f | \--force]]
 
 DESCRIPTION
 ===========
@@ -18,7 +18,7 @@ file. It provides the save, load, remove, and list operations of such files.
 
 OPTIONS
 =======
-\--save <name> [-d <description>] [-f]:
+\--save <name> [-d <description>] [-f | \--force]:
   The save option searches the current directory for a **.config** file to be
   kept under the management of **kw**. The save option expects a name to identify
   this version of the file. Additionally, users can add a description by
@@ -28,13 +28,13 @@ OPTIONS
 -l, \--list:
   Lists all the **.config** file versions available.
 
-\--get <name> [-f]:
+\--get <name> [-f | \--force]:
   Get a config file based on the *<name>* and paste it in the current
   directory. It pop-up a warning message because this operation override the
   current **.config** file. The user can suppress this warning by using ``-f``
   flag.
 
--rm <name> [-f], \--remove <name> [-f]:
+-r <name> [-f | \--force], \--remove <name> [-f | \--force]:
   Remove config labeled with *<name>*. It pop-up a warning message because it
   will remove the config file from kw management. The user can suppress this
   warning by using ``-f``.

--- a/documentation/man/features/configm.rst
+++ b/documentation/man/features/configm.rst
@@ -39,12 +39,15 @@ OPTIONS
   will remove the config file from kw management. The user can suppress this
   warning by using ``-f``.
 
-\--fetch [(-o | --output) <filename>] [-f | --force]:
+\--fetch [(-o | --output) <filename>] [-f | --force] [--optimize]:
   This option fetches a .config file from a target machine to your current
   directory. If another .config is found in this directory, then it will ask you
   whether you want to replace it or not. If you use the force option, the
   .config file will be overwritten without any warnings. By using the output
-  option, you can specify the config file name.
+  option, you can specify the config file name. With the optimize option,
+  `make localmodconfig` will be run to generate an optimized version of a
+  previously fetched .config file.
+
 
 EXAMPLES
 ========

--- a/documentation/man/features/configm.rst
+++ b/documentation/man/features/configm.rst
@@ -39,7 +39,7 @@ OPTIONS
   will remove the config file from kw management. The user can suppress this
   warning by using ``-f``.
 
-\--fetch [(-o | --output) <filename>] [-f | --force] [--optimize]:
+\--fetch [(-o | --output) <filename>] [-f | --force] [--optimize] [--remote [<remote>:<port>]]:
   This option fetches a .config file from a target machine to your current
   directory. If another .config is found in this directory, then it will ask you
   whether you want to replace it or not. If you use the force option, the
@@ -62,3 +62,8 @@ In case you want that kw saves your current **.config** file, you can use::
 You can see the config's file maintained by kw with::
 
   kw g --list
+
+If you want to fetch a .config file from a remote machine at localhost:2222 with
+user root, then you can run::
+
+  kw configm --fetch --remote root@localhost:2222

--- a/kw
+++ b/kw
@@ -110,7 +110,7 @@ function kw()
       (
         include "$KW_LIB_DIR/deploy.sh"
 
-        kernel_deploy "$@"
+        kernel_deploy '' "$@"
         local ret="$?"
         alert_completion 'kw deploy' "$1"
         return "$ret"
@@ -121,7 +121,7 @@ function kw()
         include "$KW_LIB_DIR/deploy.sh"
         include "$KW_LIB_DIR/build.sh"
 
-        kernel_build && kernel_deploy "$@"
+        kernel_build && kernel_deploy 1 "$@"
         local ret="$?"
         alert_completion 'kw db' "$1"
         return "$ret"

--- a/src/config_manager.sh
+++ b/src/config_manager.sh
@@ -1,4 +1,5 @@
 include "$KW_LIB_DIR/kwio.sh"
+include "$KW_LIB_DIR/remote.sh"
 include "$KW_LIB_DIR/kwlib.sh"
 include "$KW_LIB_DIR/signal_manager.sh"
 
@@ -15,7 +16,7 @@ function config_manager_help()
     return
   fi
   printf '%s\n' 'kw config manager:' \
-    '  configm --fetch [(-o | --output) <filename>] [-f | --force] [--optimize] - Fetch a config' \
+    '  configm --fetch [(-o | --output) <filename>] [-f | --force] [--optimize] [--remote [<user>@<ip>:<port>]] - Fetch a config' \
     '  configm (-s | --save) <name> [(-d | --description) <description>] [-f | --force] - Save a config' \
     '  configm (-l | --list) - List config files under kw management' \
     '  configm --get <name> [-f | --force] - Get a config file based named <name>' \
@@ -114,14 +115,19 @@ function cleanup()
 #        overwritten.
 # @output File name. This option requires an argument, which will be the name of
 #         the .config file to be retrieved.
-# @optimize Optimization flag. If it's set, then an optimized version of the
-#           .config file will be retrieved.
+# @optimize Optimize flag, if set then 'make localmodconfig' is used.
+# @target Target can be 2 (LOCAL_TARGET), and 3 (REMOTE_TARGET).
 function fetch_config()
 {
   local flag="$1"
   local force="$2"
   local output="$3"
   local optimize="$4"
+  local target="$5"
+  local user="${remote_parameters['REMOTE_USER']}"
+  local ip="${remote_parameters['REMOTE_IP']}"
+  local port="${remote_parameters['REMOTE_PORT']}"
+  local kernel_release
   local mods
   local cmd
   local arch
@@ -149,39 +155,96 @@ function fetch_config()
 
   signal_manager 'cleanup' || warning 'Was not able to set signal handler'
 
-  if [[ -f "${root}proc/config.gz" ]] && command_exists 'zcat'; then
-    cmd="zcat /proc/config.gz > $output"
-  elif [[ -f "${root}boot/config-$(uname -r)" ]]; then
-    cmd="cp /boot/config-$(uname -r) $output"
-  else
-    if ! is_kernel_root "$PWD"; then
-      complain 'This command should be run in a kernel tree.'
-      exit 125 # ECANCELED
-    fi
+  case "$target" in
+    2) # LOCAL_TARGET
+      if [[ -f "${root}proc/config.gz" ]] && command_exists 'zcat'; then
+        cmd="zcat /proc/config.gz > $output"
+      elif [[ -f "${root}boot/config-$(uname -r)" ]]; then
+        cmd="cp /boot/config-$(uname -r) $output"
+      else
+        if ! is_kernel_root "$PWD"; then
+          complain 'This command should be run in a kernel tree.'
+          exit 125 # ECANCELED
+        fi
 
-    arch=$(uname -m)
-    warning 'We are retrieving a .config file based on' "$arch"
-    cmd="make defconfig ARCH=$arch"
+        arch=$(uname -m)
+        warning 'We are retrieving a .config file based on' "$arch"
+        cmd="make defconfig ARCH=$arch"
 
-    # By default 'make defconfig' writes to .config without worrying if
-    # there is another .config in the current directory. In order to avoid
-    # overwriting, we check the existence of .config and whether we're
-    # allowed to overwrite it or not.
-    # If there is a .config and we are not supposed to overwrite it, then we
-    # move it to KW_CACHE_DIR, run 'make defconfig', and then move it back.
-    if [[ -f "$PWD/.config" && "$output" != '.config' ]]; then
-      cmd+=" && mv $PWD/.config $output && mv $KW_CACHE_DIR/config/.config $PWD/.config"
-    fi
-  fi
+        # By default 'make defconfig' writes to .config without worrying if
+        # there is another .config in the current directory. In order to avoid
+        # overwriting, we check the existence of .config and whether we're
+        # allowed to overwrite it or not.
+        # If there is a .config and we are not supposed to overwrite it, then we
+        # move it to KW_CACHE_DIR, run 'make defconfig', and then move it back.
+        if [[ -f "$PWD/.config" && "$output" != '.config' ]]; then
+          cmd+=" && mv $PWD/.config $output && mv $KW_CACHE_DIR/config/.config $PWD/.config"
+        fi
+      fi
 
-  mods=$(cmd_manager "$flag" 'lsmod')
-  cmd_manager "$flag" "$cmd"
+      cmd_manager "$flag" "$cmd"
 
-  ret="$?"
-  if [[ "$ret" != 0 ]]; then
-    warning 'We could not retrieve the config file'
-    exit "$ret"
-  fi
+      ret="$?"
+      if [[ "$ret" != 0 ]]; then
+        warning 'We could not retrieve the config file'
+        exit "$ret"
+      fi
+
+      mods=$(cmd_manager "$flag" 'lsmod')
+      ;;
+    3) # REMOTE_TARGET
+      kernel_release=$(cmd_remotely 'uname -r' "$flag" "$ip" "$port" "$user")
+      cmd_remotely 'mkdir -p /tmp/kw' "$flag" "$ip" "$port" "$user"
+
+      if cmd_remotely '[ -f /proc/config.gz ]' "$flag" "$ip" "$port" "$user"; then
+        cmd="zcat /proc/config.gz > /tmp/kw/$output"
+        cmd_remotely "$cmd" "$flag" "$ip" "$port" "$user"
+
+        ret="$?"
+        if [[ "$ret" != 0 ]]; then
+          warning 'We could not retrieve the config file'
+          exit "$ret"
+        fi
+
+        remote2host "/tmp/kw/$output" "$PWD" "$ip" "$port" "$user" "$flag"
+      elif cmd_remotely "[ -f /boot/config-$kernel_release ]" "$flag" "$ip" "$port" "$user"; then
+        cmd="cp /boot/config-$kernel_release /tmp/kw/$output"
+        cmd_remotely "$cmd" "$flag" "$ip" "$port" "$user"
+
+        ret="$?"
+        if [[ "$ret" != 0 ]]; then
+          warning 'We could not retrieve the config file'
+          exit "$ret"
+        fi
+
+        remote2host "/tmp/kw/$output" "$PWD" "$ip" "$port" "$user" "$flag"
+      else
+        if ! is_kernel_root "$PWD"; then
+          complain 'This command should be run in a kernel tree.'
+          exit 125 # ECANCELED
+        fi
+
+        arch=$(cmd_remotely 'uname -m' "$flag" "$ip" "$port" "$user")
+        warning 'We are retrieving a .config file based on' "$arch"
+        cmd="make defconfig ARCH=$arch"
+
+        if [[ -f "$PWD/.config" && "$output" != '.config' ]]; then
+          cmd+=" && mv $PWD/.config $output && mv $KW_CACHE_DIR/config/.config $PWD/.config"
+        fi
+
+        cmd_manager "$flag" "$cmd"
+
+        ret="$?"
+        if [[ "$ret" != 0 ]]; then
+          warning 'We could not retrieve the config file'
+          exit "$ret"
+        fi
+      fi
+
+      cmd_remotely 'rm -rf /tmp/kw' "$flag" "$ip" "$port" "$user"
+      mods=$(cmd_remotely 'lsmod' "$flag" "$ip" "$port" "$user")
+      ;;
+  esac
 
   if [[ -n "$optimize" ]]; then
     if ! is_kernel_root "$PWD"; then
@@ -348,6 +411,10 @@ function execute_config_manager()
   local force
   local flag='SILENT'
   local optimize
+  local user
+  local remote
+  local ip
+  local port
 
   if [[ -z "$*" ]]; then
     complain 'Please, provide an argument'
@@ -387,7 +454,7 @@ function execute_config_manager()
   fi
 
   if [[ -n "${options_values['FETCH']}" ]]; then
-    fetch_config "$flag" "$force" "${options_values['OUTPUT']}" "$optimize"
+    fetch_config "$flag" "$force" "${options_values['OUTPUT']}" "$optimize" "${options_values['TARGET']}"
     return
   fi
 }
@@ -400,7 +467,7 @@ function parse_configm_options()
   local long_options
   local options
 
-  long_options='save:,list,get:,remove:,force,description:,fetch,output:,optimize'
+  long_options='save:,list,get:,remove:,force,description:,fetch,output:,optimize,remote:'
   short_options='s:,l,r:,d:,h,f,o:'
 
   options="$(getopt \
@@ -420,6 +487,7 @@ function parse_configm_options()
   options_values['LIST']=''
   options_values['GET']=''
   options_values['REMOVE']=''
+  options_values['TARGET']="$LOCAL_TARGET"
 
   eval "set -- $options"
 
@@ -468,6 +536,15 @@ function parse_configm_options()
         ;;
       --optimize)
         options_values['OPTIMIZE']=1
+        shift
+        ;;
+      --remote)
+        options_values['TARGET']=$REMOTE_TARGET
+        shift
+        populate_remote_info "$1"
+        if [[ "$?" == 22 ]]; then
+          return 22 # EINVAL
+        fi
         shift
         ;;
       --)

--- a/src/config_manager.sh
+++ b/src/config_manager.sh
@@ -1,8 +1,11 @@
 include "$KW_LIB_DIR/kwio.sh"
+include "$KW_LIB_DIR/kwlib.sh"
+include "$KW_LIB_DIR/signal_manager.sh"
 
 declare -gr metadata_dir='metadata'
 declare -gr configs_dir='configs'
 declare -gA options_values
+declare -g root='/'
 
 function config_manager_help()
 {
@@ -12,7 +15,8 @@ function config_manager_help()
     return
   fi
   printf '%s\n' 'kw config manager:' \
-    '  configm (-s | --save) <name> [(-d | --description) <description>] [-f | --force] - save a config' \
+    '  configm --fetch [(-o | --output) <filename>] [-f | --force] - Fetch a config' \
+    '  configm (-s | --save) <name> [(-d | --description) <description>] [-f | --force] - Save a config' \
     '  configm (-l | --list) - List config files under kw management' \
     '  configm --get <name> [-f | --force] - Get a config file based named <name>' \
     '  configm (-r | --remove) <name> [-f | --force] - Remove config labeled with <name>'
@@ -76,6 +80,102 @@ function save_config_file()
   fi
 
   cd "$original_path" || exit_msg 'It was not possible to move back from configs dir'
+}
+
+# Clean-up for fetch_config. When running --fetch, some files may be
+# overwritten. If the user decides to cancel the command, important
+# configuration files may be gone. To overcome that, we run use cleanup, to both
+# retrieve these files and remove the temporary ones left.
+function cleanup()
+{
+  local flag=${1:-'SILENT'}
+  say 'Cleaning up and retrieving files...'
+
+  # Setting dotglob to include hidden files when running 'mv'
+  shopt -s dotglob
+  if [[ -d "$KW_CACHE_DIR/config" ]]; then
+    cmd_manager "$flag" "mv $KW_CACHE_DIR/config/* $PWD"
+    cmd_manager "$flag" "rmdir $KW_CACHE_DIR/config"
+  fi
+
+  say 'Exiting...'
+  exit 0
+}
+
+# This function retrieves a .config file.
+#
+# @flag How to display a command.
+# @force Force option. If it's set, it will ignore the warning if there's
+#        another .config file in the current directory and the file will be
+#        overwritten.
+# @output File name. This option requires an argument, which will be the name of
+#         the .config file to be retrieved.
+function fetch_config()
+{
+  local flag="$1"
+  local force="$2"
+  local output="$3"
+  local cmd
+  local arch
+  local ret
+
+  output=${output:-'.config'}
+
+  # Folder to store files in case there's an interruption and we need to return
+  # things to the state they were before or in case we need a place to store
+  # files temporarily.
+  mkdir -p "$KW_CACHE_DIR/config"
+
+  if [[ -f "$PWD/$output" ]]; then
+    if [[ -z "$force" && $(ask_yN "Do you want to overwrite $output in your current directory?") =~ "0" ]]; then
+      warning 'Operation aborted'
+      return 125 #ECANCELED
+    fi
+
+    cp "$PWD/$output" "$KW_CACHE_DIR/config"
+  fi
+
+  if [[ -f "$PWD/.config" && "$output" != '.config' ]]; then
+    cp "$PWD/.config" "$KW_CACHE_DIR/config"
+  fi
+
+  signal_manager 'cleanup' || warning 'Was not able to set signal handler'
+
+  if [[ -f "${root}proc/config.gz" ]] && command_exists 'zcat'; then
+    cmd="zcat /proc/config.gz > $output"
+  elif [[ -f "${root}boot/config-$(uname -r)" ]]; then
+    cmd="cp /boot/config-$(uname -r) $output"
+  else
+    if ! is_kernel_root "$PWD"; then
+      complain 'This command should be run in a kernel tree.'
+      exit 125 # ECANCELED
+    fi
+
+    arch=$(uname -m)
+    warning 'We are retrieving a .config file based on' "$arch"
+    cmd="make defconfig ARCH=$arch"
+
+    # By default 'make defconfig' writes to .config without worrying if
+    # there is another .config in the current directory. In order to avoid
+    # overwriting, we check the existence of .config and whether we're
+    # allowed to overwrite it or not.
+    # If there is a .config and we are not supposed to overwrite it, then we
+    # move it to KW_CACHE_DIR, run 'make defconfig', and then move it back.
+    if [[ -f "$PWD/.config" && "$output" != '.config' ]]; then
+      cmd+=" && mv $PWD/.config $output && mv $KW_CACHE_DIR/config/.config $PWD/.config"
+    fi
+  fi
+
+  cmd_manager "$flag" "$cmd"
+
+  ret="$?"
+  if [[ "$ret" != 0 ]]; then
+    warning 'We could not retrieve the config file'
+    exit "$ret"
+  fi
+
+  rm -rf "$KW_CACHE_DIR/config"
+  success 'Successfully retrieved' "$output"
 }
 
 function list_configs()
@@ -203,6 +303,7 @@ function execute_config_manager()
   local name_config
   local description_config
   local force
+  local flag='SILENT'
 
   if [[ -z "$*" ]]; then
     complain 'Please, provide an argument'
@@ -239,6 +340,10 @@ function execute_config_manager()
     remove_config "${options_values['REMOVE']}" "$force"
     return
   fi
+
+  if [[ -n "${options_values['FETCH']}" ]]; then
+    fetch_config "$flag" "$force" "${options_values['OUTPUT']}"
+  fi
 }
 
 # This function parses the options from 'kw configm', and populates the global
@@ -249,8 +354,8 @@ function parse_configm_options()
   local long_options
   local options
 
-  long_options='save:,list,get:,remove:,force,description:'
-  short_options='s,l,r:,d:,h,f'
+  long_options='save:,list,get:,remove:,force,description:,fetch,output:'
+  short_options='s:,l,r:,d:,h,f,o:'
 
   options="$(getopt \
     --name 'kw configm' \
@@ -306,6 +411,14 @@ function parse_configm_options()
         options_values['REMOVE']+="$2"
         shift 2
         ;;
+      --fetch)
+        options_values['FETCH']=1
+        shift
+        ;;
+      --output | -o)
+        options_values['OUTPUT']+="$2"
+        shift 2
+        ;;
       --)
         shift
         ;;
@@ -315,4 +428,9 @@ function parse_configm_options()
         ;;
     esac
   done
+
+  if [[ -n "${options_values['OUTPUT']}" && -z "${options_values['FETCH']}" ]]; then
+    complain '--output|-o can only be used with --fetch'
+    return 22 # EINVAL
+  fi
 }

--- a/src/config_manager.sh
+++ b/src/config_manager.sh
@@ -2,6 +2,7 @@ include "$KW_LIB_DIR/kwio.sh"
 
 declare -gr metadata_dir='metadata'
 declare -gr configs_dir='configs'
+declare -gA options_values
 
 function config_manager_help()
 {
@@ -11,10 +12,10 @@ function config_manager_help()
     return
   fi
   printf '%s\n' 'kw config manager:' \
-    '  configm --save <name> [-d <description>] [-f] - save a config' \
+    '  configm (-s | --save) <name> [(-d | --description) <description>] [-f | --force] - save a config' \
     '  configm (-l | --list) - List config files under kw management' \
-    '  configm --get <name> [-f] - Get a config file based named <name>' \
-    '  configm (-rm | --remove) <name> [-f] - Remove config labeled with <name>'
+    '  configm --get <name> [-f | --force] - Get a config file based named <name>' \
+    '  configm (-r | --remove) <name> [-f | --force] - Remove config labeled with <name>'
 }
 
 # This function handles the save operation of kernel's '.config' file. It
@@ -201,53 +202,117 @@ function execute_config_manager()
 {
   local name_config
   local description_config
-  local force=0
+  local force
 
-  for parameter in "$@"; do
-    [[ "$parameter" == '-f' ]] && force=1
-  done
+  if [[ -z "$*" ]]; then
+    complain 'Please, provide an argument'
+    config_manager_help
+    exit 22 # EINVAL
+  fi
 
-  case "$1" in
-    --help | -h)
-      config_manager_help "$1"
-      exit 0
-      ;;
-    --save)
-      shift # Skip '--save' option
-      name_config="$1"
-      # Validate string name
-      if [[ "$name_config" =~ ^- || -z "${name_config// /}" ]]; then
-        complain 'Invalid argument'
+  parse_configm_options "$@"
+
+  if [[ "$?" -gt 0 ]]; then
+    exit 22 # EINVAL
+  fi
+
+  name_config="${options_values['SAVE']}"
+  description_config="${options_values['DESCRIPTION']}"
+  force="${options_values['FORCE']}"
+
+  if [[ -n "${options_values['SAVE']}" ]]; then
+    save_config_file "$force" "$name_config" "$description_config"
+    return
+  fi
+
+  if [[ -n "${options_values['LIST']}" ]]; then
+    list_configs
+    return
+  fi
+
+  if [[ -n "${options_values['GET']}" ]]; then
+    get_config "${options_values['GET']}" "$force"
+    return
+  fi
+
+  if [[ -n "${options_values['REMOVE']}" ]]; then
+    remove_config "${options_values['REMOVE']}" "$force"
+    return
+  fi
+}
+
+# This function parses the options from 'kw configm', and populates the global
+# variable options_values accordingly.
+function parse_configm_options()
+{
+  local short_options
+  local long_options
+  local options
+
+  long_options='save:,list,get:,remove:,force,description:'
+  short_options='s,l,r:,d:,h,f'
+
+  options="$(getopt \
+    --name 'kw configm' \
+    --options "$short_options" \
+    --longoptions "$long_options" \
+    -- "$@")"
+
+  if [[ "$?" != 0 ]]; then
+    return 22 # EINVAL
+  fi
+
+  options_values['SAVE']=''
+  options_values['FORCE']=''
+  options_values['DESCRIPTION']=''
+  options_values['LIST']=''
+  options_values['GET']=''
+  options_values['REMOVE']=''
+
+  eval "set -- $options"
+
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      -h)
+        config_manager_help "$1"
+        exit 0
+        ;;
+      --force | -f)
+        options_values['FORCE']=1
+        shift
+        ;;
+      --save | -s)
+        # Validate string name
+        if [[ "$2" =~ ^- || -z "${2// /}" ]]; then
+          complain 'Invalid argument'
+          return 22 # EINVAL
+        fi
+        options_values['SAVE']+="$2"
+        shift 2
+        ;;
+      --description | -d)
+        options_values['DESCRIPTION']+="$*"
+        shift 2
+        ;;
+      --list | -l)
+        options_values['LIST']=1
+        shift
+        ;;
+      --get)
+        options_values['GET']+="$2"
+        shift 2
+        ;;
+      --remove | -r)
+        options_values['REMOVE']+="$2"
+        shift 2
+        ;;
+      --)
+        shift
+        ;;
+      *)
+        complain "Invalid option: $1"
         exit 22 # EINVAL
-      fi
-      # Shift name and get '-d'
-      shift 2 && description_config="$*"
-      save_config_file "$force" "$name_config" "$description_config"
-      ;;
-    --list | -l)
-      list_configs
-      ;;
-    --get)
-      shift # Skip '--get' option
-      if [[ -z "$1" ]]; then
-        complain 'Invalid argument'
-        return 22 # EINVAL
-      fi
-
-      get_config "$1" "$force"
-      ;;
-    --remove | -rm)
-      shift # Skip '--rm' option
-      if [[ -z "$1" ]]; then
-        complain 'Invalid argument'
-        return 22 # EINVAL
-      fi
-
-      remove_config "$1" "$force"
-      ;;
-    *)
-      complain 'Unknown option'
-      exit 22 #EINVAL
-      ;;
-  esac
+        ;;
+    esac
+  done
 }

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -52,6 +52,7 @@ declare -gA options_values
 # Note: This function relies on the parameters set in the config file.
 function kernel_deploy()
 {
+  local build="$1"
   local reboot=0
   local modules=0
   local target=0
@@ -62,6 +63,8 @@ function kernel_deploy()
   local end=0
   local runtime=0
   local ret=0
+
+  shift
 
   if [[ "$1" =~ -h|--help ]]; then
     deploy_help "$1"
@@ -132,7 +135,7 @@ function kernel_deploy()
     # Update name: release + alias
     name=$(make kernelrelease)
 
-    run_kernel_install "$reboot" "$name" '' "$target"
+    run_kernel_install "$reboot" "$name" '' "$target" '' "$build"
     end=$(date +%s)
     runtime=$((runtime + (end - start)))
     statistics_manager 'deploy' "$runtime"
@@ -564,6 +567,7 @@ function run_kernel_install()
   local flag="$3"
   local target="$4"
   local user="${5:-${remote_parameters['REMOTE_USER']}}"
+  local build="$6"
   local distro='none'
   local kernel_name="${configurations[kernel_name]}"
   local mkinitcpio_name="${configurations[mkinitcpio_name]}"
@@ -571,7 +575,7 @@ function run_kernel_install()
   local kernel_img_name="${configurations[kernel_img_name]}"
   local remote
   local port
-  local distro
+  local config_local_version
 
   # We have to guarantee some default values values
   kernel_name=${kernel_name:-'nothing'}
@@ -597,6 +601,11 @@ function run_kernel_install()
     warning "kw inferred arch/$arch_target/boot/$kernel_img_name as a kernel image"
   fi
 
+  if [[ -f "$PWD/.config" ]]; then
+    config_local_version=$(sed -nr '/CONFIG_LOCALVERSION=/s/CONFIG_LOCALVERSION="(.*)"/\1/p' \
+      "$PWD/.config")
+  fi
+
   case "$target" in
     1) # VM_TARGET
       distro=$(detect_distro "${configurations[mount_point]}/")
@@ -605,6 +614,13 @@ function run_kernel_install()
         complain 'Unfortunately, there is no support for the target distro'
         vm_umount
         exit 95 # ENOTSUP
+      fi
+
+      # Copy .config
+      if [[ -n "$build" || "$config_local_version" == "$name" ]]; then
+        cp "$PWD/.config" "${configurations[mount_point]}/boot/config-$name"
+      else
+        complain 'Undefined .config file for the target kernel. Consider using kw bd'
       fi
 
       include "$KW_PLUGINS_DIR/kernel_install/utils.sh"
@@ -624,6 +640,13 @@ function run_kernel_install()
       if [[ $(id -u) == 0 ]]; then
         complain 'kw deploy --local should not be run as root'
         exit 1 # EPERM
+      fi
+
+      # Copy .config
+      if [[ -n "$build" || "$config_local_version" == "$name" ]]; then
+        cp "$PWD/.config" "/boot/config-$name"
+      else
+        complain 'Undefined .config file for the target kernel. Consider using kw bd'
       fi
 
       include "$KW_PLUGINS_DIR/kernel_install/utils.sh"
@@ -652,6 +675,13 @@ function run_kernel_install()
 
       cp2remote "$flag" \
         "arch/$arch_target/boot/$kernel_img_name" "$REMOTE_KW_DEPLOY/vmlinuz-$name"
+
+      # Copy .config
+      if [[ -n "$build" || "$config_local_version" == "$name" ]]; then
+        cp2remote "$flag" "$PWD/.config" "/boot/config-$name"
+      else
+        complain 'Undefined .config file for the target kernel. Consider using kw bd'
+      fi
 
       # Deploy
       local cmd_parameters="$name $distro $kernel_img_name $reboot $arch_target 'remote' $flag"

--- a/src/plugins/kernel_install/utils.sh
+++ b/src/plugins/kernel_install/utils.sh
@@ -234,6 +234,7 @@ function do_uninstall()
   local initrdpath="$prefix/boot/initrd.img-$target"
   local modulespath="$prefix/lib/modules/$target"
   local libpath="$prefix/var/lib/initramfs-tools/$target"
+  local configpath="$prefix/boot/config-$target"
 
   if [ -z "$target" ]; then
     printf '%s\n' 'No parameter, nothing to do'
@@ -273,6 +274,13 @@ function do_uninstall()
     cmd_manager "$flag" "rm -rf $libpath"
   else
     printf '%s\n' "Can't find $libpath"
+  fi
+
+  if [ -f "$configpath" ]; then
+    echo "Removing: $configpath"
+    cmd_manager "$flag" "rm $configpath"
+  else
+    echo "Can't find $configpath"
   fi
 }
 

--- a/src/remote.sh
+++ b/src/remote.sh
@@ -87,6 +87,25 @@ function cp2remote()
   cmd_manager "$flag" "rsync -e $rsync_target -LrlptD --rsync-path='sudo rsync' $rsync_params"
 }
 
+# This function copies files from the remote machine to the local host.
+#
+# @src: file path from a path stored in the remote machine
+# @dst: path from local machine to store the file we're retrieving
+# @ip: IP or domain name
+# @port: TCP port
+# @user: User in the remote machine
+function remote2host()
+{
+  local src="$1"
+  local dst="$2"
+  local ip="$3"
+  local port="$4"
+  local user="$5"
+  local flag=${6:-"HIGHLIGHT_CMD"}
+
+  cmd_manager "$flag" "rsync -e \"ssh -p $port\" $user@$ip:$src $dst"
+}
+
 # Access the target device and query the distro name.
 #
 # @remote Origin of the file to be send

--- a/tests/configm_test.sh
+++ b/tests/configm_test.sh
@@ -47,33 +47,28 @@ function tearDown()
 function test_execute_config_manager_SAVE_fails()
 {
   local msg_prefix=" --save"
+  local ret
 
-  ret=$(execute_config_manager --save)
-  assert_equals_helper "$msg_prefix" "$LINENO" "$COMMAND_MSG_INVALID_ARG" "$ret"
+  ret=$(execute_config_manager --save 2>&1 > /dev/null)
+  assert_equals_helper "$msg_prefix" "$LINENO" "$ret" "kw configm: option '--save' requires an argument"
 
   ret=$(execute_config_manager --save --lala)
-  assert_equals_helper "$msg_prefix --lala" "$LINENO" "$COMMAND_MSG_INVALID_ARG" "$ret"
+  assert_equals_helper "$msg_prefix --lala" "$LINENO" "$ret" "$COMMAND_MSG_INVALID_ARG"
 
   ret=$(execute_config_manager --save -n)
-  assert_equals_helper "$msg_prefix -n" "$LINENO" "$COMMAND_MSG_INVALID_ARG" "$ret"
+  assert_equals_helper "$msg_prefix -n" "$LINENO" "$ret" "$COMMAND_MSG_INVALID_ARG"
 
   ret=$(execute_config_manager --save -d)
-  assert_equals_helper "$msg_prefix -d" "$LINENO" "$COMMAND_MSG_INVALID_ARG" "$ret"
-
-  ret=$(execute_config_manager --save -n -d)
-  assert_equals_helper "$msg_prefix -n -d" "$LINENO" "$COMMAND_MSG_INVALID_ARG" "$ret"
-
-  ret=$(execute_config_manager --save -n -lulu)
-  assert_equals_helper "$msg_prefix -n -lulu" "$LINENO" "$COMMAND_MSG_INVALID_ARG" "$ret"
+  assert_equals_helper "$msg_prefix -d" "$LINENO" "$ret" "$COMMAND_MSG_INVALID_ARG"
 
   ret=$(execute_config_manager --save -d)
-  assert_equals_helper "$msg_prefix -d" "$LINENO" "$COMMAND_MSG_INVALID_ARG" "$ret"
+  assert_equals_helper "$msg_prefix -d" "$LINENO" "$ret" "$COMMAND_MSG_INVALID_ARG"
 
   ret=$(execute_config_manager --save -d "lalala and xpto")
-  assert_equals_helper "$msg_prefix -d" "$LINENO" "$COMMAND_MSG_INVALID_ARG" "$ret"
+  assert_equals_helper "$msg_prefix -d" "$LINENO" "$ret" "$COMMAND_MSG_INVALID_ARG"
 
   ret=$(execute_config_manager --save -f)
-  assert_equals_helper "$msg_prefix -f" "$LINENO" "$COMMAND_MSG_INVALID_ARG" "$ret"
+  assert_equals_helper "$msg_prefix -f" "$LINENO" "$ret" "$COMMAND_MSG_INVALID_ARG"
 }
 
 function test_save_config_file_check_save_failures()
@@ -301,11 +296,8 @@ function test_execute_config_manager_get_config_invalid_option()
 {
   local msg_prefix=" --get"
 
-  ret=$(execute_config_manager --get)
-  assert_equals_helper "$msg_prefix" "$LINENO" "$COMMAND_MSG_INVALID_ARG" "$ret"
-
-  ret=$(execute_config_manager -get)
-  assert_equals_helper "$msg_prefix" "$LINENO" "$COMMAND_MSG_UNKNOWN" "$ret"
+  ret=$(execute_config_manager --get 2>&1 > /dev/null)
+  assert_equals_helper "$msg_prefix" "$LINENO" "$ret" "kw configm: option '--get' requires an argument"
 
   ret=$(execute_config_manager --get something_wrong)
   assert_equals_helper "$msg_prefix" "$LINENO" "$COMMAND_NO_SUCH_FILE: something_wrong" "$ret"
@@ -404,15 +396,12 @@ function test_get_config_with_force()
 
 function test_execute_config_manager_remove_that_should_fail()
 {
-  local msg_prefix=" -rm"
+  local msg_prefix=" -r"
 
-  ret=$(execute_config_manager -rm)
-  assert_equals_helper "$msg_prefix" "$LINENO" "$COMMAND_MSG_INVALID_ARG" "$ret"
+  ret=$(execute_config_manager -r 2>&1 > /dev/null)
+  assert_equals_helper "$msg_prefix" "$LINENO" "$ret" "kw configm: option requires an argument -- 'r'"
 
-  ret=$(execute_config_manager --rm)
-  assert_equals_helper "$msg_prefix" "$LINENO" "$COMMAND_MSG_UNKNOWN" "$ret"
-
-  ret=$(execute_config_manager -rm something_wrong)
+  ret=$(execute_config_manager -r something_wrong)
   assert_equals_helper "$msg_prefix" "$LINENO" "$COMMAND_NO_SUCH_FILE: something_wrong" "$ret"
 }
 

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -150,9 +150,11 @@ function test_kernel_install()
   # The following commands represets those steps
   local cmd_image_remote="$rsync_cmd $kernel_image_path $remote:$kernel_image_remote_path $rsync_flags"
   local cmd_deploy_image="$ssh_cmd $remote sudo \"$deploy_cmd\""
+  local config_warning='Undefined .config file for the target kernel. Consider using kw bd'
 
   declare -a expected_cmd=(
     "$cmd_image_remote"
+    "$config_warning"
     "$cmd_deploy_image"
   )
 
@@ -179,6 +181,7 @@ function test_kernel_install()
 
   declare -a expected_cmd=(
     "$cmd_image_remote"
+    "$config_warning"
     "$cmd_deploy_image"
   )
 
@@ -222,6 +225,7 @@ function test_kernel_archlinux_install()
   local rsync_flags="-LrlptD --rsync-path='sudo rsync'"
   local deploy_params="test arch Image 1 arm64 'remote' TEST_MODE"
   local deploy_cmd="bash $REMOTE_KW_DEPLOY/remote_deploy.sh --kernel_update $deploy_params"
+  local config_warning='Undefined .config file for the target kernel. Consider using kw bd'
 
   # For this test we expected three steps:
   #
@@ -237,6 +241,7 @@ function test_kernel_archlinux_install()
   declare -a expected_cmd=(
     "$cmd_preset_remote"
     "$cmd_image_remote"
+    "$config_warning"
     "$cmd_deploy_image"
   )
 
@@ -274,6 +279,7 @@ function test_kernel_install_x86_64()
   local rsync_flags="-LrlptD --rsync-path='sudo rsync'"
   local deploy_params="test debian bzImage 1 x86_64 'remote' TEST_MODE"
   local deploy_cmd="bash $REMOTE_KW_DEPLOY/remote_deploy.sh --kernel_update $deploy_params"
+  local config_warning='Undefined .config file for the target kernel. Consider using kw bd'
 
   # Test preparation
   cd "$original" || {
@@ -304,6 +310,7 @@ function test_kernel_install_x86_64()
 
   declare -a expected_cmd=(
     "$cmd_image_remote"
+    "$config_warning"
     "$cmd_deploy_image"
   )
 
@@ -445,9 +452,11 @@ function test_kernel_install_local()
   local cmd_update_initramfs="sudo -E update-initramfs -c -k test"
   local cmd_update_grub="sudo -E grub-mkconfig -o /boot/grub/grub.cfg"
   local cmd_reboot="sudo -E reboot"
+  local config_warning='Undefined .config file for the target kernel. Consider using kw bd'
   local msg=""
 
   declare -a expected_cmd=(
+    "$config_warning"
     "$cmd_cp_kernel_img"
     "$cmd_update_initramfs"
     "$cmd_update_grub"

--- a/tests/plugins/kernel_install/utils_test.sh
+++ b/tests/plugins/kernel_install/utils_test.sh
@@ -108,6 +108,7 @@ function test_do_uninstall_cmd_sequence()
   local initrdpath="$prefix/boot/initrd.img-$target"
   local modulespath="$prefix/lib/modules/$target"
   local libpath="$prefix/var/lib/initramfs-tools/$target"
+  local configpath="$prefix/boot/config-$target"
 
   # Invalid path
   declare -a cmd_sequence=(
@@ -116,7 +117,7 @@ function test_do_uninstall_cmd_sequence()
     "Can't find $initrdpath"
     "Can't find $modulespath"
     "Can't find $libpath"
-    "Can't find $libpath"
+    "Can't find $configpath"
   )
 
   output=$(do_uninstall "$target" "$prefix" "$TEST_MODE")
@@ -141,6 +142,8 @@ function test_do_uninstall_cmd_sequence()
     "rm -rf $modulespath"
     "Removing: $libpath"
     "rm -rf $libpath"
+    "Removing: $configpath"
+    "rm $configpath"
   )
 
   output=$(do_uninstall "$target" "$prefix" 'TEST_MODE')
@@ -158,6 +161,8 @@ function test_do_uninstall_cmd_sequence()
     "Can't find $modulespath"
     "Removing: $libpath"
     "rm -rf $libpath"
+    "Removing: $configpath"
+    "rm $configpath"
   )
 
   output=$(do_uninstall "$target" "$prefix" 'TEST_MODE')

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -180,6 +180,7 @@ function mk_fake_remote_system()
   local initrdpath="$prefix/boot/initrd.img-$target"
   local modulespath="$prefix/lib/modules/$target"
   local libpath="$prefix/var/lib/initramfs-tools/$target"
+  local configpath="$prefix/boot/config-$target"
 
   mkdir -p "$modulespath"
   mkdir -p "$prefix/boot/"
@@ -190,6 +191,7 @@ function mk_fake_remote_system()
   touch "$kernelpath.old"
   touch "$initrdpath"
   touch "$libpath"
+  touch "$configpath"
 }
 
 function mock_target_machine()


### PR DESCRIPTION
This PR introduces `--fetch` to `kw configm`, which can be used with `--optimize` and `--remote.` Below are a few usage examples:

`kw configm --fetch` gets the .config file from the local machine.
`kw configm --fetch --remote user@ip:port` gets the .config file from the specified machine.
`kw configm --fetch --optimize --remote user@ip:port` runs make localmodconfig to get an optimized .config from the remote machine.

Relates to #147.