### PR TITLE
Refactor init

### DIFF
--- a/src/init.sh
+++ b/src/init.sh
@@ -18,6 +18,15 @@ function init_kw()
     exit 0
   fi
 
+  if [[ -f "$PWD/$name" ]]; then
+    if [[ "$*" =~ --?f(orce)? || $(ask_yN "$name already exists, do you wish to overwrite it?") =~ '1' ]]; then
+      mv "$PWD/$name" "$PWD/$name.old"
+    else
+      say 'Initialization aborted!'
+      exit 0
+    fi
+  fi
+
   if [[ -f "$config_file_template" ]]; then
     cp "$config_file_template" "$PWD/$name"
     sed -i -e "s/USERKW/$USER/g" -e "s,SOUNDPATH,$KW_SHARE_SOUND_DIR,g" -e "/^#?.*/d" \

--- a/src/init.sh
+++ b/src/init.sh
@@ -23,7 +23,7 @@ function init_kw()
     sed -i -e "s/USERKW/$USER/g" -e "s,SOUNDPATH,$KW_SHARE_SOUND_DIR,g" -e "/^#?.*/d" \
       "$PWD/$name"
   else
-    complain "No such: $config_file_template or $kw_path"
+    complain "No such: $config_file_template"
     exit 2 # ENOENT
   fi
 

--- a/tests/init_test.sh
+++ b/tests/init_test.sh
@@ -25,7 +25,6 @@ function tearDown()
 
 function test_init_kw()
 {
-  local ID
   local kworkflow_content
   local path_config="$FAKE_CONFIG_PATH/$KWORKFLOW/kworkflow.config"
   local output
@@ -34,18 +33,15 @@ function test_init_kw()
 
   kworkflow_content=$(grep "$USER" -o "$path_config" | head -n 1)
 
-  ID=1
-  assertEquals "($ID)" "$USER" "$kworkflow_content"
+  assertEquals "($LINENO): USERKW wasn't updated to $USER" "$USER" "$kworkflow_content"
 
-  ID=2
   kworkflow_content=$(grep "$KW_SHARE_SOUND_DIR" -o "$path_config" | head -n 1)
-  assertEquals "($ID)" "$KW_SHARE_SOUND_DIR" "$kworkflow_content"
+  assertEquals "($LINENO): SOUNDPATH wasn't updated to $KW_SHARE_SOUND_DIR" "$KW_SHARE_SOUND_DIR" "$kworkflow_content"
 
-  ID=3
   export KW_ETC_DIR="break/on/purpose"
   output=$(init_kw)
   ret="$?"
-  assertEquals "($ID) We forced an error and expected to catch it" "2" "$ret"
+  assertEquals "($LINENO): We forced an error and expected to catch it" "2" "$ret"
 }
 
 invoke_shunit

--- a/tests/init_test.sh
+++ b/tests/init_test.sh
@@ -29,7 +29,7 @@ function test_init_kw()
   local path_config="$FAKE_CONFIG_PATH/$KWORKFLOW/kworkflow.config"
   local output
 
-  output=$(init_kw)
+  output=$(init_kw 1)
 
   kworkflow_content=$(grep "$USER" -o "$path_config" | head -n 1)
 
@@ -38,8 +38,17 @@ function test_init_kw()
   kworkflow_content=$(grep "$KW_SHARE_SOUND_DIR" -o "$path_config" | head -n 1)
   assertEquals "($LINENO): SOUNDPATH wasn't updated to $KW_SHARE_SOUND_DIR" "$KW_SHARE_SOUND_DIR" "$kworkflow_content"
 
+  output=$(init_kw --force)
+  if [[ ! -f "$path_config.old" ]]; then
+    fail "($LINENO) We expected to find a 'kworkflow.config.old' file."
+  fi
+
+  expect='Initialization aborted!'
+  output=$(echo 'n' | init_kw)
+  assertEquals "($LINENO): The init proccess didn't abort correctly" "$expect" "$output"
+
   export KW_ETC_DIR="break/on/purpose"
-  output=$(init_kw)
+  output=$(init_kw -f) # avoids the overwrite prompt
   ret="$?"
   assertEquals "($LINENO): We forced an error and expected to catch it" "2" "$ret"
 }


### PR DESCRIPTION
While testing kw I ran `kw init` on my kernel folder and lost my configurations, with this change we avoid losing any special configurations.

I also included some small changes to the init files.

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@usp.br>