### PR TITLE
Move kernel scripts parameters to kworkflow.config

### DIFF
--- a/etc/kworkflow_template.config
+++ b/etc/kworkflow_template.config
@@ -98,6 +98,7 @@ send_opts=--annotate --cover-letter --no-chain-reply-to --thread
 # list of your patches, separate values with commas
 #blocked_emails=
 
-# Options to be used with the checkpatch script
+# Options to be used with the checkpatch and get_maintainer scripts
 # Warning changing these values may cause undefined behavior!
 checkpatch_opts=--no-tree --color=always --strict
+get_maintainer_opts=--separator , --nokeywords --nogit --nogit-fallback --norolestats

--- a/etc/kworkflow_template.config
+++ b/etc/kworkflow_template.config
@@ -97,3 +97,7 @@ send_opts=--annotate --cover-letter --no-chain-reply-to --thread
 # You can choose to block certain emails from being added to the recipients
 # list of your patches, separate values with commas
 #blocked_emails=
+
+# Options to be used with the checkpatch script
+# Warning changing these values may cause undefined behavior!
+checkpatch_opts=--no-tree --color=always --strict

--- a/src/checkpatch_wrapper.sh
+++ b/src/checkpatch_wrapper.sh
@@ -22,7 +22,7 @@ function execute_checkpatch()
   # output. It could be nice if we can add another option just for this sort
   # of check.
 
-  local options='--no-tree --color=always --strict'
+  local options="${configurations[checkpatch_opts]}"
   local -r original_working_dir="$PWD"
   local kernel_root
   local cmd_script

--- a/src/get_maintainer_wrapper.sh
+++ b/src/get_maintainer_wrapper.sh
@@ -63,8 +63,7 @@ function execute_get_maintainer()
   local is_file_inside_kernel_tree=true
 
   local -r script='scripts/get_maintainer.pl'
-  local script_options='--separator , --nokeywords --nogit'
-  script_options="$script_options --nogit-fallback --norolestats"
+  local script_options="${configurations[get_maintainer_opts]}"
 
   local -r original_working_dir=$PWD
   local kernel_root=''

--- a/src/kw_config_loader.sh
+++ b/src/kw_config_loader.sh
@@ -83,6 +83,7 @@ function show_variables()
     [gui_on]='Command to activate GUI'
     [gui_off]='Command to deactivate GUI'
     [checkpatch_opts]='Options to be used in the checkpatch script'
+    [get_maintainer_opts]='Options to be used in the get_maintainer script'
   )
 
   local -Ar group_descriptions=(

--- a/src/kw_config_loader.sh
+++ b/src/kw_config_loader.sh
@@ -82,6 +82,7 @@ function show_variables()
     [disable_statistics_data_track]='Disable tracking of statistical data'
     [gui_on]='Command to activate GUI'
     [gui_off]='Command to deactivate GUI'
+    [checkpatch_opts]='Options to be used in the checkpatch script'
   )
 
   local -Ar group_descriptions=(

--- a/tests/checkpatch_wrapper_test.sh
+++ b/tests/checkpatch_wrapper_test.sh
@@ -14,6 +14,8 @@ function oneTimeSetUp()
   cp -f tests/external/const_structs.checkpatch "$SHUNIT_TMPDIR"/scripts/
   cp -f tests/external/spelling.txt "$SHUNIT_TMPDIR"/scripts/
   cp -r tests/samples "$SHUNIT_TMPDIR"
+
+  parse_configuration "$KW_CONFIG_SAMPLE"
 }
 
 function checkpatch_helper()

--- a/tests/get_maintainer_wrapper_test.sh
+++ b/tests/get_maintainer_wrapper_test.sh
@@ -66,6 +66,8 @@ function oneTimeSetUp()
     fail "($LINENO) It was not possible to move back from temp directory"
     return
   }
+
+  parse_configuration "$KW_CONFIG_SAMPLE"
 }
 
 function oneTimeTearDown()

--- a/tests/kw_config_loader_test.sh
+++ b/tests/kw_config_loader_test.sh
@@ -85,6 +85,7 @@ function test_parse_configuration_output()
     [doc_type]='htmldocs'
     [send_opts]='--annotate --cover-letter --no-chain-reply-to --thread'
     [blocked_emails]='test@email.com'
+    [checkpatch_opts]='--no-tree --color=always --strict'
   )
 
   cp tests/samples/kworkflow.config "$TMP_DIR/"
@@ -128,6 +129,7 @@ function test_parse_configuration_standard_config()
     [disable_statistics_data_track]='no'
     [doc_type]='htmldocs'
     [send_opts]='--annotate --cover-letter --no-chain-reply-to --thread'
+    [checkpatch_opts]='--no-tree --color=always --strict'
   )
 
   parse_configuration "$TMP_DIR/kworkflow.config"

--- a/tests/kw_config_loader_test.sh
+++ b/tests/kw_config_loader_test.sh
@@ -86,6 +86,7 @@ function test_parse_configuration_output()
     [send_opts]='--annotate --cover-letter --no-chain-reply-to --thread'
     [blocked_emails]='test@email.com'
     [checkpatch_opts]='--no-tree --color=always --strict'
+    [get_maintainer_opts]='--separator , --nokeywords --nogit --nogit-fallback --norolestats'
   )
 
   cp tests/samples/kworkflow.config "$TMP_DIR/"
@@ -130,6 +131,7 @@ function test_parse_configuration_standard_config()
     [doc_type]='htmldocs'
     [send_opts]='--annotate --cover-letter --no-chain-reply-to --thread'
     [checkpatch_opts]='--no-tree --color=always --strict'
+    [get_maintainer_opts]='--separator , --nokeywords --nogit --nogit-fallback --norolestats'
   )
 
   parse_configuration "$TMP_DIR/kworkflow.config"

--- a/tests/samples/kworkflow.config
+++ b/tests/samples/kworkflow.config
@@ -15,3 +15,4 @@ doc_type=htmldocs
 send_opts=--annotate --cover-letter --no-chain-reply-to --thread
 blocked_emails=test@email.com
 checkpatch_opts=--no-tree --color=always --strict
+get_maintainer_opts=--separator , --nokeywords --nogit --nogit-fallback --norolestats

--- a/tests/samples/kworkflow.config
+++ b/tests/samples/kworkflow.config
@@ -14,3 +14,4 @@ gui_off=turn off
 doc_type=htmldocs
 send_opts=--annotate --cover-letter --no-chain-reply-to --thread
 blocked_emails=test@email.com
+checkpatch_opts=--no-tree --color=always --strict


### PR DESCRIPTION
This PR moves the parameters used by the `checkpatch_wrapper.sh` and `get_maintainer_wrapper.sh` scripts to the *kworkflow.config* file.

Closes #260