### PR TITLE
Fix regression in generate_tarball

### DIFF
--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -429,8 +429,8 @@ function modules_install()
 
       release=$(get_kernel_release "$flag")
       success "Kernel: $release"
-      generate_tarball "$KW_CACHE_DIR/$LOCAL_REMOTE_DIR/lib/modules/$release" \
-        "$KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR/$release.tar" '' "$flag"
+      generate_tarball "$KW_CACHE_DIR/$LOCAL_REMOTE_DIR/lib/modules/" \
+        "$KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR/$release.tar" '' "$release" "$flag"
 
       local tarball_for_deploy_path="$KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR/$release.tar"
       cp_host2remote "$tarball_for_deploy_path" \

--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -425,23 +425,26 @@ function kw_parse_get_errors()
 
 # This function compresses a given path to a .tar.gz file
 #
-# @path_to_compress The directory to compress
+# @go_to_path_to_compress Directory to go into
 # @file_path Where the compressed directory will be stored
 # @compression_type compression program used
+# @dir_name The directory to be compressed, inside go_to_path_to_compress
 # @flag How to display (or not) the command used
 function generate_tarball()
 {
-  local path_to_compress="$1"
+  local go_to_path_to_compress="$1"
   local file_path="$2"
   local compression_type="$3"
-  local flag="$4"
+  local dir_name="$4"
+  local flag="$5"
   local ret
   local cmd
 
   flag=${flag:-'SILENT'}
+  dir_name=${dir_name:-'.'}
 
-  if [[ ! -d "$path_to_compress" ]]; then
-    complain "$path_to_compress" 'does not exist'
+  if [[ ! -d "$go_to_path_to_compress" ]]; then
+    complain "$go_to_path_to_compress" 'does not exist'
     exit 22 #EINVAL
   fi
 
@@ -456,7 +459,10 @@ function generate_tarball()
 
   compression_type=${compression_type:-'--auto-compress'}
 
-  cmd="tar -C $path_to_compress $compression_type -cf $file_path ."
+  # -C: Go to $go_to_path_to_compress directory
+  # -cf: Compress the directory named $dir_name (inside $go_to_path_to_compress) to
+  #      $file_path
+  cmd="tar -C $go_to_path_to_compress $compression_type -cf $file_path $dir_name"
   cmd_manager "$flag" "$cmd"
 
   ret="$?"

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -312,7 +312,7 @@ function test_kernel_modules()
   local expected_output="Kernel: $version"
 
   # Compress modules for sending
-  local compress_cmd="tar -C $local_remote_path/lib/modules/$version --auto-compress -cf $to_deploy_path/$version.tar ."
+  local compress_cmd="tar -C $local_remote_path/lib/modules/ --auto-compress -cf $to_deploy_path/$version.tar $version"
 
   # Rsync modules
   local rsync_tarball="$rsync_cmd $to_deploy_path/$version.tar $remote_access:$remote_path --rsync-path='sudo rsync'"

--- a/tests/kwlib_test.sh
+++ b/tests/kwlib_test.sh
@@ -435,7 +435,7 @@ function test_generate_tarball()
     './file2'
   )
 
-  output=$(generate_tarball "$path_to_compress" "$file_path" 'gzip' 'SUCCESS')
+  output=$(generate_tarball "$path_to_compress" "$file_path" 'gzip' '' 'SUCCESS')
   assertEquals "($LINENO)" "tar -C $path_to_compress --gzip -cf $file_path ." "$output"
 
   assertTrue 'Compressed file was not created' "[[ -f $SHUNIT_TMPDIR/compressed.tar.gz ]]"
@@ -443,7 +443,7 @@ function test_generate_tarball()
   output=$(tar -taf "$file_path" | sort -d)
   compare_command_sequence expected_files "$output" "$LINENO"
 
-  output=$(generate_tarball "$SHUNIT_TMPDIR/vacation/photos" "$file_path" 'gzip' 'SUCCESS')
+  output=$(generate_tarball "$SHUNIT_TMPDIR/vacation/photos" "$file_path" 'gzip' '' 'SUCCESS')
   assertEquals "($LINENO)" "$SHUNIT_TMPDIR/vacation/photos does not exist" "$output"
 
   output=$(generate_tarball "$path_to_compress" "$file_path" 'zipper')


### PR DESCRIPTION
The way generate_tarball was implemented in 30b0459c51f2 led to the deploy malfunctioning in remote machines. This commit fixes this by adding a new parameter to the function (namely _dir_name_).