### PR TITLE
doc: index: remove duplicate entry

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -29,10 +29,9 @@ Check out our tutorials to see how you can use kw.
    :maxdepth: 1
    :caption: Tutorials:
 
-   tutorials/buildlinux
-   tutorials/configm
    tutorials/setup
    tutorials/buildlinux
+   tutorials/configm
    tutorials/pomodoro-report
 
 kw Man


### PR DESCRIPTION
Recent PRs introduced a duplicate entry in the toctree for the
tutorials, this removes the duplicate and reorganizes the remaining.

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@usp.br>