### PR TITLE
pomodoro: fix SC2004 issues

### DIFF
--- a/src/pomodoro.sh
+++ b/src/pomodoro.sh
@@ -252,7 +252,7 @@ function calculate_missing_time()
       ;;
   esac
 
-  missing_time=$(($time_value - $elapsed_time))
+  missing_time=$((time_value - elapsed_time))
   if [[ "$missing_time" -lt 0 ]]; then
     missing_time=0
   fi
@@ -279,7 +279,7 @@ function show_active_pomodoro_timebox()
 
     # Calculate and process output
     timestamp_to_date=$(date_to_format "@$timestamp" '+%H:%M:%S[%Y/%m/%d]')
-    diff_time=$(($current_timestamp - $timestamp))
+    diff_time=$((current_timestamp - timestamp))
 
     timebox=$(calculate_missing_time "$timebox" "$diff_time")
 

--- a/tests/pomodoro_test.sh
+++ b/tests/pomodoro_test.sh
@@ -131,7 +131,7 @@ function test_show_active_pomodoro_timebox()
   output=$(show_active_pomodoro_timebox)
 
   timestamp_to_date=$(date_to_format "@$timestamp" '+%H:%M:%S[%Y/%m/%d]')
-  diff_time=$((3332232700 - $timestamp))
+  diff_time=$((3332232700 - timestamp))
   elapsed_time=$(sec_to_format "$diff_time")
   missing_time=$(calculate_missing_time "${options_values['TIMER']}" "$diff_time")
   missing_time=$(sec_to_format "$missing_time")


### PR DESCRIPTION
SC2004 - $/${} is unnecessary on arithmetic variables.

Signed-off-by: Alan Barzilay <alan.barzilay@gmail.com>