### PR TITLE
src: init: Adds SSH key creation.

### DIFF
--- a/documentation/dependencies/arch.dependencies
+++ b/documentation/dependencies/arch.dependencies
@@ -22,3 +22,4 @@ bc
 perl-authen-sasl
 perl-io-socket-ssl
 sqlite3
+openssh

--- a/documentation/dependencies/debian.dependencies
+++ b/documentation/dependencies/debian.dependencies
@@ -23,3 +23,5 @@ zstd
 bc
 git-email
 sqlite3
+openssh-server
+openssh-client

--- a/src/init.sh
+++ b/src/init.sh
@@ -170,3 +170,33 @@ function init_help()
     '  init --remote <user>@<ip>:<port> - Set remote fields in the kworkflow.config file.' \
     '  init --target <target> Set the default_deploy_target field in the kworkflow.config file'
 }
+
+# This function creates a new ssh key.
+#
+# @ssh_dir  : directory where the key will be stored.
+# @key_name : this is the name of the key, usually
+#             used to avoid overwriting keys.
+#             If not given, defaults to "kw_ssh_key".
+#
+# Returns:
+# ENOTDIR                   : a file named @ssh_dir already exists and
+#                             is not a directory.
+# EEXISTS                   : key already exists.
+# ssh-keygen's return value : returns ssh-keygen's value if @ssh_dir is valid.
+function create_ssh_key()
+{
+  local ssh_dir="$1"
+  local key_name="${2:-kw_ssh_key}"
+  local path="$ssh_dir/$key_name"
+
+  if [[ -e "$ssh_dir" && ! -d "$ssh_dir" ]]; then
+    return 20 # ENOTDIR
+  fi
+
+  if [[ -e "$path" ]]; then
+    return 17 # EEXISTS
+  fi
+
+  mkdir -p "$ssh_dir"
+  ssh-keygen -q -t rsa -f "$path"
+}


### PR DESCRIPTION
This commit creates an auxiliary function to help interactive setup
in init.sh. The function creates new ssh keys. Also adds openssh to
the dependencies list for arch and debian.

Co-authored-by: Eduardo Brancher Urenha <eduardo.urenha@usp.br>
Co-authored-by: Miguel de Mello Carpi <miguelmello@usp.br>
Signed-off-by: Lourenço Henrique Moinheiro Martins Sborz Bogo <louhmmsb@usp.br>