### PR TITLE
kw: fix help text and man page in main

### DIFF
--- a/kw
+++ b/kw
@@ -168,7 +168,14 @@ function kw()
         execute_config_manager "$@"
       )
       ;;
-    help | h)
+    help | --help)
+      (
+        include "$KW_LIB_DIR/help.sh"
+
+        kworkflow_man
+      )
+      ;;
+    h | -h)
       (
         include "$KW_LIB_DIR/help.sh"
 


### PR DESCRIPTION
There was no difference between 'kw help' and 'kw h', now using the long
option brings up the kw man page. Also adds 'kw --help' and 'kw -h'

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@usp.br>