### PR TITLE
Remove -z flag from extract_tarball

### DIFF
--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -504,6 +504,6 @@ function extract_tarball()
 
   compression_type=${compression_type:-'--auto-compress'}
 
-  cmd="tar $compression_type -xzf $file_to_extract -C $path"
+  cmd="tar $compression_type -xf $file_to_extract -C $path"
   cmd_manager "$flag" "$cmd"
 }

--- a/tests/kwlib_test.sh
+++ b/tests/kwlib_test.sh
@@ -459,7 +459,7 @@ function test_extract_tarball()
   local output
 
   output=$(extract_tarball "$file" "$SHUNIT_TMPDIR" 'gzip' 'SUCCESS')
-  assertEquals "($LINENO)" "tar --gzip -xzf $file -C $SHUNIT_TMPDIR" "$output"
+  assertEquals "($LINENO)" "tar --gzip -xf $file -C $SHUNIT_TMPDIR" "$output"
 
   assertTrue 'Extraction not done' "[[ -f $SHUNIT_TMPDIR/file1 ]] && [[ -f $SHUNIT_TMPDIR/file2 ]]"
 


### PR DESCRIPTION
The command for extracting a tarball mistakenly had the -z flag in it, which causes errors when setting the compression_type variable to a compression program other than gzip. By removing this flag from the command, we're able to use the function with other compression programs.