### PR TITLE
kw_config_loader refactor

### DIFF
--- a/src/kw_config_loader.sh
+++ b/src/kw_config_loader.sh
@@ -22,7 +22,7 @@ declare -gA deploy_target_opt=(['vm']=1 ['local']=2 ['remote']=3)
 function show_variables()
 {
   local test_mode=0
-  local has_local_config_path="No"
+  local has_local_config_path='No'
 
   if [[ "$1" =~ -h|--help ]]; then
     vars_help "$1"
@@ -31,13 +31,11 @@ function show_variables()
 
   # TODO: Drop [[ -f "$PWD/$CONFIG_FILENAME" ]] in the future
   if [[ -f "$PWD/$KW_DIR/$CONFIG_FILENAME" ]] || [[ -f "$PWD/$CONFIG_FILENAME" ]]; then
-    has_local_config_path="Yes"
-  else
-    has_local_config_path="No"
+    has_local_config_path='Yes'
   fi
 
   if [[ "$1" == 'TEST_MODE' ]]; then
-    test_mode='1'
+    test_mode=1
   fi
 
   local -Ar ssh=(
@@ -83,7 +81,7 @@ function show_variables()
 
   local -Ar group_descriptions=(
     [build]='Kernel build options'
-    [deploy]='kernel deploy options'
+    [deploy]='Kernel deploy options'
     [ssh]='SSH options'
     [qemu]='QEMU options'
     [notification]='Notification options'
@@ -91,15 +89,15 @@ function show_variables()
   )
 
   say "kw configuration variables:"
-  echo -e "  Local config file: $has_local_config_path"
+  printf '%s\n' "  Local config file: $has_local_config_path"
 
   for group in 'build' 'deploy' 'qemu' 'ssh' 'notification' 'misc'; do
-    echo "  ${group_descriptions["$group"]}:"
+    printf '%s\n' "  ${group_descriptions["$group"]}:"
     local -n descriptions="$group"
 
     for option in "${!descriptions[@]}"; do
-      if [[ -v configurations["$option"] || "$test_mode" == '1' ]]; then
-        echo "    ${descriptions[$option]} ($option): ${configurations[$option]}"
+      if [[ -v configurations["$option"] || "$test_mode" == 1 ]]; then
+        printf '%s\n' "    ${descriptions[$option]} ($option): ${configurations[$option]}"
       fi
     done
   done
@@ -133,10 +131,10 @@ function parse_configuration()
     # Line started with # should be ignored
     [[ "$line" =~ ^# ]] && continue
 
-    if echo "$line" | grep -F = &> /dev/null; then
-      varname="$(echo "$line" | cut -d '=' -f 1 | tr -d '[:space:]')"
-      value="$(echo "${line%#*}" | cut -d '=' -f 2-)"
-      value="$(echo "$value" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    if printf '%s\n' "$line" | grep -F = &> /dev/null; then
+      varname="$(printf '%s\n' "$line" | cut -d '=' -f 1 | tr -d '[:space:]')"
+      value="$(printf '%s\n' "${line%#*}" | cut -d '=' -f 2-)"
+      value="$(printf '%s\n' "$value" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
 
       configurations["$varname"]="$value"
     fi

--- a/tests/kw_config_loader_test.sh
+++ b/tests/kw_config_loader_test.sh
@@ -22,7 +22,7 @@ function tearDown()
 function test_parse_configuration_success_exit_code()
 {
   parse_configuration tests/samples/kworkflow.config
-  assertTrue "Kw failed to load a regular config file" "[ 0 -eq $? ]"
+  assertTrue 'kw failed to load a regular config file' "[ 0 -eq $? ]"
 }
 
 function test_parse_configuration_config_with_spaces_and_comments()
@@ -39,27 +39,28 @@ function test_parse_configuration_config_with_spaces_and_comments()
 function test_parser_configuration_failed_exit_code()
 {
   parse_configuration tests/foobarpotato
-  assertTrue "kw loaded an unsupported file" "[ 22 -eq $? ]"
+  assertTrue 'kw loaded an unsupported file' "[ 22 -eq $? ]"
 }
 
 function assertConfigurations()
 {
   declare -n configurations_ref=$1
   declare -n expected_configurations_ref=$2
+  local lineno=${3:-LINENO}
 
   # check if configurations is contained in expected_configurations
   for k in "${!configurations_ref[@]}"; do
     if [[ ${expected_configurations_ref[$k]+token} != token ]]; then
-      fail "Did not expect setting \"$k\"."
+      fail "($lineno): Did not expect setting '$k'."
     elif [[ ${configurations_ref[$k]} != "${expected_configurations_ref[$k]}" ]]; then
-      fail "Expected setting \"${k}\" to be \"${expected_configurations_ref[$k]}\" (found \"${configurations_ref[$k]}\")."
+      fail "($lineno): Expected setting '${k}' to be '${expected_configurations_ref[$k]}' (found '${configurations_ref[$k]}')."
     fi
   done
 
   # check if configurations has all expected_configurations keys
   for k in "${!expected_configurations_ref[@]}"; do
     if [[ ${configurations_ref[$k]+token} != token ]]; then
-      fail "Expected setting \"$k\" to be present."
+      fail "($lineno): Expected setting '$k' to be present."
     fi
   done
 }
@@ -68,20 +69,20 @@ function assertConfigurations()
 function test_parse_configuration_output()
 {
   declare -A expected_configurations=(
-    [arch]="arm64"
-    [kernel_img_name]="Image"
-    [cross_compile]="aarch64-linux-gnu-"
-    [virtualizer]="libvirt"
-    [qemu_path_image]="/home/xpto/p/virty.qcow2"
+    [arch]='arm64'
+    [kernel_img_name]='Image'
+    [cross_compile]='aarch64-linux-gnu-'
+    [virtualizer]='libvirt'
+    [qemu_path_image]='/home/xpto/p/virty.qcow2'
     [ssh_user]='juca'
-    [ssh_ip]="127.0.0.1"
-    [ssh_port]="3333"
-    [mount_point]="/home/lala"
-    [default_deploy_target]="vm"
-    [reboot_after_deploy]="no"
-    [gui_on]="turn on"
-    [gui_off]="turn off"
-    [doc_type]="htmldocs"
+    [ssh_ip]='127.0.0.1'
+    [ssh_port]='3333'
+    [mount_point]='/home/lala'
+    [default_deploy_target]='vm'
+    [reboot_after_deploy]='no'
+    [gui_on]='turn on'
+    [gui_off]='turn off'
+    [doc_type]='htmldocs'
   )
 
   cp tests/samples/kworkflow.config "$TMP_DIR/"
@@ -96,7 +97,7 @@ function test_parse_configuration_output()
     return
   }
 
-  assertConfigurations configurations expected_configurations
+  assertConfigurations configurations expected_configurations "$LINENO"
 
   true # Reset return value
 }
@@ -104,30 +105,30 @@ function test_parse_configuration_output()
 # Test if etc/kworkflow_template.config contains all the expected settings
 function test_parse_configuration_standard_config()
 {
-
+  # shellcheck disable=2016
   declare -A expected_configurations=(
-    [arch]="x86_64"
-    [kernel_img_name]="bzImage"
-    [menu_config]="nconfig"
-    [virtualizer]="qemu-system-x86_64"
-    [qemu_path_image]="/home/USERKW/p/virty.qcow2"
-    [qemu_hw_options]="-enable-kvm -daemonize -smp 2 -m 1024"
-    [qemu_net_options]="-nic user,hostfwd=tcp::2222-:22,smb=/home/USERKW"
+    [arch]='x86_64'
+    [kernel_img_name]='bzImage'
+    [menu_config]='nconfig'
+    [virtualizer]='qemu-system-x86_64'
+    [qemu_path_image]='/home/USERKW/p/virty.qcow2'
+    [qemu_hw_options]='-enable-kvm -daemonize -smp 2 -m 1024'
+    [qemu_net_options]='-nic user,hostfwd=tcp::2222-:22,smb=/home/USERKW'
     [ssh_user]='root'
-    [ssh_ip]="localhost"
-    [ssh_port]="22"
-    [mount_point]="/home/USERKW/p/mount"
-    [alert]="n"
-    [sound_alert_command]="paplay SOUNDPATH/bell.wav"
-    [visual_alert_command]="notify-send -i checkbox -t 10000 \"kw\" \"Command: \\\"\$COMMAND\\\" completed!\""
-    [default_deploy_target]="vm"
-    [reboot_after_deploy]="no"
-    [disable_statistics_data_track]="no"
-    [doc_type]="htmldocs"
+    [ssh_ip]='localhost'
+    [ssh_port]='22'
+    [mount_point]='/home/USERKW/p/mount'
+    [alert]='n'
+    [sound_alert_command]='paplay SOUNDPATH/bell.wav'
+    [visual_alert_command]='notify-send -i checkbox -t 10000 "kw" "Command: \"$COMMAND\" completed!"'
+    [default_deploy_target]='vm'
+    [reboot_after_deploy]='no'
+    [disable_statistics_data_track]='no'
+    [doc_type]='htmldocs'
   )
 
   parse_configuration "$TMP_DIR/kworkflow.config"
-  assertConfigurations configurations expected_configurations
+  assertConfigurations configurations expected_configurations "$LINENO"
 
   true # Reset return value
 }
@@ -141,13 +142,13 @@ function test_parse_configuration_files_loading_order()
   local original_dir="$PWD"
 
   cd "$SHUNIT_TMPDIR" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "($LINENO): It was not possible to move to temporary directory"
     return
   }
 
-  KW_ETC_DIR="1"
-  XDG_CONFIG_DIRS="2:3:4"
-  XDG_CONFIG_HOME="5"
+  KW_ETC_DIR='1'
+  XDG_CONFIG_DIRS='2:3:4'
+  XDG_CONFIG_HOME='5'
 
   expected=(
     "1/$CONFIG_FILENAME"
@@ -160,17 +161,17 @@ function test_parse_configuration_files_loading_order()
   output="$(
     function parse_configuration()
     {
-      echo "$@"
+      printf '%s\n' "$@"
     }
     load_configuration
   )"
 
-  compare_command_sequence 'expected' "$output" "$LINENO - Wrong config file reading order."
+  compare_command_sequence 'expected' "$output" "($LINENO): Wrong config file reading order."
 
   # IF XDG global variables are not defined
   unset XDG_CONFIG_DIRS
   unset XDG_CONFIG_HOME
-  HOME="5"
+  HOME='5'
 
   expected=(
     "1/$CONFIG_FILENAME"
@@ -182,15 +183,15 @@ function test_parse_configuration_files_loading_order()
   output="$(
     function parse_configuration()
     {
-      echo "$@"
+      printf '%s\n' "$@"
     }
     load_configuration
   )"
 
-  compare_command_sequence 'expected' "$output" "$LINENO - Wrong config file reading order."
+  compare_command_sequence 'expected' "$output" "($LINENO): Wrong config file reading order."
 
   cd "$original_dir" || {
-    fail "($LINENO) It was not possible to move back to original directory"
+    fail "($LINENO): It was not possible to move back to original directory"
     return
   }
 }
@@ -204,7 +205,7 @@ function test_show_variables_completeness()
   # get all assigned options, including commented ones
   # remove #'s and ='s to get option names
   output="$(cat 'etc/kworkflow_template.config')"
-  output="$(echo "$output" | grep -oE '^(#?\w+=?)' | sed -E 's/[#=]//g')"
+  output="$(printf '%s\n' "$output" | grep -oE '^(#?\w+=?)' | sed -E 's/[#=]//g')"
 
   for option in $output; do
     possible_options["$option"]='1'
@@ -212,7 +213,7 @@ function test_show_variables_completeness()
 
   output="$(show_variables 'TEST_MODE' | grep -E '^    ')"
   # shellcheck disable=2001
-  output="$(echo "$output" | sed 's/.*(\(\S*\)).*/\1/')"
+  output="$(printf '%s\n' "$output" | sed 's/.*(\(\S*\)).*/\1/')"
 
   for option in $output; do
     shown_options["$option"]=1
@@ -220,13 +221,13 @@ function test_show_variables_completeness()
 
   for option in "${!possible_options[@]}"; do
     if [[ ! -v shown_options["$option"] ]]; then
-      fail "show_variables is missing option $option"
+      fail "($LINENO): show_variables is missing option $option"
     fi
   done
 
   for option in "${!shown_options[@]}"; do
     if [[ ! -v possible_options["$option"] ]]; then
-      fail "show_variable is showing $option not present in kworkflow_template.config"
+      fail "($LINENO): show_variable is showing $option not present in kworkflow_template.config"
     fi
   done
 }
@@ -265,12 +266,12 @@ function test_show_variables_correctness()
   output="$(show_variables | grep -E '^    ')"
 
   while read -r line; do
-    option="$(echo "$line" | sed -E 's/.*\((\S*)\).*/\1/')"
-    value=$(echo "$line" | sed -E 's/.*: (.*)/\1/')
+    option="$(printf '%s\n' "$line" | sed -E 's/.*\((\S*)\).*/\1/')"
+    value=$(printf '%s\n' "$line" | sed -E 's/.*: (.*)/\1/')
     if [[ "${configurations["$option"]}" != "$value" ]]; then
       message="Value of option $option should be "
       message+="${configurations["$option"]} but is $value"
-      fail "$message"
+      fail "($LINENO): $message"
     fi
   done <<< "$output"
 }
@@ -295,12 +296,12 @@ function test_load_configuration()
   mk_fake_kernel_root "$PWD"
 
   # No to updating kworkflow.config to .kw/kworkflow.config
-  output="$(echo n | load_configuration)"
+  output="$(printf '%s\n' 'n' | load_configuration)"
   assertEquals "($LINENO): There should have been a warning" "$output" "$msg"
   assertTrue 'kworkflow.config was moved' '[[ -f "$PWD/$CONFIG_FILENAME" ]]'
 
   # Yes to updating kworkflow.config to .kw/kworkflow.config
-  output="$(echo y | load_configuration)"
+  output="$(printf '%s\n' 'y' | load_configuration)"
 
   assertEquals "($LINENO): There should have been a warning" "$output" "$msg"
 
@@ -322,7 +323,7 @@ function test_load_configuration()
   output="$(
     function parse_configuration()
     {
-      echo "$@"
+      printf '%s\n' "$@"
     }
     load_configuration
   )"


### PR DESCRIPTION
Small refactor of kw_config_loader and its tests.
This updates the tests to use `$LINENO` to make it easier to find test errors. And also replaces double quotes with single quotes in strings that don't have substitutions.

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@usp.br>