### PR TITLE
run shellcheck on push

### DIFF
--- a/.github/workflows/shellcheck_reviewdog.yml
+++ b/.github/workflows/shellcheck_reviewdog.yml
@@ -1,5 +1,6 @@
 name: shellcheck-reviewdog
-on: [pull_request]
+on:
+  [push, pull_request]
 jobs:
   shellcheck:
     name: runner / shellcheck


### PR DESCRIPTION
Shellcheck was our only action that was only run upon creating a PR,
this adds the check to pushes as well.

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@usp.br>