### PR TITLE
tests: kw_time_and_date_test: fix bug

### DIFF
--- a/tests/kw_time_and_date_test.sh
+++ b/tests/kw_time_and_date_test.sh
@@ -30,12 +30,18 @@ function test_get_today_info()
   local today
 
   today=$(date +%Y/%m/%d)
-  formated_today=$(get_today_info '+%Y/%m/%d')
-  assert_equals_helper 'Today info did not match' "$LINENO" "$today" "$formated_today"
+  formatted_today=$(get_today_info '+%Y/%m/%d')
+  assert_equals_helper 'Today info did not match' "$LINENO" "$today" "$formatted_today"
 
-  formated_today=$(get_today_info)
   today=$(date)
-  assert_equals_helper 'No parameter' "$LINENO" "$today" "$formated_today"
+  formatted_today=$(get_today_info)
+
+  if [[ "$today" != "$formatted_today" ]]; then
+    today=$(date)
+    formatted_today=$(get_today_info)
+  fi
+
+  assert_equals_helper 'No parameter' "$LINENO" "$today" "$formatted_today"
 }
 
 function test_get_week_beginning_day()


### PR DESCRIPTION
The function test_get_today_info sometimes failed when a second passed
between calling date and get_today_info functions. Solves #308

Adds a new variable to check the date return before and after the
calling of the get_today_info function. Checks if they are the same
and, if they are not, repeat the process. Assuring that both calls
were made in the same second.

It was also considered to use a while loop instead of an if, but
to avoid problems with possible endless loops, this solution
was disregarded.

Signed-off-by: Paulo Guilherme <pauloguilherme@usp.br>
Co-authored-by: Lucas Cardoso <lucas.cardoso.santos@usp.br>