### PR TITLE
src: init: Modify kernel tree check

### DIFF
--- a/src/init.sh
+++ b/src/init.sh
@@ -25,8 +25,10 @@ function init_kw()
   fi
 
   if ! is_kernel_root "$PWD"; then
-    complain 'This command should be run in a kernel tree.'
-    exit 125 # ECANCELED
+    warning 'This command should be run in a kernel tree.'
+    if [[ $(ask_yN 'Do you want to continue?') =~ '0' ]]; then
+      exit 125 # ECANCELED
+    fi
   fi
 
   parse_init_options "$@"

--- a/tests/init_test.sh
+++ b/tests/init_test.sh
@@ -30,7 +30,7 @@ function test_init_kw()
     "Initialized kworkflow directory in $SHUNIT_TMPDIR/$KWORKFLOW/$KW_DIR based on $USER data"
   )
 
-  output=$(init_kw)
+  output=$(printf 'n' | init_kw)
   assertEquals "($LINENO):" 'This command should be run in a kernel tree.' "$output"
 
   mk_fake_kernel_root "$SHUNIT_TMPDIR/$KWORKFLOW/"


### PR DESCRIPTION
Stops the program from exiting if a kernel tree is not found.
Queries the user for instructions on how to proceed.
Updates the test for kw init for the new behaviour.

Co-authored-by: Eduardo Brancher Urenha <eduardo.urenha@usp.br>
Co-authored-by: Miguel de Mello Carpi <miguelmello@usp.br>
Signed-off-by: Lourenço Henrique Moinheiro Martins Sborz Bogo <louhmmsb@usp.br>