### PR TITLE
src: db: introduce db model and migration script

### DIFF
--- a/database/kwdb.sql
+++ b/database/kwdb.sql
@@ -1,0 +1,222 @@
+PRAGMA foreign_keys = 1;
+BEGIN TRANSACTION;
+-- Tables
+
+-- This table holds the metadata of the config files handled by kw
+CREATE TABLE IF NOT EXISTS "config" (
+  "id" INTEGER NOT NULL UNIQUE,
+  "name" TEXT NOT NULL UNIQUE,
+  "description" TEXT,
+  "path" TEXT NOT NULL UNIQUE,
+  PRIMARY KEY("id")
+);
+
+-- This table holds the names of the commands that kw keeps track of, like
+-- build and deploy
+CREATE TABLE IF NOT EXISTS "command_label" (
+  "id" INTEGER NOT NULL UNIQUE,
+  "name" TEXT NOT NULL UNIQUE,
+  PRIMARY KEY("id")
+);
+
+-- Table containing the possible exit status of an executed commmand
+CREATE TABLE IF NOT EXISTS "status" (
+  "id" INTEGER NOT NULL UNIQUE,
+  "name" TEXT NOT NULL UNIQUE,
+  PRIMARY KEY("id")
+);
+
+-- Table containing user created tags
+CREATE TABLE IF NOT EXISTS "tag" (
+  "id" INTEGER NOT NULL UNIQUE,
+  "name" TEXT NOT NULL UNIQUE,
+  "active" INTEGER NOT NULL CHECK ("active" IN (0, 1)) DEFAULT 1,
+  PRIMARY KEY("id")
+);
+
+-- This is the table that holds the events triggered by kw, currently pertains
+-- to the executed commands that are saved and the pomodoro sessions created
+CREATE TABLE IF NOT EXISTS "event" (
+  "id" INTEGER NOT NULL UNIQUE,
+  "date" TEXT NOT NULL,
+  "time" TEXT,
+  PRIMARY KEY("id")
+);
+
+-- This is the relationship between an "event" that executes a given
+-- "command_label"
+CREATE TABLE IF NOT EXISTS "executed" (
+  "id" INTEGER NOT NULL UNIQUE,
+  "command_label_id" INTEGER NOT NULL,
+  "elapsed_time_in_secs" INTEGER NOT NULL,
+  "status_id" INTEGER NOT NULL,
+  PRIMARY KEY("id"),
+  FOREIGN KEY("id") REFERENCES "event"("id")
+    ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY("command_label_id") REFERENCES "command_label"("id")
+    ON UPDATE CASCADE ON DELETE RESTRICT,
+  FOREIGN KEY("status_id") REFERENCES "status"("id")
+    ON UPDATE CASCADE ON DELETE RESTRICT
+);
+
+-- Table containing the information related to each pomodoro timebox
+CREATE TABLE IF NOT EXISTS "timebox" (
+  "id" INTEGER NOT NULL UNIQUE,
+  "duration" INTEGER NOT NULL,
+  "description" TEXT,
+  "tag_id" INTEGER NOT NULL,
+  PRIMARY KEY("id"),
+  FOREIGN KEY("id") REFERENCES "event"("id")
+    ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY("tag_id") REFERENCES "tag"("id")
+    ON UPDATE CASCADE ON DELETE RESTRICT
+);
+
+-- Populate commands and status tables
+INSERT OR IGNORE INTO "status" ("name") VALUES
+  ('success'),
+  ('failure'),
+  ('interrupted'),
+  ('unknown');
+
+INSERT OR IGNORE INTO "command_label" ("name") VALUES
+  ('build'),
+  ('codestyle'),
+  ('configm'),
+  ('deploy'),
+  ('device'),
+  ('drm'),
+  ('explore'),
+  ('list'),
+  ('maintainers'),
+  ('modules_deploy'),
+  ('ssh'),
+  ('uninstall');
+
+-- Views
+-- This view shows the currently active pomodoro sessions
+CREATE VIEW IF NOT EXISTS "active_timebox"
+AS
+SELECT
+  "e_id" AS "id",
+  "tag",
+  "date",
+  "time",
+  "duration",
+  "description"
+FROM
+  (SELECT "id" AS "e_id", "date", "time" FROM "event" ORDER BY "date")
+JOIN "timebox" ON "e_id" IS "timebox"."id"
+JOIN (SELECT "id" AS "g_id", "name" AS "tag" FROM "tag") ON "g_id" IS "timebox"."tag_id"
+WHERE
+  CAST (strftime('%s',"date"||'T'||"time",'utc')+"duration" AS INTEGER) >= strftime('%s','now');
+
+-- This view aggregates all the pomodoro sessions on record
+CREATE VIEW IF NOT EXISTS "pomodoro_report"
+AS
+SELECT
+  "e_id" AS "id",
+  "tag_id",
+  "name" AS "tag",
+  "date",
+  "time",
+  "duration",
+  "description"
+FROM
+  (SELECT "id" AS "e_id", "date", "time" FROM "event")
+JOIN "timebox" ON "timebox"."id" IS "e_id"
+JOIN "tag" ON "tag"."id" IS "timebox"."tag_id";
+
+-- This view aggregates all data relevant to the statistics reports
+CREATE VIEW IF NOT EXISTS "statistics_report"
+AS
+SELECT
+  "e_id" AS "id",
+  "name" AS "label_name",
+  "status_name" AS "status",
+  "date",
+  "time",
+  "elapsed_time_in_secs"
+FROM
+  (SELECT "id" AS "e_id", "date", "time" FROM "event")
+JOIN "executed" ON "executed"."id" IS "e_id"
+JOIN "command_label" ON "command_label"."id" IS "executed"."command_label_id"
+JOIN (SELECT "id" AS "s_id", "name" AS "status_name" FROM "status") ON "s_id" IS "executed"."status_id";
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS "command_label_idx" ON "command_label" (
+  "name" ASC,
+  "id"
+);
+
+CREATE INDEX IF NOT EXISTS "tag_idx" ON "tag" (
+  "active" DESC,
+  "name" ASC,
+  "id"
+);
+
+CREATE INDEX IF NOT EXISTS "chronological_events" ON "event" (
+  "date" ASC,
+  "time" ASC,
+  "id"
+);
+
+CREATE INDEX IF NOT EXISTS "executed_idx" ON "executed" (
+  "command_label_id" ASC,
+  "status_id" ASC,
+  "elapsed_time_in_secs" DESC,
+  "id"
+);
+
+CREATE INDEX IF NOT EXISTS "timebox_idx" ON "timebox" (
+  "tag_id" ASC,
+  "duration" DESC,
+  "id",
+  "description"
+);
+
+-- Triggers
+CREATE TRIGGER IF NOT EXISTS "delete_pomodoro" INSTEAD OF DELETE ON "pomodoro_report"
+  BEGIN
+    DELETE FROM "timebox" WHERE "timebox"."id" IS "OLD"."id";
+    DELETE FROM "event" WHERE "event"."id" IS "OLD"."id";
+  END;
+
+CREATE TRIGGER IF NOT EXISTS "delete_statistics" INSTEAD OF DELETE ON "statistics_report"
+  BEGIN
+    DELETE FROM "executed" WHERE "executed"."id" IS "OLD"."id";
+    DELETE FROM "event" WHERE "event"."id" IS "OLD"."id";
+  END;
+
+CREATE TRIGGER IF NOT EXISTS "insert_pomodoro" INSTEAD OF INSERT ON "pomodoro_report"
+  BEGIN
+    INSERT OR IGNORE INTO "tag" ("name") VALUES ("NEW"."tag");
+
+    INSERT INTO "event" ("date", "time") VALUES ("NEW"."date", "NEW"."time");
+
+    INSERT INTO "timebox" ("id","duration","description","tag_id")
+      VALUES(
+        last_insert_rowid(),
+        "NEW"."duration",
+        "NEW"."description",
+        (SELECT "id" FROM "tag" AS "g" WHERE "g"."name" IS "NEW"."tag")
+      );
+  END;
+
+CREATE TRIGGER IF NOT EXISTS "insert_statistics" INSTEAD OF INSERT ON "statistics_report"
+  BEGIN
+    INSERT OR IGNORE INTO "command_label" ("name") VALUES ("NEW"."label_name");
+    INSERT OR IGNORE INTO "status" ("name") VALUES ("NEW"."status");
+
+    INSERT INTO "event" ("date", "time") VALUES ("NEW"."date", "NEW"."time");
+
+    INSERT INTO "executed" ("id", "command_label_id", "status_id", "elapsed_time_in_secs")
+      VALUES (
+        last_insert_rowid(),
+        (SELECT "id" FROM "command_label" AS "c" WHERE "c"."name" IS "NEW"."label_name"),
+        (SELECT "id" FROM "status" AS "s" WHERE "s"."name" IS "NEW"."status"),
+        "NEW"."elapsed_time_in_secs"
+      );
+  END;
+
+COMMIT;

