### PR TITLE
Add interaction support to init.sh for ssh setup and remote config

### DIFF
--- a/documentation/man/features/init.rst
+++ b/documentation/man/features/init.rst
@@ -29,6 +29,12 @@ OPTIONS
   Set the variable `default_deploy_target` from **kworkflow.config** to
   *<target>*, which can be any of vm, local or remote.
 
+\--interactive:
+  Initiates interactive setup mode. In this mode, kw will suggest a series of
+  configurations, explaining their purpose and recommending default options.
+  User confirmation and input is required to configure every feature.
+  Recommended for first time users.
+
 EXAMPLES
 ========
 For these examples, we suppose that the kernel directory is your current

--- a/src/init.sh
+++ b/src/init.sh
@@ -229,5 +229,6 @@ function init_help()
     '  init - Creates a kworkflow.config file in the current directory.' \
     '  init --arch <arch> - Set the arch field in the kworkflow.config file.' \
     '  init --remote <user>@<ip>:<port> - Set remote fields in the kworkflow.config file.' \
-    '  init --target <target> Set the default_deploy_target field in the kworkflow.config file'
+    '  init --target <target> Set the default_deploy_target field in the kworkflow.config file' \
+    '  init --interactive - Perform first time setup in an interactive manner. Recommended for new users.'
 }

--- a/src/init.sh
+++ b/src/init.sh
@@ -39,6 +39,13 @@ function init_kw()
 
   if [[ "${options_values['INTERACTIVE']}" ]]; then
 
+    say 'Welcome to the interactive mode!'     
+    say 'We will ask you a series of questions regarding how do you want to configure kernel workflow.'
+    say 'Before each question there will be a brief explanation of the feature and why it is used.'
+    say 'This is not exhaustive, we recommend you search for more information online.'
+    say 'Please follow the prompts to continue.'
+    echo 
+    
     local cmd=''
     local distro=''
     local has_ssh
@@ -46,10 +53,23 @@ function init_kw()
 
     distro=$(detect_distro '/')
 
+    say 'We will now setup SSH.'
+    say 'SSH stands for Secure Shell and is a networking protocol used for' 
+    say 'operating network services securely over an unsecured network.'
+    say 'This is useful if you want to deploy a kernel remotely or inside a virtual machine (VM).'
+    say 'Deploying in a remote machine or VM is recommended so you do not break your own kernel.'
+    say 'For a tutorial on how to setup a VM compatible with KW refer to:' 
+    say 'https://flusp.ime.usp.br/others/use-qemu-to-play-with-linux/'
+    say 'KW will now attempt to automatically locate SSH.'
+    warning 'If your Linux distribution is not Debian or Arch this will likely fail.'
+    warning 'We do not support any other distributions (yet).'
+    warning 'We strongly recommend using one of these distributions to work with KW.'
+    echo
+
     case "$distro" in
       none)
         warning "We do not support your distro (yet). We cannot check if SSH is installed."
-	if [[ $(ask_yN "Do you wish to proceed without configuring SSH?") =~ '0' ]]; then
+	      if [[ $(ask_yN "Do you wish to proceed without configuring SSH?") =~ '0' ]]; then
           exit 0
         fi
         ;;

--- a/src/init.sh
+++ b/src/init.sh
@@ -26,7 +26,9 @@ function init_kw()
 
   if ! is_kernel_root "$PWD"; then
     complain 'This command should be run in a kernel tree.'
-    exit 125 # ECANCELED
+    if [[ $(ask_yN "Do you want to continue?") =~ '0' ]]; then
+    	exit 125 # ECANCELED
+    fi
   fi
 
   parse_init_options "$@"
@@ -47,7 +49,7 @@ function init_kw()
     case "$distro" in
       none)
         warning "We do not support your distro (yet). We cannot check if SSH is installed."
-        if [[ $(ask_yN "Do you wish to proceed without configuring SSH?" =~ '0') ]]; then
+	if [[ $(ask_yN "Do you wish to proceed without configuring SSH?") =~ '0' ]]; then
           exit 0
         fi
         ;;

--- a/src/init.sh
+++ b/src/init.sh
@@ -27,7 +27,7 @@ function init_kw()
   if ! is_kernel_root "$PWD"; then
     complain 'This command should be run in a kernel tree.'
     if [[ $(ask_yN "Do you want to continue?") =~ '0' ]]; then
-    	exit 125 # ECANCELED
+      exit 125 # ECANCELED
     fi
   fi
 
@@ -39,13 +39,13 @@ function init_kw()
 
   if [[ "${options_values['INTERACTIVE']}" ]]; then
 
-    say 'Welcome to the interactive mode!'     
+    say 'Welcome to the interactive mode!'
     say 'We will ask you a series of questions regarding how do you want to configure kernel workflow.'
     say 'Before each question there will be a brief explanation of the feature and why it is used.'
     say 'This is not exhaustive, we recommend you search for more information online.'
     say 'Please follow the prompts to continue.'
-    echo 
-    
+    echo
+
     local cmd=''
     local distro=''
     local has_ssh
@@ -54,11 +54,11 @@ function init_kw()
     distro=$(detect_distro '/')
 
     say 'We will now setup SSH.'
-    say 'SSH stands for Secure Shell and is a networking protocol used for' 
+    say 'SSH stands for Secure Shell and is a networking protocol used for'
     say 'operating network services securely over an unsecured network.'
     say 'This is useful if you want to deploy a kernel remotely or inside a virtual machine (VM).'
     say 'Deploying in a remote machine or VM is recommended so you do not break your own kernel.'
-    say 'For a tutorial on how to setup a VM compatible with KW refer to:' 
+    say 'For a tutorial on how to setup a VM compatible with KW refer to:'
     say 'https://flusp.ime.usp.br/others/use-qemu-to-play-with-linux/'
     say 'KW will now attempt to automatically locate SSH.'
     warning 'If your Linux distribution is not Debian or Arch this will likely fail.'
@@ -69,7 +69,7 @@ function init_kw()
     case "$distro" in
       none)
         warning "We do not support your distro (yet). We cannot check if SSH is installed."
-	      if [[ $(ask_yN "Do you wish to proceed without configuring SSH?") =~ '0' ]]; then
+        if [[ $(ask_yN "Do you wish to proceed without configuring SSH?") =~ '0' ]]; then
           exit 0
         fi
         ;;


### PR DESCRIPTION
In this commit we modified init.sh to look for the --interactive
(or -i) options when parsing arguments. If these options are found,
the script will attempt to interactively detect and setup SSH in
the user's system. Prompts are added to allow the user to interact
with this process and skip steps if desired. We also added an
interactive configuration step for the user's remote connection
settings after SSH is setup. These functionalities are intended to
provide a better user experience for new users who may never have
setup KW before. Functionalities yet to be implemented for this
goal are commented with a #TODO: in the body of the script.

Co-authored-by: Miguel de Mello Carpi <49130937+melloguel@users.noreply.github.com>
Co-authored-by: Lourenço Henrique Moinheiro Martins Sborz Bogo <62181861+louhmmsb@users.noreply.github.com>
Co-authored-by: Eduardo Brancher Urenha <49043437+EduBrancher@users.noreply.github.com>