### PR TITLE
src: report: Compatibility of statistiscs with output option

### DIFF
--- a/documentation/man/features/report.rst
+++ b/documentation/man/features/report.rst
@@ -57,6 +57,14 @@ OPTIONS
 \--year[=<year>]:
   Exhibits the current year summary if the user does not specify *<year>*.
 
+\--all:
+  Display all information for the current date. You can choose the date and 
+  range with date options. 
+
+\--pomodoro:
+  Display current date pomodoro report. You can choose the date and range
+  with date options. 
+
 \--statistics:
   Display statistics for the current date. You can choose the date and range
   with date options. 
@@ -79,6 +87,16 @@ some examples below:
   kw report --month
   kw report --year
 
+  kw report --all --day
+  kw report --all --week
+  kw report --all --month
+  kw report --all --year
+
+  kw report --pomodoro --day
+  kw report --pomodoro --week
+  kw report --pomodoro --month
+  kw report --pomodoro --year
+
   kw report --statistics --day
   kw report --statistics --week
   kw report --statistics --month
@@ -90,6 +108,16 @@ You can also request a specific day, week, month, or year. For example::
   kw report --week=2020/02/29
   kw report --month=2020/04
   kw report --year=1984
+
+  kw report --all --day=2020/05/12
+  kw report --all --week=2020/02/29
+  kw report --all --month=2020/04
+  kw report --all --year=1984
+
+  kw report --pomodoro --day=2020/05/12
+  kw report --pomodoro --week=2020/02/29
+  kw report --pomodoro --month=2020/04
+  kw report --pomodoro --year=1984
 
   kw report --statistics --day=2020/05/12
   kw report --statistics --week=2020/02/29

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -54,7 +54,7 @@ function _kw_autocomplete()
   kw_options['pomodoro']='--description --list --set-timer --tag'
   kw_options['p']="${kw_options['pomodoro']}"
 
-  kw_options['report']='--day --month --output --week --year --statistics'
+  kw_options['report']='--day --pomodoro --all --month --output --week --year --statistics'
   kw_options['r']="${kw_options['report']}"
 
   kw_options['ssh']='--command --script'

--- a/src/report.sh
+++ b/src/report.sh
@@ -12,6 +12,7 @@ declare -g KW_POMODORO_DATA="$KW_DATA_DIR/pomodoro"
 declare -gA options_values
 declare -gA tags_details
 declare -gA tags_metadata
+declare -g statistics_data
 
 function report_main()
 {
@@ -29,32 +30,24 @@ function report_main()
     return 22 # EINVAL
   fi
 
-  if [[ "${options_values['STATISTICS']}" == 1 ]]; then
-    show_statistics
-    return
-  elif [[ -n "${options_values['DAY']}" ]]; then
-    grouping_day_data "${options_values['DAY']}"
-    target_time="${options_values['DAY']}"
-  elif [[ -n "${options_values['WEEK']}" ]]; then
-    target_time="${options_values['WEEK']}"
-    grouping_week_data "${options_values['WEEK']}"
-  elif [[ -n "${options_values['MONTH']}" ]]; then
-    target_time="${options_values['MONTH']}"
-    grouping_month_data "${options_values['MONTH']}"
-  elif [[ -n "${options_values['YEAR']}" ]]; then
-    target_time="${options_values['YEAR']}"
-    grouping_year_data "${options_values['YEAR']}"
+  if [[ -n "${options_values['STATISTICS']}" ]]; then
+    run_statistics
+  fi
+
+  if [[ -n "${options_values['POMODORO']}" ]]; then
+    run_pomodoro
   fi
 
   if [[ -z "${options_values['OUTPUT']}" ]]; then
-    show_data "$target_time"
+    [[ -n "${options_values['POMODORO']}" ]] && show_data "$target_time"
+    [[ -n "${options_values['STATISTICS']}" ]] && show_statistics
   else
     save_data_to "${options_values['OUTPUT']}"
   fi
 }
 
 # Call the statistics based on the options_values
-function show_statistics()
+function run_statistics()
 {
   if [[ "${configurations[disable_statistics_data_track]}" == 'yes' ]]; then
     say 'You have disable_statistics_data_track marked as "yes"'
@@ -63,13 +56,36 @@ function show_statistics()
   fi
 
   if [[ -n "${options_values['DAY']}" ]]; then
-    day_statistics "${options_values['DAY']}"
+    statistics_data=$(day_statistics "${options_values['DAY']}")
   elif [[ -n "${options_values['WEEK']}" ]]; then
-    week_statistics "${options_values['WEEK']}"
+    statistics_data=$(week_statistics "${options_values['WEEK']}")
   elif [[ -n "${options_values['MONTH']}" ]]; then
-    month_statistics "${options_values['MONTH']}"
+    statistics_data=$(month_statistics "${options_values['MONTH']}")
   elif [[ -n "${options_values['YEAR']}" ]]; then
-    year_statistics "${options_values['YEAR']}"
+    statistics_data=$(year_statistics "${options_values['YEAR']}")
+  fi
+}
+
+function show_statistics()
+{
+  printf "# Statistics: %s\n" "$date"
+  printf "%s\n\n" "$statistics_data"
+}
+
+function run_pomodoro()
+{
+  if [[ -n "${options_values['DAY']}" ]]; then
+    target_time="${options_values['DAY']}"
+    grouping_day_data "$target_time"
+  elif [[ -n "${options_values['WEEK']}" ]]; then
+    target_time="${options_values['WEEK']}"
+    grouping_week_data "$target_time"
+  elif [[ -n "${options_values['MONTH']}" ]]; then
+    target_time="${options_values['MONTH']}"
+    grouping_month_data "$target_time"
+  elif [[ -n "${options_values['YEAR']}" ]]; then
+    target_time="${options_values['YEAR']}"
+    grouping_year_data "$target_time"
   fi
 }
 
