### PR TITLE
fix broken tests

### DIFF
--- a/src/diff.sh
+++ b/src/diff.sh
@@ -106,7 +106,10 @@ function diff_side_by_side()
   local diff_cmd
   local columns
 
-  columns=$(tput cols)
+  # In case TERM is gibberish tput won't work properly
+  # specify dummy terminal option to manage that
+  [[ "$TERM" == '' || "$TERM" == 'dumb' ]] && TPUTTERM=' -T xterm-256color'
+  columns=$(eval tput"${TPUTTERM}" cols)
   diff_cmd="diff -y --color=always --width=$columns"
   flag=${flag:-''}
 

--- a/tests/build_test.sh
+++ b/tests/build_test.sh
@@ -68,7 +68,7 @@ function test_kernel_build()
   ret="$?"
   assertEquals "($LINENO)" "$ret" "22"
 
-  output=$(kernel_build 'TEST_MODE' | head -1) # Remove statistics output
+  output=$(kernel_build 'TEST_MODE' | tail -n +1 | head -1) # Remove statistics output
   expected_result="make -j$PARALLEL_CORES ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu-"
   assertEquals "($LINENO)" "$expected_result" "${output}"
 
@@ -90,7 +90,7 @@ function test_kernel_build()
     return
   }
 
-  output=$(kernel_build 'TEST_MODE' | head -1) # Remove statistics output
+  output=$(kernel_build 'TEST_MODE' | tail -n +1 | head -1) # Remove statistics output
   expected_result="make -j$PARALLEL_CORES ARCH=x86_64"
   assertEquals "($LINENO)" "$expected_result" "${output}"
 

--- a/tests/build_test.sh
+++ b/tests/build_test.sh
@@ -17,6 +17,7 @@ oneTimeSetUp()
 {
   original_dir="$PWD"
   FAKE_KERNEL="$SHUNIT_TMPDIR"
+  KW_DATA_DIR="$SHUNIT_TMPDIR"
   mk_fake_kernel_root "$FAKE_KERNEL"
 
   parse_configuration "$KW_CONFIG_SAMPLE"

--- a/tests/configm_test.sh
+++ b/tests/configm_test.sh
@@ -474,18 +474,20 @@ function test_get_config_from_proc()
   assert_equals_helper 'proc/config.gz is not supported for VM' "$LINENO" "$?" 95
 
   # 2) Local
+  # Mocking non-existent proc
+  mkdir 'proc'
+  export PROC_CONFIG_PATH='proc/config.gz'
+
   declare -la expected_cmd=(
-    'sudo modprobe -q configs && [ -s /proc/config.gz ]'
+    'sudo modprobe -q configs && [ -s proc/config.gz ]'
     'zcat /proc/config.gz > .config'
   )
 
   output=$(get_config_from_proc 'TEST_MODE' '.config' 2)
   compare_command_sequence 'expected_cmd' "$output" "$LINENO"
 
-  # Creating a fake proc
-  mkdir "proc"
+  # Creating a fake config
   touch "proc/config.gz"
-  export PROC_CONFIG_PATH="proc/config.gz"
 
   expected_cmd=()
   declare -a expected_cmd=(

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -333,13 +333,15 @@ function test_kernel_install_x86_64()
 
   # Test kernel image infer
   configurations['kernel_img_name']=''
-  output=$(run_kernel_install 1 'test' 'TEST_MODE' 3 '127.0.0.1:3333' | head -1)
+  output=$(run_kernel_install 1 'test' 'TEST_MODE' 3 '127.0.0.1:3333' |
+    tail -n +1 | head -1)
   expected_msg='kw inferred arch/x86_64/boot/arch/x86_64/boot/bzImage as a kernel image'
   assert_equals_helper "Infer kernel image" "$LINENO" "$expected_msg" "$output"
 
   # Test failures
   rm -rf arch/x86_64/
-  output=$(run_kernel_install 1 'test' 'TEST_MODE' 3 '127.0.0.1:3333' | head -1)
+  output=$(run_kernel_install 1 'test' 'TEST_MODE' 3 '127.0.0.1:3333' |
+    tail -n +1 | head -1)
   expected_msg='We could not find a valid kernel image at arch/x86_64/boot'
   assertEquals "($LINENO): " "$output" "$expected_msg"
   assert_equals_helper "Could not find a valid image" "$LINENO" "$expected_msg" "$output"

--- a/tests/diff_test.sh
+++ b/tests/diff_test.sh
@@ -11,7 +11,8 @@ function test_diff_side_by_side()
   local columns
   local diff_cmd
 
-  columns=$(tput cols)
+  [[ "$TERM" == '' || "$TERM" == 'dumb' ]] && TPUTTERM=' -T xterm-256color'
+  columns=$(eval tput"${TPUTTERM}" cols)
   diff_cmd="diff -y --color=always --width=$columns $file_1 $file_2 | less -R"
 
   declare -a expected_cmd=(

--- a/tests/init_test.sh
+++ b/tests/init_test.sh
@@ -93,7 +93,7 @@ function test_init_kw()
   assertEquals "($LINENO)" 'default_deploy_target=local' "$kworkflow_content"
 
   rm -rf "${path:?}"/*
-  output=$(init_kw --target dartboard | head -n 1)
+  output=$(init_kw --target dartboard | tail -n +1 | head -n 1)
   kworkflow_content=$(grep default_deploy_target= "$path_config")
   assertEquals "($LINENO)" 'Target can only be vm, local or remote.' "$output"
 


### PR DESCRIPTION
This attemps at fixing the broken pipe error that occurs in the project's CI [1], the broken local config manager test and also `tput`'s behavior in a non-configured environment [2].

Attempted fixes:
[1] - _https://superuser.com/questions/554855/how-can-i-fix-a-broken-pipe-error_
[2] - _https://stackoverflow.com/questions/48536791/error-tput-no-value-for-term-and-no-t-specified_

Fixes: #484, #499, #517.