### PR TITLE
src: kw_include: fix dashed variables naming

### DIFF
--- a/src/kw_include.sh
+++ b/src/kw_include.sh
@@ -25,6 +25,7 @@ function include()
   varname="${varname//\//_}"          # change bars to underlines
   varname="${varname//\./_}"          # change dots into underscores
   varname="${varname// /_}"           # change spaces into underscores
+  varname="${varname//-/_}"           # change dashes into underscores
   varname="${varname^^}_IMPORTED"     # capitalize and append "_IMPORTED"
 
   if [[ -v "${varname}" ]]; then

--- a/tests/kw_include_test.sh
+++ b/tests/kw_include_test.sh
@@ -21,6 +21,7 @@ function oneTimeSetUp()
     "$KW_INC_TEST_HIDDEN_PATH/include_test.sh"
     "$KW_INC_TEST_SPACED_PATH/include_spaced.sh"
     "$KW_INC_TEST_PATH/include_test.sh"
+    "$KW_INC_TEST_PATH/include-dashed.sh"
   )
 
   touch "${test_files[@]}"
@@ -93,6 +94,12 @@ function test_include_hidden_files()
 function test_include_spaced_path()
 {
   include "$KW_INC_TEST_SPACED_PATH/include_spaced.sh"
+  assertEquals "($LINENO)" 0 "$?"
+}
+
+function test_include_dashed_path()
+{
+  include "$KW_INC_TEST_PATH/include-dashed.sh"
   assertEquals "($LINENO)" 0 "$?"
 }
 


### PR DESCRIPTION
This fixes `bash`'s declare function errors that occur when the included path has dashes on it (see #510).

