### PR TITLE
src: config_manager: Add olddefconfig

### DIFF
--- a/src/config_manager.sh
+++ b/src/config_manager.sh
@@ -380,6 +380,11 @@ function fetch_config()
   [[ "$ret" != 0 ]] && get_config_from_defconfig "$flag" "$output"
   [[ "$?" == 125 ]] && return 125 # ECANCELED
 
+  # Let's ensure that we keep all of the options from the old .config and set
+  # new options to their default values.
+  cmd='make olddefconfig'
+  cmd_manager "$flag" "$cmd"
+
   if [[ -n "$optimize" ]]; then
     if ! is_kernel_root "$PWD"; then
       complain 'This command should be run in a kernel tree.'

--- a/tests/configm_test.sh
+++ b/tests/configm_test.sh
@@ -630,6 +630,7 @@ function test_fetch_config()
     # Note: since we are creating a faking /proc, we dropped '/'.
     'sudo modprobe -q configs && [ -s proc/config.gz ]'
     'zcat /proc/config.gz > .config'
+    'make olddefconfig'
     'Successfully retrieved .config'
   )
   output=$(fetch_config 'TEST_MODE' '' '' '' "$LOCAL_TARGET")
@@ -637,6 +638,7 @@ function test_fetch_config()
 
   expected_output=(
     'zcat /proc/config.gz > .config'
+    'make olddefconfig'
     'Successfully retrieved .config'
   )
 
@@ -662,6 +664,7 @@ function test_fetch_config()
 
   expected_output=(
     'zcat /proc/config.gz > newconfig'
+    'make olddefconfig'
     'Successfully retrieved newconfig'
   )
 
@@ -681,6 +684,7 @@ function test_fetch_config()
   touch "${root}proc/config.gz"
   expected_output=(
     'zcat /proc/config.gz > .config'
+    'make olddefconfig'
     "make localmodconfig LSMOD=$KW_CACHE_DIR/lsmod"
     'Successfully retrieved .config'
   )
@@ -694,6 +698,7 @@ function test_fetch_config()
     "ssh -p 1234 mary@localhost sudo \"zcat /proc/config.gz > /tmp/kw/.config\""
     "rsync -e \"ssh -p 1234\" mary@localhost:/tmp/kw/.config $PWD"
     "ssh -p 1234 mary@localhost sudo \"rm -rf /tmp/kw\""
+    'make olddefconfig'
     'Successfully retrieved .config'
   )
 


### PR DESCRIPTION
kw retrieve the config file by copying it. However, we can do something
a little bit better by running olddefconfig, which will ensure that we
set the default options in the config file.

Signed-off-by: Rodrigo Siqueira <rodrigosiqueiramelo@gmail.com>