--- a/database/migrate_legacy_data_20220101.sh
+++ b/database/migrate_legacy_data_20220101.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+
+# This file handles the migration of user data, from the old folders and files
+# storage, to the new database model
+
+KW_LIB_DIR='src'
+KW_DB_DIR='database'
+. 'src/kw_include.sh' --source-only
+include "$KW_LIB_DIR/kwio.sh"
+include "$KW_LIB_DIR/kwlib.sh"
+include "$KW_LIB_DIR/kw_string.sh"
+include "$KW_LIB_DIR/kw_db.sh"
+
+declare -r app_name='kw'
+declare -r datadir="${XDG_DATA_HOME:-"$HOME/.local/share"}/$app_name"
+
+declare -gr KW_DATA_DIR=${KW_DATA_DIR:-"$datadir"}
+
+function migrate_statistics()
+{
+  local -a file_list
+  local start_date
+  local label_name
+  local status
+  local elapsed_time_in_secs
+  local rows
+  local columns='("date","label_name","status","elapsed_time_in_secs")'
+  local count=0
+  local -a values=()
+
+  file_list=$(find "${datadir}/statistics" -type f | sort)
+
+  for file in $file_list; do
+    # This line converts the file path into a usable date value
+    # E.g.: ${datadir}/statistics/2021/10/05 -> 2021-10-05
+    start_date=$(printf '%s\n' "$file" | sed -e 's/.*statistics\///' -e 's/\//-/g')
+    while IFS=' ' read -r label_name elapsed_time_in_secs; do
+      status='success'
+      # The new database stores execution status, making this label unnecessary
+      if [[ "$label_name" == 'build_failure' ]]; then
+        status='failure'
+        label_name='build'
+      fi
+      label_name="$(str_lowercase "$label_name")"
+      values+=("$start_date" "$label_name" "$status" "$elapsed_time_in_secs")
+      ((count++))
+      # insert statements have a limit on the amount of values being inserted
+      # at once, this ensures that limit is never reached
+      if [[ "$count" -ge 100 ]]; then
+        rows="$(format_values_db 4 "${values[@]}")"
+        insert_into '"statistics_report"' "$columns" "$rows"
+
+        values=()
+        count=0
+      fi
+    done < "$file"
+  done
+
+  # insert_values '"statistics_report"' "$columns" 4 "${values[@]}"
+
+  # if there are no values left, return, otherwise insert them
+  [[ "${#values}" == 0 ]] && return
+
+  rows="$(format_values_db 4 "${values[@]}")"
+  insert_into '"statistics_report"' "$columns" "$rows"
+}
+
+function migrate_pomodoro()
+{
+  local -a file_list
+  local line
+  local tag
+  local start_date
+  local start_time
+  local duration
+  local description
+  local rows
+  local columns='("tag","date","time","duration","description")'
+  local count=0
+  local -a values=()
+
+  file_list=$(find "${datadir}/pomodoro" -type f | sort)
+
+  for file in $file_list; do
+    # avoid processing tags file
+    [[ "$file" =~ tags$ ]] && continue
+    # This line converts the file path into a usable date value
+    # E.g.: ${datadir}/pomodoro/2021/10/05 -> 2021-10-05
+    start_date=$(printf '%s\n' "$file" | sed -e 's/.*pomodoro\///' -e 's/\//-/g')
+    while read -r line; do
+      tag=$(printf '%s\n' "$line" | cut -d ',' -f1)
+      duration=$(printf '%s\n' "$line" | cut -d ',' -f2)
+      start_time=$(printf '%s\n' "$line" | cut -d ',' -f3)
+      description=$(printf '%s\n' "$line" | cut -d ',' -f1,2,3 --complement)
+
+      [[ -z "$description" ]] && description='NULL'
+      duration=$(timebox_to_sec "$duration")
+
+      values+=("$tag" "$start_date" "$start_time" "$duration" "$description")
+      ((count++))
+      # insert statements have a limit on the amount of values being inserted
+      # at once, this ensures that limit is never reached
+      if [[ "$count" -ge 100 ]]; then
+        rows="$(format_values_db 5 "${values[@]}")"
+        insert_into '"pomodoro_report"' "$columns" "$rows"
+
+        values=()
+        count=0
+      fi
+    done < "$file"
+  done
+
+  # insert_values '"pomodoro_report"' "$columns" 5 "${values[@]}"
+
+  # if there are no values left, return, otherwise insert them
+  [[ "${#values}" == 0 ]] && return
+
+  rows="$(format_values_db 5 "${values[@]}")"
+
+  insert_into '"pomodoro_report"' "$columns" "$rows"
+}
+
+function migrate_configs()
+{
+  local -a file_list
+  local line
+  local name
+  local path
+  local description
+  local rows
+  local columns='("name","description","path")'
+  local count=0
+  local -a values=()
+
+  local configs_dir="${datadir}/configs/configs"
+  local metadata_dir="${datadir}/configs/metadata"
+
+  file_list=$(find "$configs_dir" -type f | sort)
+
+  for file in $file_list; do
+    path="$file"
+    name="${path##*/}" # get just the file name
+    description=$(cat "${metadata_dir}/${name}")
+
+    [[ -z "$description" ]] && description='NULL'
+
+    values+=("$name" "$description" "$path")
+    ((count++))
+    # insert statements have a limit on the amount of values being inserted
+    # at once, this ensures that limit is never reached
+    if [[ "$count" -ge 100 ]]; then
+      rows="$(format_values_db 3 "${values[@]}")"
+      insert_into '"config"' "$columns" "$rows"
+
+      values=()
+      count=0
+    fi
+  done
+
+  # insert_values '"config"' "$columns" 3 "${values[@]}"
+
+  # if there are no values left, return, otherwise insert them
+  [[ "${#values}" == 0 ]] && return
+
+  rows="$(format_values_db 3 "${values[@]}")"
+
+  insert_into '"config"' "$columns" "$rows"
+}
+
+function timebox_to_sec()
+{
+  local timebox="$1"
+  local time_type
+  local time_value
+
+  time_type=$(last_char "$timebox")
+  time_value=$(chop "$timebox")
+
+  case "$time_type" in
+    h)
+      time_value=$((3600 * time_value))
+      ;;
+    m)
+      time_value=$((60 * time_value))
+      ;;
+    s)
+      : # Do nothing
+      ;;
+  esac
+
+  printf '%s\n' "$time_value"
+}
+
+function insert_values()
+{
+  local table="$1"
+  local columns="$2"
+  local length="$3"
+  shift 3
+  local rows
+  local n
+
+  n="$((100 * length))"
+
+  # inserts values in increments of 100 values at a time to avoid problems when
+  # users have lots of entries
+  while [[ "$#" -gt 0 ]]; do
+    rows="$(format_values_db "$length" "${@:1:$n}")"
+    insert_into "$table" "$columns" "$rows"
+
+    shift "$n"
+  done
+}
+
+function db_migration()
+{
+  execute_sql_script "$KW_DB_DIR/kwdb.sql"
+
+  migrate_statistics
+  migrate_pomodoro
+  migrate_configs
+
+  execute_command_db 'PRAGMA optimize;'
+}
+
+db_migration

