### PR TITLE
src: improve usability in ask_yN

### DIFF
--- a/src/kwio.sh
+++ b/src/kwio.sh
@@ -99,20 +99,35 @@ function success()
   colored_print GREENCOLOR "$@"
 }
 
-# Ask for yes or no
+# Allows the user to select a given question with yes or no answers. Shows a
+# default option (as a capitalized letter). If the user inserts anything
+# different from a "y" or a "yes" (capitalization doesn't matter here) it will
+# be treated as a "no".
 #
 # @message A string with the message to be displayed for the user.
+# @default_option A string (simply y or n) to set the default answer for the
+#                 user. If this parameter is not given, or if it is invalid, 'n'
+#                 will be used.
 #
-# Returns:
+# Return:
 # Return "1" if the user accept the question, otherwise, return "0"
-#
 # Note: ask_yN return the string '1' and '0', you have to handle it by
 # yourself in the code.
 function ask_yN()
 {
-  local message="$*"
+  local message="$1"
+  local default_option="${2:-'n'}"
+  local yes='y'
+  local no='N'
 
-  read -r -p "$message [y/N] " response
+  if [[ "$default_option" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
+    yes='Y'
+    no='n'
+  fi
+
+  message="$message [$yes/$no]"
+  response=$(ask_with_default "$message" "$default_option" false)
+
   if [[ "$response" =~ ^([yY][eE][sS]|[yY])+$ ]]; then
     printf '%s\n' '1'
   else

--- a/src/kwio.sh
+++ b/src/kwio.sh
@@ -119,3 +119,41 @@ function ask_yN()
     printf '%s\n' '0'
   fi
 }
+
+# Asks for user input
+#
+# @message A string with the message to be displayed to the user.
+# @default_option String with default answer to be used if no input is given.
+# @show_default A string that defines if the default value will be printed to
+#               the user. Any non-empty value causes this behavior to be false.
+# @flag String to mark special conditions in this function. To activate the test
+#       mode, set this to 'TEST_MODE'.
+#
+# Return:
+# The user answer, guaranteed not to be empty.
+# Note: this function does not verify the given answer. You have to handle this
+# somewhere else.
+function ask_with_default()
+{
+  local message="$1"
+  local default_option="$2"
+  local show_default="$3"
+  local flag="$4"
+  local value
+
+  if [[ -z "$show_default" ]]; then
+    message+=" ($default_option)"
+  fi
+  message+=': '
+
+  [[ "$flag" == 'TEST_MODE' ]] && printf '%s\n' "$message"
+
+  read -r -p "$message" response
+
+  if [[ "$?" -ne 0 || -z "$response" ]]; then
+    printf '%s\n' "$default_option"
+    return
+  fi
+
+  printf '%s\n' "$response"
+}

--- a/tests/kwio_test.sh
+++ b/tests/kwio_test.sh
@@ -124,4 +124,33 @@ function test_alert_completion_sound_alert()
   assertEquals 'Variable s should exist.' "$expected" "$output"
 }
 
+function test_ask_with_default()
+{
+  local output=''
+  local expected_output=''
+  local assert_equals_message=''
+
+  # Default option showing
+  expected_output=$'Insert something here (lala): \nsomething'
+  assert_equals_message='Default answer and user answer are different.'
+  output=$(printf 'something\n' | ask_with_default 'Insert something here' 'lala' '' 'TEST_MODE')
+  assert_equals_helper "$assert_equals_message" "$LINENO" "$expected_output" "$output"
+
+  expected_output=$'Insert something here (lala): \nlala'
+  assert_equals_message='User selected default answer.'
+  output=$(printf '\n' | ask_with_default 'Insert something here' 'lala' '' 'TEST_MODE')
+  assert_equals_helper "$assert_equals_message" "$LINENO" "$expected_output" "$output"
+
+  # Default option not showing (third parameter not empty)
+  expected_output=$'Insert something here: \nsomething'
+  assert_equals_message='Not showing default answer, user answered different.'
+  output=$(printf 'something\n' | ask_with_default 'Insert something here' 'lala' 'false' 'TEST_MODE')
+  assert_equals_helper "$assert_equals_message" "$LINENO" "$expected_output" "$output"
+
+  expected_output=$'Insert something here: \nlala'
+  assert_equals_message='Not showing default answer, user selected it.'
+  output=$(printf '\n' | ask_with_default 'Insert something here' 'lala' 'false' 'TEST_MODE')
+  assert_equals_helper "$assert_equals_message" "$LINENO" "$expected_output" "$output"
+}
+
 invoke_shunit

--- a/tests/kwio_test.sh
+++ b/tests/kwio_test.sh
@@ -153,4 +153,88 @@ function test_ask_with_default()
   assert_equals_helper "$assert_equals_message" "$LINENO" "$expected_output" "$output"
 }
 
