### PR TITLE
src: kw_time_and_date: fix octal bug

### DIFF
--- a/documentation/dependencies/arch.dependencies
+++ b/documentation/dependencies/arch.dependencies
@@ -18,3 +18,4 @@ lzop
 zstd
 xz
 python-pip
+bc

--- a/documentation/dependencies/debian.dependencies
+++ b/documentation/dependencies/debian.dependencies
@@ -20,3 +20,4 @@ lzip
 xz-utils
 lzop
 zstd
+bc

--- a/src/kw_time_and_date.sh
+++ b/src/kw_time_and_date.sh
@@ -50,9 +50,9 @@ function get_week_beginning_day()
 
   format=${format:-'+%Y/%m/%d'}
   date_param=${date_param:-$(date '+%Y/%m/%d')}
-  week_day_num=$(date -d "$date_param" '+%u')
+  week_day_num=$(date -d "$date_param" '+%u' 2> /dev/null)
 
-  date --date="${date_param} - ${week_day_num} day" "$format"
+  date --date="${date_param} - ${week_day_num} day" "$format" 2> /dev/null
 }
 
 # Convert a value to a specific date format. If uses do not provide any format,
@@ -70,7 +70,7 @@ function date_to_format()
 
   format=${format:-'+%Y/%m/%d'}
   value=${value:-$(date "$format")}
-  date -d "$value" "$format"
+  date -d "$value" "$format" 2> /dev/null
 }
 
 # Return the total number of days in a specific month.

--- a/src/kw_time_and_date.sh
+++ b/src/kw_time_and_date.sh
@@ -87,9 +87,11 @@ function days_in_the_month()
   local month_number="$1"
   local year="$2"
   local days=31
-  local short=(4 6 9 11) # list of months with 30 days
+  local short=(4 04 6 06 9 09 11) # list of months with 30 days
 
-  if [[ -n "$month_number" && "$month_number" -lt 1 || "$month_number" -gt 12 ]]; then
+  month_number="$(printf '%s\n' "obase=10; $month_number" | bc)"
+
+  if [[ -n "$month_number" ]] && [[ "$month_number" -lt 1 || "$month_number" -gt 12 ]]; then
     return 22 # EINVAL
   fi
 
@@ -97,7 +99,7 @@ function days_in_the_month()
   year=${year:-$(date +%Y)}
 
   # check if it's a leap year
-  if [[ "$month_number" == 2 ]]; then
+  if [[ "$month_number" =~ ^0?2$ ]]; then
     if ((year % 4 != 0)); then
       days=28
     elif ((year % 100 != 0)); then
@@ -108,7 +110,7 @@ function days_in_the_month()
       days=29
     fi
   # check if it's a short month
-  elif [[ "${short[*]}" =~ (^|[[:space:]])$month_number($|[[:space:]]) ]]; then
+  elif [[ "${short[*]}" =~ (^|[[:space:]])"$month_number"($|[[:space:]]) ]]; then
     days=30
   fi
 

--- a/tests/kw_time_and_date_test.sh
+++ b/tests/kw_time_and_date_test.sh
@@ -85,6 +85,9 @@ function test_days_in_the_month()
   total_days=$(days_in_the_month 2 2021)
   assert_equals_helper 'We expect 28 days' "$LINENO" "$total_days" 28
 
+  total_days=$(days_in_the_month 02 2021)
+  assert_equals_helper 'We expect 28 days' "$LINENO" "$total_days" 28
+
   # Leap year, February has 29 days
   total_days=$(days_in_the_month 2 2016)
   assert_equals_helper 'We expect 29 days' "$LINENO" "$total_days" 29
@@ -102,6 +105,12 @@ function test_days_in_the_month()
   total_days=$(days_in_the_month 6 2021)
   assert_equals_helper 'We expect 30 days' "$LINENO" "$total_days" 30
 
+  total_days=$(days_in_the_month 9 2021)
+  assert_equals_helper 'We expect 30 days' "$LINENO" "$total_days" 30
+
+  total_days=$(days_in_the_month 09 2021)
+  assert_equals_helper 'We expect 30 days' "$LINENO" "$total_days" 30
+
   total_days=$(days_in_the_month 8 2021)
   assert_equals_helper 'We expect 31 days' "$LINENO" "$total_days" 31
 
@@ -111,6 +120,18 @@ function test_days_in_the_month()
 
   # An invalid month
   days_in_the_month 333
+  ret="$?"
+  assert_equals_helper 'Invalid month' "$LINENO" "$ret" 22
+
+  days_in_the_month -5
+  ret="$?"
+  assert_equals_helper 'Invalid month' "$LINENO" "$ret" 22
+
+  days_in_the_month -09
+  ret="$?"
+  assert_equals_helper 'Invalid month' "$LINENO" "$ret" 22
+
+  days_in_the_month -009
   ret="$?"
   assert_equals_helper 'Invalid month' "$LINENO" "$ret" 22
 }


### PR DESCRIPTION
Inside the `days_in_the_month` function the months 08 and 09 were being
interpreted as octal values due to the leading zero, and as they are
greater than 7 it would cause problems related to invalid integer.
This uses bc to correctly convert any numbers to base 10 without any
leading zeros.

The 'short' array has been expanded to accept the months numbers with
leading zeros as this is the usual output by the `date` command.
The leap year check has also been updated for the same reason.

Additional tests have been added to account for these situations.

Unwanted error messages were being displayed whenever statistics was
invoked with wrong date parameters.
This redirects the error messages so they are no longer displayed.

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@usp.br>