### PR TITLE
src: plugins: kernel_install: Fix uninstall bugs

### DIFF
--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -476,7 +476,8 @@ function run_kernel_uninstall()
       # TODO
       # It would be better if `cmd_remotely` handle the extra space added by
       # line break with `\`; this may allow us to break a huge line like this.
-      local cmd="bash $REMOTE_KW_DEPLOY/remote_deploy.sh --uninstall_kernel '' '$reboot' remote '$kernels_target' '$flag' '$force'"
+      local cmd="bash $REMOTE_KW_DEPLOY/remote_deploy.sh --uninstall_kernel '$reboot' remote '$kernels_target' '$flag' '$force'"
+
       cmd_remotely "$cmd" "$flag" "$remote" "$port"
       ;;
   esac

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -540,7 +540,7 @@ function test_kernel_uninstall()
   local single_kernel='5.7.0-rc2'
 
   # Rsync script command
-  local cmd="bash $remote_path/remote_deploy.sh --uninstall_kernel '' '0' remote '$kernel_list' 'TEST_MODE' ''"
+  local cmd="bash $remote_path/remote_deploy.sh --uninstall_kernel '0' remote '$kernel_list' 'TEST_MODE' ''"
   local run_kernel_uninstall_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"$cmd\""
 
   cd "$FAKE_KERNEL" || {
@@ -557,14 +557,14 @@ function test_kernel_uninstall()
   assert_equals_helper 'Standard uninstall' "$LINENO" "$run_kernel_uninstall_cmd" "$output"
   # Reboot
   output=$(run_kernel_uninstall 3 1 "$kernel_list" 'TEST_MODE')
-  cmd="bash $remote_path/remote_deploy.sh --uninstall_kernel '' '1' remote '$kernel_list' 'TEST_MODE' ''"
+  cmd="bash $remote_path/remote_deploy.sh --uninstall_kernel '1' remote '$kernel_list' 'TEST_MODE' ''"
   run_kernel_uninstall_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"$cmd\""
   assert_equals_helper 'Reboot option' "$LINENO" "$run_kernel_uninstall_cmd" "$output"
 
   # Single kernel
   output=$(run_kernel_uninstall 3 1 "$single_kernel" 'TEST_MODE')
 
-  cmd="bash $remote_path/remote_deploy.sh --uninstall_kernel '' '1' remote '$single_kernel' 'TEST_MODE' ''"
+  cmd="bash $remote_path/remote_deploy.sh --uninstall_kernel '1' remote '$single_kernel' 'TEST_MODE' ''"
   run_kernel_uninstall_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"$cmd\""
   assert_equals_helper 'Reboot option' "$LINENO" "$run_kernel_uninstall_cmd" "$output"
 


### PR DESCRIPTION
The uninstall feature in the deploy is broken due to the wrong sequence
in the parameter for removing a kernel in the target machine.
Additionally, the script responsible for removing kernel files made some
incorrect assumptions. This commit fixes these problems and updates the
unit test to make sure that we better check the uninstall behavior.

Signed-off-by: Rodrigo Siqueira <rodrigosiqueiramelo@gmail.com>