@@ -326,14 +342,16 @@ function save_data_to()
     exit "$ret"
   fi
 
-  show_data > "$path"
+  truncate -s 0 "$path"
+  [[ -n "${options_values['POMODORO']}" ]] && show_data "$target_time" >> "$path"
+  [[ -n "${options_values['STATISTICS']}" ]] && show_statistics >> "$path"
 }
 
 function parse_report_options()
 {
   local reference_count=0
-  local long_options='day::,week::,month::,year::,output:,statistics'
-  local short_options='o:,s'
+  local long_options='day::,week::,month::,year::,output:,statistics,pomodoro,all'
+  local short_options='o:,s,p,a'
   local options
 
   options="$(kw_parse "$short_options" "$long_options" "$@")"
@@ -349,6 +367,7 @@ function parse_report_options()
   options_values['YEAR']=''
   options_values['OUTPUT']=''
   options_values['STATISTICS']=''
+  options_values['POMODORO']=''
 
   eval "set -- $options"
 
@@ -418,6 +437,15 @@ function parse_report_options()
         options_values['STATISTICS']=1
         shift
         ;;
+      --pomodoro | -p)
+        options_values['POMODORO']=1
+        shift
+        ;;
+      --all | -a)
+        options_values['STATISTICS']=1
+        options_values['POMODORO']=1
+        shift
+        ;;
       --)
         shift
         ;;
@@ -429,9 +457,9 @@ function parse_report_options()
     esac
   done
 
-  if [[ -n "${options_values['STATISTICS']}" ]] && [[ -n "${options_values['OUTPUT']}" ]]; then
-    options_values['ERROR']='--output cannot be used with --statistics.'
-    return 22 # EINVAL
+  if [[ -z "${options_values['STATISTICS']}" && -z "${options_values['POMODORO']}" ]]; then
+    options_values['STATISTICS']=1
+    options_values['POMODORO']=1
   fi
 
   if [[ "$reference_count" -gt 1 ]]; then
@@ -451,14 +479,11 @@ function report_help()
     return
   fi
   printf '%s\n' 'kw report:' \
-    '  report [--day[=<year>/<month>/<day>]] - Report of the day' \
-    '  report [--week[=<year>/<month>/<day>]] - Report of the week' \
-    '  report [--month[=<year>/<month>]] - Report of the month' \
-    '  report [--year[=<year>]] - Report fo the year' \
-    '  report [--output <path>] - Save report to <path>' \
-    '  report [--statistics] - Statistics for current date' \
-    '  report [--statistics [--day[=<year>/<month>/<day>]] - Statistics of given day' \
-    '  report [--statistics [--week[=<year>/<month>/<day>]] - Statistics of given week' \
-    '  report [--statistics [--month[=<month>/<day>]] - Statistics of given month' \
-    '  report [--statistics [--year[=<year>]] - Statistics of given year'
+    '  report (-p | --pomodoro) [--day | --week | --month | --year] - Pomodoro report for current date' \
+    '  report (-s | --statistics) [--day | --week | --month | --year] - Statistics for current date' \
+    '  report (-a | --all) [--day | --week | --month | --year] - Display all the information for the current date' \
+    '  report [--day[=<year>/<month>/<day>]] - Display all the information for the specified day' \
+    '  report [--week[=<year>/<month>/<day>]] - Display all the information for the specified week' \
+    '  report [--month[=<year>/<month>]] - Display all the information for the specified month' \
+    '  report [--year[=<year>]] - Display all the information for the specified year'
 }

--- a/tests/report_test.sh
+++ b/tests/report_test.sh
@@ -93,6 +93,7 @@ function test_statistics()
   declare -a expected_cmd=(
     'You have disable_statistics_data_track marked as "yes"'
     'If you want to see the statistics, change this option to "no"'
+    '# Statistics:'
   )
 
   configurations[disable_statistics_data_track]='yes'
@@ -102,7 +103,7 @@ function test_statistics()
   configurations[disable_statistics_data_track]='no'
 
   # DAY
-  msg='Currently, kw does not have any data for the present date.'
+  msg=$'# Statistics: \nCurrently, kw does not have any data for the present date.'
 
   output=$(report_main --statistics --day)
   assertEquals "($LINENO)" "$msg" "$output"
@@ -110,19 +111,19 @@ function test_statistics()
   #WEEK
   start_target_week='2021/11/14'
   end_target_week='2021/11/20'
-  msg="Sorry, kw does not have any data from $start_target_week to $end_target_week"
+  msg=$(printf "# Statistics: \nSorry, kw does not have any data from %s to %s" "$start_target_week" "$end_target_week")
 
   output=$(report_main --statistics --week=2021/11/17)
   assertEquals "($LINENO)" "$msg" "$output"
 
   #MONTH
-  msg='Currently, kw does not have any data for the present month.'
+  msg=$'# Statistics: \nCurrently, kw does not have any data for the present month.'
 
   output=$(report_main --statistics --month)
   assertEquals "($LINENO)" "$msg" "$output"
 
   #YEAR
-  msg='Currently, kw does not have any data for the requested year.'
+  msg=$'# Statistics: \nCurrently, kw does not have any data for the requested year.'
 
   output=$(report_main --statistics --year=2019)
   assertEquals "($LINENO)" "$msg" "$output"


### PR DESCRIPTION
This is a proposal solution to resolve the issue #523 and add option to select between `--statistiscs` or `--pomodoro` or both. 

Obs: This pull request depends on #506 and the commits tree will be resolved when #506 is accept.