--- a/database/pre_cmd.sql
+++ b/database/pre_cmd.sql
@@ -1,0 +1,1 @@
+PRAGMA foreign_keys = 1;

--- a/kw
+++ b/kw
@@ -13,6 +13,7 @@ KW_SHARE_DIR="${XDG_DATA_HOME:-"$HOME/.local/share"}/$KWORKFLOW"
 KW_DOC_DIR="$KW_SHARE_DIR/doc"
 KW_MAN_DIR="$KW_SHARE_DIR/man"
 KW_SOUND_DIR="$KW_SHARE_DIR/sound"
+KW_DB_DIR="$KW_SHARE_DIR/database"
 
 # User specific data files (currently this collapses with the share dir,
 # but would not for a system-wide installation)
@@ -37,6 +38,7 @@ if [ -f "${KW_BASE_DIR}/src/kwlib.sh" ]; then
   KW_DOC_DIR="${KW_BASE_DIR}/documentation"
   KW_MAN_DIR="${KW_BASE_DIR}/documentation/man"
   KW_SOUND_DIR="${KW_BASE_DIR}/sound"
+  KW_DB_DIR="${KW_BASE_DIR}/database"
   KW_ETC_DIR="${KW_BASE_DIR}/etc"
   KW_PLUGINS_DIR="${KW_LIB_DIR}/plugins"
   # KW_CACHE_DIR # use default cache folder

--- a/setup.sh
+++ b/setup.sh
@@ -22,6 +22,7 @@ declare -r sharedir="${XDG_DATA_HOME:-"$HOME/.local/share"}/$app_name"
 declare -r docdir="$sharedir/doc"
 declare -r mandir="$sharedir/man"
 declare -r sounddir="$sharedir/sound"
+declare -r databasedir="$sharedir/database"
 declare -r datadir="${XDG_DATA_HOME:-"$HOME/.local/share"}/$app_name"
 declare -r etcdir="${XDG_CONFIG_HOME:-"$HOME/.config"}/$app_name"
 declare -r cachedir="${XDG_CACHE_HOME:-"$HOME/.cache/$app_name"}"
@@ -35,6 +36,7 @@ declare -r CONFIG_DIR='etc/'
 declare -r KW_CACHE_DIR="$cachedir"
 
 declare -r SOUNDS='sounds'
+declare -r DATABASE='database'
 declare -r BASH_AUTOCOMPLETE='bash_autocomplete'
 declare -r DOCUMENTATION='documentation'
 
@@ -312,10 +314,18 @@ function synchronize_files()
   cmd_output_manager "rsync -vr $CONFIG_DIR/ $etcdir" "$verbose"
   ASSERT_IF_NOT_EQ_ZERO "The command 'rsync -vr $CONFIG_DIR/ $etcdir $verbose' failed" "$?"
 
