### PR TITLE
src: init: Enforce dictionary order when display architecture

### DIFF
--- a/src/init.sh
+++ b/src/init.sh
@@ -58,7 +58,7 @@ function init_kw()
         complain 'This arch was not found in the arch directory'
         complain 'You can use --force next time if you want to proceed anyway'
         say 'Available architectures:'
-        find "$PWD/arch" -maxdepth 1 -mindepth 1 -type d -printf '%f\n'
+        find "$PWD/arch" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | sort -d
       fi
     fi
 


### PR DESCRIPTION
Currently, when we show the available architecture, we list them from
arch/ folder. However, this can cause test failures because every system
can sort this information in its own way; i.e., tests are not portable
right now. This commit enforces dictionary order when we list
architecture to avoid failures in different distributions.

Signed-off-by: Rodrigo Siqueira <rodrigosiqueiramelo@gmail.com>