### PR TITLE
remove left over echo

### DIFF
--- a/documentation/content/codingstyle.rst
+++ b/documentation/content/codingstyle.rst
@@ -171,14 +171,15 @@ Redirection
 -----------
 
 Redirection operators should be written with space before, but no space after
-them. In other words, write 'echo test >"$file"' instead of 'echo test> $file'
-or 'echo test > $file'. Note that even though it is not required by POSIX to
-double-quote the redirection target in a variable (as shown above), our code
-does so because some versions of bash issue a warning without the quotes::
+them. In other words, write ``printf '%s\n' test >"$file"`` instead of
+``printf '%s\n' test> "$file"`` or ``printf '%s\n' test > "$file"``. Note that
+even though it is not required by POSIX to double-quote the redirection target
+in a variable (as shown above), our code does so because some versions of bash
+issue a warning without the quotes::
 
     (incorrect)
     cat hello > world < universe
-    echo hello >$world
+    printf '%s\n' hello >$world
 
     (correct)
     cat hello >world "$world"
@@ -273,6 +274,14 @@ it's de-pollution upon receiving a SIGINT or a SIGTERM: an interrupted command
 should always leave the environment in the same state as it was prior to its
 invocation. Convenience functions for this purpose (setting and resetting
 handlers for arbitrary signals) are implemented in `src/signal_manager`.
+
+Use ``printf`` instead of ``echo``
+----------------------------------
+We stay away from ``echo`` as it is not always consistent with its output
+depending on system and bash version. Therefore always use ``printf`` instead,
+it stays consistent across mutliple platforms. If you need to add extra lines
+while generating a string you can use the ``$'\n'`` literal to add a new line
+character or other special characters.
 
 Conclusion
 ----------

--- a/src/plugins/subsystems/drm/drm.sh
+++ b/src/plugins/subsystems/drm/drm.sh
@@ -299,7 +299,7 @@ function get_available_connectors()
 
     IFS=',' read -r -a connectors <<< "${cards[$card]}"
     for conn in "${connectors[@]}"; do
-      echo -e " $conn" # TODO
+      printf '%s\n' " $conn"
     done
 
   done
@@ -343,7 +343,7 @@ function get_supported_mode_per_connector()
   modes=${modes//sys\/class\/drm\//}
 
   say 'Modes per card'
-  echo -e "$modes" # TODO
+  printf '%s\n' "$modes"
 }
 
 function drm_parser_options()

--- a/src/report.sh
+++ b/src/report.sh
@@ -147,7 +147,7 @@ function grouping_day_data()
     end_time=$(date --date="$start_time $time_label" +%H:%M:%S)
 
     [[ -n "$details" ]] && details=": $details"
-    tags_details["$tag"]+=" * [$start_time-$end_time][$timebox]$details\n"
+    tags_details["$tag"]+=" * [$start_time-$end_time][$timebox]$details"$'\n'
 
     # Preparing metadata: total timebox in sec, total repetition
     timebox_sec=$(timebox_to_sec "$timebox")
@@ -275,7 +275,7 @@ function show_data
       " - Total repetitions: $total_repetition" \
       '' \
       'Summary:'
-    echo -e "${tags_details[$tag]}" # TODO
+    printf '%s\n' "${tags_details[$tag]}"
   done
 }
 

--- a/src/statistics.sh
+++ b/src/statistics.sh
@@ -208,7 +208,7 @@ function basic_data_process()
   local min
 
   for option in "${statistics_opt[@]}"; do
-    values=$(echo -e "$all_data" | grep "$option" | cut -d' ' -f2-) # TODO
+    values=$(printf '%s\n' "$all_data" | grep "$option" | cut -d' ' -f2-)
     [[ -z "$values" ]] && continue
 
     # Calculate values
@@ -273,7 +273,7 @@ function week_statistics()
     all_file_data=$(cat "$KW_DATA_DIR/statistics/$day")
     [[ -z "$all_file_data" ]] && continue
 
-    all_data="${all_data}${all_file_data}\n"
+    all_data="${all_data}${all_file_data}"$'\n'
   done
 
   if [[ -z "$all_data" ]]; then
@@ -290,7 +290,7 @@ function month_statistics()
 {
   local month="$1"
   local month_path="$KW_DATA_DIR/statistics/$month"
-  local all_data=""
+  local all_data=''
   local pretty_month
   local current_path
 
@@ -306,7 +306,7 @@ function month_statistics()
     all_file_data=$(cat "$day")
     [[ -z "$all_file_data" ]] && continue
 
-    all_data="${all_data}${all_file_data}\n"
+    all_data="${all_data}${all_file_data}"$'\n'
   done
   cd "$current_path" || exit_msg 'It was not possible to move back from month dir'
 
@@ -341,7 +341,7 @@ function year_statistics()
     all_file_data=$(cat "$day_full_path")
     [[ -z "$all_file_data" ]] && continue
 
-    all_data="${all_data}${all_file_data}\n"
+    all_data="${all_data}${all_file_data}"$'\n'
   done
 
   basic_data_process "$all_data"

--- a/tests/report_test.sh
+++ b/tests/report_test.sh
@@ -116,13 +116,14 @@ function test_grouping_day_data()
   local count=0
   local line
 
+  # Here we use $'...' to evaluate the newline at the end of the strings
   declare -a expected_content=(
-    ' * [06:00:40-06:20:40][20m]: Tag 1 description\n'
-    ' * [08:30:50-08:45:50][15m]: Tag 2 description\n'
-    ' * [09:00:00-10:00:00][1h]: Tag 3 description\n'
-    ' * [11:00:00-11:00:44][44s]: Tag 4 description\n'
-    ' * [14:00:00-14:30:00][30m]: Tag 5 description\n'
-    ' * [15:00:00-15:10:00][10m]\n'
+    $' * [06:00:40-06:20:40][20m]: Tag 1 description\n'
+    $' * [08:30:50-08:45:50][15m]: Tag 2 description\n'
+    $' * [09:00:00-10:00:00][1h]: Tag 3 description\n'
+    $' * [11:00:00-11:00:44][44s]: Tag 4 description\n'
+    $' * [14:00:00-14:30:00][30m]: Tag 5 description\n'
+    $' * [15:00:00-15:10:00][10m]\n'
   )
 
   declare -a expected_tags=(
@@ -144,8 +145,8 @@ function test_grouping_day_data()
   # Try to process file with bad data
   count=0
   declare -a expected_content=(
-    ' * [06:00:40-06:20:40][20m]: Tag 1 description\n'
-    ' * [09:00:00-10:00:00][1h]: Tag 3 description\n'
+    $' * [06:00:40-06:20:40][20m]: Tag 1 description\n'
+    $' * [09:00:00-10:00:00][1h]: Tag 3 description\n'
   )
 
   declare -a expected_tags=(


### PR DESCRIPTION
Three files still had echo commands, this commit removes them in
compliance with the rest of the codebase.
It also adapts and adds the 'codingstyle.rst' file to mention the use of
printf instead of echo.

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@usp.br>