### PR TITLE
docs: dependencies: add missing send-email deps

### DIFF
--- a/documentation/dependencies/arch.dependencies
+++ b/documentation/dependencies/arch.dependencies
@@ -19,3 +19,5 @@ zstd
 xz
 python-pip
 bc
+perl-authen-sasl
+perl-io-socket-ssl

--- a/documentation/dependencies/debian.dependencies
+++ b/documentation/dependencies/debian.dependencies
@@ -21,3 +21,4 @@ xz-utils
 lzop
 zstd
 bc
+git-email


### PR DESCRIPTION
The files created to store the dependencies were created while I worked
on the mail feature, because of this I forgot to add the dependencies
related to `git send-email`.

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@usp.br>