+  # Database files
+  mkdir -p "$databasedir"
+  cmd_output_manager "rsync -vr $DATABASE/ $databasedir" "$verbose"
+  ASSERT_IF_NOT_EQ_ZERO "The command 'rsync -vr $DATABASE $databasedir' failed" "$?"
+
   # User data
   mkdir -p "$datadir"
   mkdir -p "$datadir/statistics"
   mkdir -p "$datadir/configs"
+  if [[ -x "$databasedir/migrate_legacy_data_20220101.sh" ]]; then
+    eval "$databasedir/migrate_legacy_data_20220101.sh"
+  fi
 
   if command_exists 'bash'; then
     # Add tabcompletion to bashrc

--- a/src/config_manager.sh
+++ b/src/config_manager.sh
@@ -1,5 +1,6 @@
 include "$KW_LIB_DIR/kwlib.sh"
 include "$KW_LIB_DIR/kwio.sh"
+include "$KW_LIB_DIR/kw_db.sh"
 include "$KW_LIB_DIR/remote.sh"
 include "$KW_LIB_DIR/signal_manager.sh"
 
@@ -92,25 +93,23 @@ function save_config_file()
   local -r description="$3"
   local -r original_path="$PWD"
   local -r dot_configs_dir="$KW_DATA_DIR/configs"
+  local metadata=''
 
   if [[ ! -f "$original_path/.config" ]]; then
     complain 'There is no .config file in the current directory'
     return 2 # ENOENT
   fi
 
-  if [[ ! -d "$dot_configs_dir" || ! -d "$dot_configs_dir/$metadata_dir" ]]; then
+  if [[ ! -d "$dot_configs_dir" ]]; then
     mkdir -p "$dot_configs_dir"
     cd "$dot_configs_dir" || exit_msg 'It was not possible to move to configs dir'
     git init --quiet
-    mkdir -p "$metadata_dir" "$configs_dir"
   fi
 
-  cd "$dot_configs_dir" || exit_msg 'It was not possible to move to configs dir'
+  metadata="$(select_from "\"config\" WHERE \"name\" IS '$name'" '"name","description"')"
 
   # Check if the metadata related to .config file already exists
-  if [[ ! -f "$metadata_dir/$name" ]]; then
-    touch "$metadata_dir/$name"
-  elif [[ "$force" != 1 ]]; then
+  if [[ -n "$metadata" && "$force" != 1 ]]; then
     if [[ $(ask_yN "$name already exists. Update?") =~ '0' ]]; then
       complain 'Save operation aborted'
       cd "$original_path" || exit_msg 'It was not possible to move back from configs dir'
@@ -118,12 +117,13 @@ function save_config_file()
     fi
   fi
 
-  if [[ -n "$description" ]]; then
-    printf '%s\n' "$description" > "$metadata_dir/$name"
+  if [[ -z "$description" ]]; then
+    description='NULL'
   fi
 
-  cp "$original_path/.config" "$dot_configs_dir/$configs_dir/$name"
-  git add "$configs_dir/$name" "$metadata_dir/$name"
+  cp "$original_path/.config" "$dot_configs_dir/$name"
+  git add "$configs_dir/$name"
+  # execute_command_db "UPDATE \"config\"
   current_date=$(date)
   git commit -m "New config file added: $USER - $current_date" > /dev/null 2>&1
   ret="$?"
