### PR TITLE
Ignore comments in kworkflow.config

### DIFF
--- a/src/kw_config_loader.sh
+++ b/src/kw_config_loader.sh
@@ -115,7 +115,7 @@ function parse_configuration()
 
     if echo "$line" | grep -F = &> /dev/null; then
       varname="$(echo "$line" | cut -d '=' -f 1 | tr -d '[:space:]')"
-      configurations["$varname"]="$(echo "$line" | cut -d '=' -f 2-)"
+      configurations["$varname"]="$(echo "${line%#*}" | cut -d '=' -f 2-)"
     fi
   done < "$config_path"
 }


### PR DESCRIPTION
We were ignoring only lines that started with '#', so any other line that had a '#' in the middle of it wasn't ignored.