### PR TITLE
explore: fix explore help text

### DIFF
--- a/documentation/man/features/explore.rst
+++ b/documentation/man/features/explore.rst
@@ -16,9 +16,8 @@ string matches in files under git control or in the git log messages.
 Additional parameters extended its behavior to cover all files in a directory
 (whether or not controlled by git) and also to replace the search tool with the
 GNU grep utility. Default usage: you can use :code:`kw e <function-name>` to
-find *<function-name>* in the source directory; If you want to search for a
-composed string, you have to quote your search (e.g.,
-:code:`kw e "<str1> <str2>"`).
+find *<function-name>* in the source directory; If your string has spaces in it
+you have to quote your search (e.g., :code:`kw e "<str1> <str2>"`).
 
 OPTIONS
 =======

--- a/src/explore.sh
+++ b/src/explore.sh
@@ -89,8 +89,7 @@ function explore_help()
     return
   fi
   printf '%s\n' 'kw explore:' \
-    '  explore,e <string> [<path>] - Search for <string> based in <path> (./ by default) ' \
-    '  explore,e "STR SRT" [<path>] - Search for strings only in files under git control' \
+    '  explore,e <string> [<path>] - Search for <string> based in <path> (./ by default)' \
     '  explore,e --log,-l <string> - Search for <string> on git log' \
     '  explore,e --grep,-g <string> - Search for <string> using the GNU grep tool' \
     '  explore,e --all,-a <string> - Search for all <string> match under or not of git management.'


### PR DESCRIPTION
The help text for the explore command was a bit confusing, there was a
weird parameter. I realized its purpose was to show that strings with
spaces need to be quoted. I don't think this is needed in the help text
as it is clearly stated in the man page.

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@usp.br>