@@ -446,22 +446,16 @@ function fetch_config()
 
 function list_configs()
 {
-  local -r dot_configs_dir="$KW_DATA_DIR/configs"
-  local name
-  local content
+  local configs
 
-  if [[ ! -d "$dot_configs_dir" || ! -d "$dot_configs_dir/$metadata_dir" ]]; then
-    say 'There is no tracked .config file'
+  configs="$(select_from '"config"' '"name" AS "Name", "description" AS "Description"' '.mode column')"
+
+  if [[ -z "$configs" ]]; then
+    say 'There are no tracked .config files'
     return 0
   fi
 
-  printf '%-30s | %-30s\n' 'Name' $'Description\n'
-  for filename in "$dot_configs_dir/$metadata_dir"/*; do
-    [[ ! -f "$filename" ]] && continue
-    name=$(basename "$filename")
-    content=$(< "$filename")
-    printf '%-30s | %-30s\n' "$name" "$content"
-  done
+  printf '%s\n' "$configs"
 }
 
 # Remove and Get operation in the configm has similar criteria for working,

--- a/src/kw_db.sh
+++ b/src/kw_db.sh
@@ -152,8 +152,8 @@ function format_values_db()
 
   for val in "$@"; do
     [[ "$count" -eq 0 ]] && values+='('
-    # check if not a sqlite function
-    if [[ ! "$val" =~ ^[[:alnum:]_]+\(.*\)$ ]]; then
+    # check if not a sqlite function nor NULL
+    if [[ ! "$val" =~ ^[[:alnum:]_]+\(.*\)$ && "$val" != 'NULL' ]]; then
       val="'${val//\'/\'\'}'" # escapes single quotes and enclose
     fi
     values+="$val"

--- a/src/kw_db.sh
+++ b/src/kw_db.sh
@@ -29,7 +29,7 @@ function execute_sql_script()
 
   [[ -f "$db_path" ]] || warning "Creating database: $db_path"
 
-  sqlite3 "$db_path" < "$sql_path"
+  sqlite3 -init "$KW_DB_DIR/pre_cmd.sql" "$db_path" < "$sql_path"
 }
 
 # This function reads and executes a SQL script in the database
@@ -55,7 +55,7 @@ function execute_command_db()
     return 2
   fi
 
-  sqlite3 "$db_path" -bail -batch "$sql_cmd"
+  sqlite3 -init "$KW_DB_DIR/pre_cmd.sql" "$db_path" -bail -batch "$sql_cmd"
 }
 
 # This function inserts values into table of given database
@@ -92,7 +92,7 @@ function insert_into()
 
   [[ -n "$entries" && ! "$entries" =~ ^\(.*\)$ ]] && entries="($entries)"
 
-  sqlite3 "$db_path" -batch "INSERT INTO $table $entries VALUES $values;"
+  sqlite3 -init "$KW_DB_DIR/pre_cmd.sql" "$db_path" -batch "INSERT INTO $table $entries VALUES $values;"
 }
 
 # This function gets the values in the table of given database
@@ -125,7 +125,7 @@ function select_from()
     return 22 # EINVAL
   fi
 
-  sqlite3 "$db_path" -batch "SELECT $columns FROM $table;"
+  sqlite3 -init "$KW_DB_DIR/pre_cmd.sql" "$db_path" -batch "SELECT $columns FROM $table;"
 }
 
 # This function takes arguments and assembles them into the correct format to

--- a/src/kw_db.sh
+++ b/src/kw_db.sh
@@ -109,8 +109,9 @@ function select_from()
 {
   local table="$1"
   local columns="${2:-"*"}"
-  local db="${3:-"$DB_NAME"}"
-  local db_folder="${4:-"$KW_DATA_DIR"}"
+  local pre_cmd="$3"
+  local db="${4:-"$DB_NAME"}"
+  local db_folder="${5:-"$KW_DATA_DIR"}"
   local db_path
 
   db_path="$(join_path "$db_folder" "$db")"
@@ -125,7 +126,7 @@ function select_from()
     return 22 # EINVAL
   fi
 
-  sqlite3 -init "$KW_DB_DIR/pre_cmd.sql" "$db_path" -batch "SELECT $columns FROM $table;"
+  sqlite3 -init "$KW_DB_DIR/pre_cmd.sql" -cmd "$pre_cmd" "$db_path" -batch "SELECT $columns FROM $table;"
 }
 
 # This function takes arguments and assembles them into the correct format to

--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -1,5 +1,6 @@
 # NOTE: src/kw_config_loader.sh must be included before this file
 include "$KW_LIB_DIR/kw_string.sh"
+include "$KW_LIB_DIR/kw_db.sh"
 
 # Array with compression programs accepted by tar
 declare -ga compression_programs=('gzip' 'bzip2' 'lzip' 'lzma' 'lzop' 'zstd'
@@ -315,62 +316,35 @@ function detect_distro()
 # related to kw. It also manages the database creation, any data that should be
 # handled as a kw statistics should use this function.
 #
-# @label Label name used to identify a value
-# @value Value should be an integer number
+# @label_name:           Label name used to identify a value
+# @elapsed_time_in_secs: Should be an integer number
+# @status:               Execution status
 #
 # Return:
 # Print a execution time info
 function statistics_manager()
 {
-  local label="$1"
-  local value="$2"
-  local day
-  local year_month_dir
-  local day_path
+  local label_name="$1"
+  local elapsed_time_in_secs="$2"
+  local status=${3:-'success'}
+  local start_date
+  local start_time
+  local row
+  local columns='("label_name","status","date","time","elapsed_time_in_secs")'
 
-  day=$(date +%d)
-  year_month_dir=$(date +%Y/%m)
-  day_path="$KW_DATA_DIR/statistics/$year_month_dir/$day"
+  start_date=$(date +%Y-%m-%d)
+  start_time=$(date +%H:%M:%S)
 
-  elapsed_time=$(date -d@"$value" -u +%H:%M:%S)
+  elapsed_time=$(date -d@"$elapsed_time_in_secs" -u +%H:%M:%S)
   say "-> Execution time: $elapsed_time"
 
   [[ ${configurations[disable_statistics_data_track]} == 'yes' ]] && return
 
-  update_statistics_database "$year_month_dir" "$day"
-  store_statistics_data "$day_path" "$label" "$value"
-}
+  [[ -z "$label_name" || -z "$status" || -z "$start_date" || -z "$start_time" || -z "$elapsed_time_in_secs" ]] && return 22 # EINVAL
 
-# This function is part of the statistics feature and it is responsible for
-# managing the database by following the calendar organization.
-#
-# @year_month_dir Current year
-# @day Current day of the week
-function update_statistics_database()
-{
-  local year_month_path="$1"
-  local day="$2"
+  row=$(format_values_db 5 "$label_name" "$status" "$start_date" "$start_time" "$elapsed_time_in_secs")
 
-  [[ -z "$day" || -z "$year_month_path" ]] && return 22 # EINVAL
-
-  mkdir -p "$KW_DATA_DIR/statistics/$year_month_path"
-  touch "$KW_DATA_DIR/statistics/$year_month_path/$day"
-}
-
-# This function save the information directly to a file.
-#
-# @day_path Current day
-# @label Label used to identify a value
-# @value An integer number associated to a label
-function store_statistics_data()
-{
-  local day_path="$1"
-  local label="$2"
-  local value="$3"
-
-  [[ ! -f "$day_path" || -z "$label" || -z "$value" ]] && return 22 # EINVAL
-
-  printf '%s\n' "$label $value" >> "$day_path"
+  insert_into '"statistics_report"' "$columns" "$row"
 }
 
 # This function checks if a certain command can be run

--- a/src/statistics.sh
+++ b/src/statistics.sh
@@ -4,6 +4,7 @@
 
 include "$KW_LIB_DIR/kw_config_loader.sh"
 include "$KW_LIB_DIR/kw_time_and_date.sh"
+include "$KW_LIB_DIR/kw_db.sh"
 
 # This is a data struct that describes the main type of data collected. We use
 # this in some internal loops.

--- a/tests/kw_db_test.sh
+++ b/tests/kw_db_test.sh
@@ -15,6 +15,7 @@ function oneTimeSetUp()
   mkdir -p "$FAKE_DATA"
 
   KW_DATA_DIR="$FAKE_DATA"
+  KW_DB_DIR="$(realpath './database')"
 }
 
 function oneTimeTearDown()

--- a/tests/kw_db_test.sh
+++ b/tests/kw_db_test.sh
@@ -44,7 +44,7 @@ function test_execute_sql_script()
   # Here we make use of SQLite's internal commands to return a list of the
   # tables in the db, the semicolon ensures sqlite3 closes
   output=$(sqlite3 "$KW_DATA_DIR/kw.db" -cmd '.tables' -batch ';')
-  expected='^pomodoro[[:space:]]+statistic[[:space:]]+tags[[:space:]]*$'
+  expected='^pomodoro[[:space:]]+statistics[[:space:]]+tags[[:space:]]*$'
   assertTrue "($LINENO) Testing tables" '[[ "$output" =~ $expected ]]'
 
   execute_sql_script "$DB_FILES/insert.sql"
@@ -58,7 +58,7 @@ function test_execute_sql_script()
   output=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT count(rowid) FROM pomodoro;')
   assert_equals_helper 'Expected 5 pomodoro entries' "$LINENO" "$output" 5
 
-  output=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT count(rowid) FROM statistic;')
+  output=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT count(rowid) FROM statistics;')
   assert_equals_helper 'Expected 4 statistic entries' "$LINENO" "$output" 4
 }
 
@@ -136,11 +136,11 @@ function test_execute_command_db()
   assert_equals_helper 'Invalid table.' "$LINENO" "$ret" 1
   assert_substring_match 'Wrong output.' "($LINENO)" "$output" "$expected"
 
-  entries="$(concatenate_with_commas label dt_start)"
+  entries="$(concatenate_with_commas name start_date)"
 
-  output=$(execute_command_db "SELECT $entries FROM statistic;")
+  output=$(execute_command_db "SELECT $entries FROM statistics;")
   ret="$?"
-  expected=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT label,dt_start FROM statistic;')
+  expected=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT name,start_date FROM statistics;')
   assert_equals_helper 'No error expected' "$LINENO" "$ret" 0
   assert_equals_helper 'Testing with concatenate_with_commas' "$LINENO" "$output" "$expected"
 }
@@ -194,18 +194,18 @@ function test_insert_into()
   assert_equals_helper 'No error expected' "$LINENO" "$ret" 0
   assert_equals_helper 'Wrong output' "$LINENO" "$output" "$expected"
 
-  insert_into 'pomodoro' '(tag_id,dt_start,dt_end,descript)' "('4',datetime('now'),datetime('now', '+10 minutes'),'some description')"
+  insert_into 'pomodoro' '("tag_id","start_date","start_time","duration","description")' "(4,date('now'),time('now'),600,'some description')"
   ret="$?"
-  output=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT descript FROM pomodoro WHERE tag_id = 4;')
+  output=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT "description" FROM pomodoro WHERE "tag_id" = 4;')
   expected='some description'
   assert_equals_helper 'No error expected' "$LINENO" "$ret" 0
   assert_equals_helper 'Wrong output' "$LINENO" "$output" "$expected"
 
-  entries=$(concatenate_with_commas tag_id dt_start dt_end descript)
-  values=$(format_values_db 4 '5' "datetime('now')" "datetime('now','+10 minutes')" 'some description 2')
+  entries=$(concatenate_with_commas '"tag_id"' '"start_date"' '"start_time"' '"duration"' '"description"')
+  values=$(format_values_db 5 '5' "date('now')" "time('now','+10 minutes')" '650' 'some description 2')
   insert_into pomodoro "$entries" "$values"
   ret="$?"
-  output=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT descript FROM pomodoro WHERE tag_id = 5;')
+  output=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT "description" FROM pomodoro WHERE "tag_id" = 5;')
   expected='some description 2'
   assert_equals_helper 'No error expected' "$LINENO" "$ret" 0
   assert_equals_helper 'Testing with format functions' "$LINENO" "$output" "$expected"
@@ -253,10 +253,10 @@ function test_select_from()
   assert_equals_helper 'No error expected' "$LINENO" "$ret" 0
   assert_equals_helper 'Wrong output' "$LINENO" "$output" "$expected"
 
-  entries=$(concatenate_with_commas dt_start dt_end descript)
+  entries=$(concatenate_with_commas '"start_date"' '"start_time"' '"description"')
   output=$(select_from 'pomodoro' "$entries")
   ret="$?"
-  expected=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT dt_start,dt_end,descript FROM pomodoro;')
+  expected=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT "start_date","start_time","description" FROM "pomodoro";')
   assert_equals_helper 'No error expected' "$LINENO" "$ret" 0
   assert_equals_helper 'Wrong output' "$LINENO" "$output" "$expected"
 }

--- a/tests/kw_db_test.sh
+++ b/tests/kw_db_test.sh
@@ -96,6 +96,12 @@ function test_format_values_db()
   expected="('some ''quotes''')"
   assert_equals_helper 'No error expected' "$LINENO" "$ret" 0
   assert_equals_helper 'Wrong output' "$LINENO" "$output" "$expected"
+
+  output=$(format_values_db 2 'first' 'NULL')
+  ret="$?"
+  expected="('first',NULL)"
+  assert_equals_helper 'No error expected' "$LINENO" "$ret" 0
+  assert_equals_helper 'Wrong output' "$LINENO" "$output" "$expected"
 }
 
 function test_execute_command_db()

--- a/tests/kwlib_test.sh
+++ b/tests/kwlib_test.sh
@@ -6,20 +6,23 @@ include './tests/utils.sh'
 
 function oneTimeSetUp()
 {
-  KW_DATA_DIR="$SHUNIT_TMPDIR"
-  TARGET_YEAR_MONTH="2020/05"
-  FAKE_STATISTICS_PATH="$KW_DATA_DIR/statistics"
-  FAKE_STATISTICS_MONTH_PATH="$FAKE_STATISTICS_PATH/$TARGET_YEAR_MONTH"
-  FAKE_STATISTICS_DAY_PATH="$FAKE_STATISTICS_MONTH_PATH/03"
-  ORIGINAL_DIR="$PWD"
+  declare -gr ORIGINAL_DIR="$PWD"
+  declare -gr FAKE_DATA="$SHUNIT_TMPDIR/db_testing"
+
+  declare -g DB_FILES
+
+  DB_FILES="$(realpath './tests/samples/db_files')"
+
+  mkdir -p "$FAKE_DATA"
+
+  KW_DATA_DIR="$FAKE_DATA"
+  KW_DB_DIR="$(realpath './database')"
 
   setupFakeKernelRepo
 }
 
 function setupPatch()
 {
-  mkdir -p "$FAKE_STATISTICS_MONTH_PATH"
-  touch "$FAKE_STATISTICS_DAY_PATH"
   cp -f tests/samples/test.patch "$SHUNIT_TMPDIR"
 }
 
@@ -59,7 +62,6 @@ function setupFakeKernelRepo()
 
 function tearDown()
 {
-  rm -rf "$FAKE_STATISTICS_PATH"
   cd "$ORIGINAL_DIR" || {
     fail "($LINENO) It was not possible to move back to original directory"
     return

--- a/tests/samples/db_files/init.sql
+++ b/tests/samples/db_files/init.sql
@@ -1,17 +1,20 @@
-CREATE TABLE IF NOT EXISTS tags(
-	id INTEGER PRIMARY KEY,
-	tag VARCHAR(32) UNIQUE
+CREATE TABLE IF NOT EXISTS "tags"(
+	"id" INTEGER PRIMARY KEY,
+	"tag" TEXT UNIQUE
 );
 
-CREATE TABLE IF NOT EXISTS pomodoro(
-	tag_id INTEGER REFERENCES tags(id),
-	dt_start DATETIME NOT NULL,
-	dt_end DATETIME NOT NULL,
-	descript VARCHAR(512)
+CREATE TABLE IF NOT EXISTS "pomodoro"(
+	"tag_id" INTEGER NOT NULL,
+	"start_date" TEXT NOT NULL,
+	"start_time" TEXT NOT NULL,
+	"duration" INTEGER NOT NULL,
+	"description" TEXT,
+	FOREIGN KEY("tag_id") REFERENCES "tags"("id")
 );
 
-CREATE TABLE IF NOT EXISTS statistic(
-	label VARCHAR(32),
-	dt_start DATETIME NOT NULL,
-	dt_end DATETIME NOT NULL
+CREATE TABLE IF NOT EXISTS "statistics"(
+	"name" TEXT NOT NULL,
+	"start_date" TEXT NOT NULL,
+	"start_time" TEXT,
+	"execution_time" INTEGER NOT NULL
 );

--- a/tests/samples/db_files/insert.sql
+++ b/tests/samples/db_files/insert.sql
@@ -1,15 +1,15 @@
-INSERT INTO tags (tag)
+INSERT INTO "tags" ("tag")
 VALUES ('first tag'), ('second tag'), ('third tag'), ('fourth tag');
 
-INSERT INTO pomodoro (tag_id,dt_start,dt_end,descript)
-VALUES (1, '2021-11-18 16:53:00', '2021-11-18 16:53:45', 'first description'),
-(2, '2021-11-18 10:52:45', '2021-11-18 10:53:45', 'second description'),
-(2, '2021-11-18 10:54:10', '2021-11-18 10:55:45', 'second description 2'),
-(3, '2021-11-17 16:24:23', '2021-11-17 16:34:22', 'third description'),
-(3, '2021-09-18 13:00:43', '2021-09-18 14:00:43', 'third description 2');
+INSERT INTO "pomodoro" ("tag_id","start_date","start_time","duration","description")
+VALUES (1, '2021-11-18', '16:53:00', 45, 'first description'),
+(2, '2021-11-18', '10:52:45', 60, 'second description'),
+(2, '2021-11-18', '10:54:10', 3600, 'second description 2'),
+(3, '2021-11-17', '16:24:23', 600, 'third description'),
+(3, '2021-09-18', '13:00:43', 1800, 'third description 2');
 
-INSERT INTO statistic (label,dt_start,dt_end)
-VALUES ('build_failure', '2021-11-18 16:53:25', '2021-11-18 16:53:45'),
-('list', '2021-11-18 10:53:00', '2021-11-18 10:53:45'),
-('deploy', '2021-11-17 16:33:22', '2021-11-17 16:34:22'),
-('build', '2021-09-18 13:00:43', '2021-09-18 14:00:43');
+INSERT INTO "statistics" ("name","start_date","start_time","execution_time")
+VALUES ('build_failure', '2021-11-18', '16:53:25', 20),
+('list', '2021-11-18', '10:53:00', 45),
+('deploy', '2021-11-17', '16:33:22', 60),
+('build', '2021-09-18', '13:00:43', 980);

--- a/tests/samples/db_files/insert_kwdb.sql
+++ b/tests/samples/db_files/insert_kwdb.sql
@@ -1,0 +1,15 @@
+INSERT INTO "pomodoro_report" ("tag","date","time","duration","description")
+VALUES ('first tag', '2021-11-18', '16:53:00', 45, 'first description'),
+('second tag', '2021-11-18', '10:52:45', 60, 'second description'),
+('second tag', '2021-11-18', '10:54:10', 3600, 'second description 2'),
+('third tag', '2021-11-17', '16:24:23', 600, 'third description'),
+('third tag', '2021-09-18', '13:00:43', 1800, 'third description 2');
+
+INSERT INTO "statistics_report" ("label_name","status","date","time","elapsed_time_in_secs")
+VALUES ('build', 'failure', '2021-11-18', '16:53:25', 20),
+('list', 'success', '2021-11-18', '10:53:00', 45),
+('deploy', 'success', '2021-11-17', '16:33:22', 60),
+('build', 'success', '2021-09-18', '13:00:43', 980);
+
+INSERT INTO "config" ("name", "description", "path")
+VALUES ('some_config', 'this is the test config', '/some/path/some_config');

--- a/tests/samples/db_files/kwdb.sql
+++ b/tests/samples/db_files/kwdb.sql
@@ -1,0 +1,172 @@
+PRAGMA foreign_keys = 'ON';
+BEGIN TRANSACTION;
+-- Tables
+CREATE TABLE IF NOT EXISTS "command_label" (
+  "id" INTEGER NOT NULL UNIQUE,
+  "name" TEXT NOT NULL UNIQUE,
+  PRIMARY KEY("id")
+);
+
+CREATE TABLE IF NOT EXISTS "config" (
+  "id" INTEGER NOT NULL UNIQUE,
+  "name" TEXT NOT NULL,
+  "description" TEXT,
+  "path" TEXT NOT NULL UNIQUE,
+  PRIMARY KEY("id")
+);
+
+CREATE TABLE IF NOT EXISTS "event" (
+  "id" INTEGER NOT NULL UNIQUE,
+  "date" TEXT NOT NULL,
+  "time" TEXT,
+  PRIMARY KEY("id")
+);
+
+CREATE TABLE IF NOT EXISTS "executed" (
+  "id" INTEGER NOT NULL UNIQUE,
+  "command_label_id" INTEGER NOT NULL,
+  "elapsed_time_in_secs" INTEGER NOT NULL,
+  "status_id" INTEGER NOT NULL,
+  PRIMARY KEY("id"),
+  FOREIGN KEY("id") REFERENCES "event"("id")
+    ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY("command_label_id") REFERENCES "command_label"("id")
+    ON UPDATE CASCADE ON DELETE RESTRICT,
+  FOREIGN KEY("status_id") REFERENCES "status"("id")
+    ON UPDATE CASCADE ON DELETE RESTRICT
+);
+
+CREATE TABLE IF NOT EXISTS "status" (
+  "id" INTEGER NOT NULL UNIQUE,
+  "name" TEXT NOT NULL UNIQUE,
+  PRIMARY KEY("id")
+);
+
+CREATE TABLE IF NOT EXISTS "tag" (
+  "id" INTEGER NOT NULL UNIQUE,
+  "name" TEXT NOT NULL UNIQUE,
+  PRIMARY KEY("id")
+);
+
+CREATE TABLE IF NOT EXISTS "timebox" (
+  "id" INTEGER NOT NULL UNIQUE,
+  "duration" INTEGER NOT NULL,
+  "description" TEXT,
+  "tag_id" INTEGER NOT NULL,
+  PRIMARY KEY("id"),
+  FOREIGN KEY("id") REFERENCES "event"("id")
+    ON UPDATE CASCADE ON DELETE CASCADE,
+  FOREIGN KEY("tag_id") REFERENCES "tag"("id")
+    ON UPDATE CASCADE ON DELETE RESTRICT
+);
+
+-- Populate commands and status tables
+INSERT OR IGNORE INTO "status" ("name") VALUES
+  ('success'),
+  ('failure'),
+  ('interrupted');
+
+INSERT OR IGNORE INTO "command_label" ("name") VALUES
+  ('build'),
+  ('deploy'),
+  ('modules_deploy'),
+  ('uninstall'),
+  ('list');
+
+-- Views
+CREATE VIEW "active_timebox" AS
+  SELECT "e_id" AS "id", "tag", "date", "time", "duration", "description"
+  FROM (SELECT "id" AS "e_id", "date", "time" FROM "event" ORDER BY "date")
+  JOIN "timebox" AS "t" ON "e_id" IS "t"."id"
+  JOIN (SELECT "id" AS "t_id", "name" AS "tag" FROM "tag") ON "t_id" IS "t"."tag_id"
+  WHERE CAST (strftime('%s',"date"||'T'||"time",'utc')+"duration" AS INTEGER) >= strftime('%s','now');
+
+CREATE VIEW "pomodoro_report" AS
+  SELECT "e_id" AS "id", "tag_id", "name" AS "tag", "date", "time", "duration", "description"
+  FROM (SELECT "id" AS "e_id", "date", "time" FROM "event")
+  JOIN "timebox" AS "t" ON "t"."id" IS "e_id"
+  JOIN "tag" AS "g" ON "g"."id" IS "t"."tag_id";
+
+CREATE VIEW "statistics_report" AS
+  SELECT "e_id" AS "id", "name" AS "label_name", "status_name" AS "status", "date", "time", "elapsed_time_in_secs"
+  FROM (SELECT "id" AS "e_id", "date", "time" FROM "event")
+  JOIN "executed" AS "x" ON "x"."id" IS "e_id"
+  JOIN "command_label" AS "c" ON "c"."id" IS "x"."command_label_id"
+  JOIN (SELECT "id" AS "s_id", "name" AS "status_name" FROM "status") ON "s_id" IS "x"."status_id";
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS "command_label_idx" ON "command_label" (
+  "name" ASC,
+  "id"
+);
+
+CREATE INDEX IF NOT EXISTS "tag_idx" ON "tag" (
+  "name" ASC,
+  "id"
+);
+
+CREATE INDEX IF NOT EXISTS "chronological_events" ON "event" (
+  "date" ASC,
+  "time" ASC,
+  "id"
+);
+
+CREATE INDEX IF NOT EXISTS "exec_idx" ON "executed" (
+  "command_label_id" ASC,
+  "status_id" ASC,
+  "elapsed_time_in_secs" DESC,
+  "id"
+);
+
+CREATE INDEX IF NOT EXISTS "timebox_idx" ON "timebox" (
+  "tag_id" ASC,
+  "duration" DESC,
+  "id",
+  "description"
+);
+
+-- Triggers
+CREATE TRIGGER "delete_pomodoro" INSTEAD OF DELETE ON "pomodoro_report"
+  BEGIN
+    DELETE FROM "timebox" WHERE "timebox"."id" IS "OLD"."id";
+    DELETE FROM "event" WHERE "event"."id" IS "OLD"."id";
+  END;
+
+CREATE TRIGGER "delete_statistics" INSTEAD OF DELETE ON "statistics_report"
+  BEGIN
+    DELETE FROM "executed" WHERE "executed"."id" IS "OLD"."id";
+    DELETE FROM "event" WHERE "event"."id" IS "OLD"."id";
+  END;
+
+CREATE TRIGGER "insert_pomodoro" INSTEAD OF INSERT ON "pomodoro_report"
+  BEGIN
+    INSERT OR IGNORE INTO "tag" ("name") VALUES ("NEW"."tag");
+
+    INSERT INTO "event" ("date", "time") VALUES ("NEW"."date", "NEW"."time");
+
+    INSERT INTO "timebox" ("id","duration","description","tag_id")
+      VALUES(
+        last_insert_rowid(),
+        "NEW"."duration",
+        "NEW"."description",
+        (SELECT "id" FROM "tag" AS "g" WHERE "g"."name" IS "NEW"."tag")
+      );
+  END;
+
+CREATE TRIGGER "insert_statistics" INSTEAD OF INSERT ON "statistics_report"
+  BEGIN
+    INSERT OR IGNORE INTO "command_label" ("name") VALUES ("NEW"."label_name");
+    INSERT OR IGNORE INTO "status" ("name") VALUES ("NEW"."status");
+
+    INSERT INTO "event" ("date", "time") VALUES ("NEW"."date", "NEW"."time");
+
+    INSERT INTO "executed" ("id", "command_label_id", "status_id", "elapsed_time_in_secs")
+      VALUES (
+        last_insert_rowid(),
+        (SELECT "id" FROM "command_label" AS "c" WHERE "c"."name" IS "NEW"."label_name"),
+        (SELECT "id" FROM "status" AS "s" WHERE "s"."name" IS "NEW"."status"),
+        "NEW"."elapsed_time_in_secs"
+      );
+  END;
+
+COMMIT;


### PR DESCRIPTION
Introduces the file that builds the model to be used by kw to store all
data related to statistics options and pomodoro sessions.
Adds a script to handle the data migration from the files in
`KW_DATA_DIR` to the newly introduced database.

Thanks: Magali Lemes for the help modelling the database. @magalilemes
Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@usp.br>