### PR TITLE
time_and_date: remove cal dependency

### DIFF
--- a/src/kw_time_and_date.sh
+++ b/src/kw_time_and_date.sh
@@ -86,6 +86,8 @@ function days_in_the_month()
 {
   local month_number="$1"
   local year="$2"
+  local days=31
+  local short=(4 6 9 11) # list of months with 30 days
 
   if [[ -n "$month_number" && "$month_number" -lt 1 || "$month_number" -gt 12 ]]; then
     return 22 # EINVAL
@@ -94,5 +96,21 @@ function days_in_the_month()
   month_number=${month_number:-$(date +%m)}
   year=${year:-$(date +%Y)}
 
-  cal "$month_number" "$year" | awk 'NF {DAYS = $NF}; END {print DAYS}'
+  # check if it's a leap year
+  if [[ "$month_number" == 2 ]]; then
+    if ((year % 4 != 0)); then
+      days=28
+    elif ((year % 100 != 0)); then
+      days=29
+    elif ((year % 400 != 0)); then
+      days=28
+    else
+      days=29
+    fi
+  # check if it's a short month
+  elif [[ "${short[*]}" =~ (^|[[:space:]])$month_number($|[[:space:]]) ]]; then
+    days=30
+  fi
+
+  printf '%s\n' "$days"
 }

--- a/tests/kw_time_and_date_test.sh
+++ b/tests/kw_time_and_date_test.sh
@@ -82,9 +82,22 @@ function test_days_in_the_month()
   local this_month_total_days
   local ret
 
+  total_days=$(days_in_the_month 2 2021)
+  assert_equals_helper 'We expect 28 days' "$LINENO" "$total_days" 28
+
   # Leap year, February has 29 days
   total_days=$(days_in_the_month 2 2016)
   assert_equals_helper 'We expect 29 days' "$LINENO" "$total_days" 29
+
+  total_days=$(days_in_the_month 2 300)
+  assert_equals_helper 'We expect 28 days' "$LINENO" "$total_days" 28
+
+  # Leap year, February has 29 days
+  total_days=$(days_in_the_month 2 1600)
+  assert_equals_helper 'We expect 29 days' "$LINENO" "$total_days" 29
+
+  total_days=$(days_in_the_month 1 2016)
+  assert_equals_helper 'We expect 31 days' "$LINENO" "$total_days" 31
 
   total_days=$(days_in_the_month 6 2021)
   assert_equals_helper 'We expect 30 days' "$LINENO" "$total_days" 30
@@ -95,13 +108,6 @@ function test_days_in_the_month()
   # Empty year should be converted to the present year
   total_days=$(days_in_the_month 8)
   assert_equals_helper 'Use this year' "$LINENO" "$total_days" 31
-
-  # Empty year should be converted to the present year
-  total_days=$(days_in_the_month)
-  this_year=$(date +%Y)
-  this_month=$(date +%m)
-  this_month_total_days=$(cal "$this_month" "$this_year" | awk 'NF {DAYS = $NF}; END {print DAYS}')
-  assert_equals_helper 'Use the current month' "$LINENO" "$total_days" "$this_month_total_days"
 
   # An invalid month
   days_in_the_month 333


### PR DESCRIPTION
A previous commit introduced a dependency on the `ncal` package, in an
effort to keep kw as minimal as possible the functions affected have
been refactored to remove that dependency.

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@usp.br>