+function test_ask_yN()
+{
+  local assert_equals_message=''
+
+  assert_equals_message='Default answer: no, user answer: y'
+  output=$(printf 'y\n' | ask_yN 'Test message')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '1' "$output"
+
+  assert_equals_message='Default answer: no, user answer: Y'
+  output=$(printf 'Y\n' | ask_yN 'Test message')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '1' "$output"
+
+  assert_equals_message='Default answer: no, user answer: Yes'
+  output=$(printf 'Yes\n' | ask_yN 'Test message')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '1' "$output"
+
+  assert_equals_message='Default answer: no, user answer: invalid (sim)'
+  output=$(printf 'Sim\n' | ask_yN 'Test message')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '0' "$output"
+
+  assert_equals_message='Default answer: no, user answer: No'
+  output=$(printf 'No\n' | ask_yN 'Test message')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '0' "$output"
+
+  assert_equals_message='Default answer: no, user answer: N'
+  output=$(printf 'N\n' | ask_yN 'Test message')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '0' "$output"
+
+  # Tests with default option selected
+  assert_equals_message='Default answer: N, user answer: y'
+  output=$(printf 'y\n' | ask_yN 'Test message' 'N')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '1' "$output"
+
+  assert_equals_message='Default answer: y, user answer: Y'
+  output=$(printf 'Y\n' | ask_yN 'Test message' 'y')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '1' "$output"
+
+  assert_equals_message='Default answer: y, user answer: default'
+  output=$(printf '\n' | ask_yN 'Test message' 'y')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '1' "$output"
+
+  assert_equals_message='Default answer: Y, user answer: n'
+  output=$(printf 'n\n' | ask_yN 'Test message' 'Y')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '0' "$output"
+
+  assert_equals_message='Default answer: n, user answer: N'
+  output=$(printf 'N\n' | ask_yN 'Test message' 'n')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '0' "$output"
+
+  assert_equals_message='Default answer: n, user anser: default'
+  output=$(printf '\n' | ask_yN 'Test message' 'n')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '0' "$output"
+
+  # Invalid default
+  assert_equals_message='Default answer: invalid (lala), user answer: default'
+  output=$(printf '\n' | ask_yN 'Test message' 'lala')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '0' "$output"
+
+  assert_equals_message='Default answer: invalid (lala), user answer: n'
+  output=$(printf 'n\n' | ask_yN 'Test message' 'lala')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '0' "$output"
+
+  assert_equals_message='Default answer: invalid (lala), user answer: y'
+  output=$(printf 'y\n' | ask_yN 'Test message' 'lala')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '1' "$output"
+
+  assert_equals_message='Default answer: invalid (lalaYes), user answer: default (no)'
+  output=$(printf '\n' | ask_yN 'Test message' 'lalaYes')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '0' "$output"
+
+  assert_equals_message='Default answer: invalid (lalaNo), user answer: default (no)'
+  output=$(printf '\n' | ask_yN 'Test message' 'lalaNo')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '0' "$output"
+
+  # Invalid answer
+  assert_equals_message='Default answer: invalid (lala), user answer: no (invalid: lalaYes)'
+  output=$(printf 'lalaYes\n' | ask_yN 'Test message' 'lala')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '0' "$output"
+
+  assert_equals_message='Default answer: invalid (lala), user answer: no (invalid: lalano)'
+  output=$(printf 'lalano\n' | ask_yN 'Test message' 'lala')
+  assert_equals_helper "$assert_equals_message" "$LINENO" '0' "$output"
+}
+
 invoke_shunit

--- a/tests/plugins/kernel_install/utils_test.sh
+++ b/tests/plugins/kernel_install/utils_test.sh
@@ -47,29 +47,6 @@ function test_cmd_manager()
   assert_equals_helper 'TEST_MODE' "$LINENO" 'ls something' "$output"
 }
 
-function test_ask_yN()
-{
-  local count=0
-
-  output=$(printf '%s\n' 'y' | ask_yN 'Test message')
-  assert_equals_helper 'TEST_MODE' "$LINENO" '1' "$output"
-
-  output=$(printf '%s\n' 'Y' | ask_yN 'Test message')
-  assert_equals_helper 'TEST_MODE' "$LINENO" '1' "$output"
-
-  output=$(printf '%s\n' 'Yes' | ask_yN 'Test message')
-  assert_equals_helper 'TEST_MODE' "$LINENO" '1' "$output"
-
-  output=$(printf '%s\n' 'Sim' | ask_yN 'Test message')
-  assert_equals_helper 'TEST_MODE' "$LINENO" '0' "$output"
-
-  output=$(printf '%s\n' 'No' | ask_yN 'Test message')
-  assert_equals_helper 'TEST_MODE' "$LINENO" '0' "$output"
-
-  output=$(printf '%s\n' 'N' | ask_yN 'Test message')
-  assert_equals_helper 'TEST_MODE' "$LINENO" '0' "$output"
-}
-
 function test_human_list_installed_kernels()
 {
   declare -a expected_out=(


### PR DESCRIPTION
There was no way to select a default answer in ask_yN and to
change what letter would be capitalized. The pattern, in other
Bash applications, is to use the capitalized letter as a default
answer, so the user must only press ENTER to select it.

Add a second parameter to change the default option, capitalizing
the letter corresponding to it. Also, add a first test in the
user's answer to check if the answer is empty. This allows the user
to select the default answer by typing anything.

Signed-off-by: Lucas Cardoso <lucas.cardoso.santos@usp.br>
Co-authored-by: Paulo Guilherme <pauloguilherme@usp.br>