### PR TITLE
src: Improve autocompletion on all features

### DIFF
--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -1,31 +1,69 @@
 function _kw_autocomplete()
 {
-  local current_command previous_command kw_options
-  COMPREPLY=()
-  current_command="${COMP_WORDS[COMP_CWORD]}"
-  previous_command="${COMP_WORDS[COMP_CWORD - 1]}"
-  kw_options="explore e bd build b init ssh s clear-cache
-                mount mo umount um vars up u codestyle c configm g
-                maintainers m deploy d help h version statistics
-                pomodoro p report r device drm diff df --version -v man
-                backup debug mail"
+  declare -A kw_options
 
-  # By default, autocomplete with kw_options
-  if [[ ${previous_command} == kw ]]; then
-    COMPREPLY=("$(compgen -W "${kw_options}" -- "${current_command}")")
-    return 0
+  local current_command previous_command kw_options comp_curr
+
+  comp_curr=$COMP_CWORD
+
+  if [[ "$COMP_CWORD" -gt 2 ]]; then
+    comp_curr=2
   fi
+
+  current_command="${COMP_WORDS[$COMP_CWORD]}"
+  previous_command="${COMP_WORDS[$comp_curr - 1]}"
+
+  kw_options['kw']='backup bd build clear-cache codestyle configm debug deploy
+                    device diff drm explore help init maintainers mail man mount
+                    pomodoro report ssh statistics umount up vars version'
+
+  kw_options['backup']='--restore --force --help'
+
+  kw_options['build']='--menu --info --doc --help'
+  kw_options['b']="${kw_options['build']}"
+
+  kw_options['configm']='--fetch --get --list --remove --save --force
+                         --description --output --optimize --remote'
+  kw_options['g']="${kw_options['configm']}"
+
+  kw_options['deploy']='--force --list --list-all --local --ls-line --modules
+                        --reboot --remote --uninstall --vm'
+  kw_options['d']="${kw_options['deploy']}"
+
+  kw_options['device']='--local --remote --vm'
+
+  kw_options['diff']='--no-interactive'
+  kw_options['df']="${kw_options['diff']}"
+
+  kw_options['explore']='--log --grep --all'
+  kw_options['e']="${kw_options['explore']}"
+
+  kw_options['init']='--arch --force --remote --target'
+
+  kw_options['mail']='--setup --local --global --force --verify --list --email  
+                     --name --smtpuser --smtpencryption --smtpserver 
+                     --smtpserverport --smtppass'
+
+  kw_options['maintainers']='--authors --update-patch'
+  kw_options['m']="${kw_options['mantainers']}"
+
+  kw_options['pomodoro']='--description --list --set-timer --tag'
+  kw_options['p']="${kw_options['pomodoro']}"
+
+  kw_options['report']='--day --month --output --week --year'
+  kw_options['r']="${kw_options['report']}"
+
+  kw_options['ssh']='--command --script'
+  kw_options['s']="${kw_options['ssh']}"
+
+  kw_options['statistics']='--day --month --week --year'
+
+  mapfile -t COMPREPLY < <(compgen -W "${kw_options[${previous_command}]} " -- "${current_command}")
 
   # TODO:
   # Autocomplete in the bash terminal is a powerful tool which allows us to
-  # make many interesting things. In the future, we could add an
-  # autocompletion for subcommands, the code below illustrates an example
-  # that tries to add this feature for the ‘maintainers’ options.
-  #
-  # For maintainers and m options, autocomplete with folder
-  # if [ ${previous_command} == maintainers ] || [ ${previous_command} == m ] ; then
-  #   COMPREPLY=( $(compgen -d -- ${current_command}) )
-  #   return 0
-  # fi
+  # make many interesting things. In the future, we could use a tree.
+
 }
+
 complete -o default -F _kw_autocomplete kw


### PR DESCRIPTION
The idea to fix Issue #458 is to use two bash features to improve the autocompletion for all features: using arrays that work as a hash map and `mapfile` to read a string and generate an array of possible combinations. This commit is only a proof-of-concept (as it only covers the base `kw` command and the `build` / `b` feature). If this idea is accepted, we can work on replicating it for the rest of the features.

While testing the autocompletion, we realized that adding both the full name options and the short name equivalents (like `kw build` and `kw b`) cluttered the screen without adding any information, so we suggest hiding them from the autocompletion. This does not make the autocompletion stop working if the user types a short name command. Also, the user can still find out about short name equivalents by adding the `--help` flag on each feature, so it's not hidden from them.

Examples:

Without the short name equivalents:

![Image](https://user-images.githubusercontent.com/32470473/137414573-53f87102-bbd4-4a15-b8fd-535da1d3949b.png)

![image](https://user-images.githubusercontent.com/32470473/137414662-1c942ef3-b3bd-43ea-a345-e6ed28c3cbab.png)

![image](https://user-images.githubusercontent.com/32470473/137414723-93f6080e-6384-4390-b6f3-8d3cd91658ba.png)

Can we cut out the short name equivalents for all features or is it preferred to keep both possibilities?