### PR TITLE
src: init:  add git configuration

### DIFF
--- a/documentation/man/features/init.rst
+++ b/documentation/man/features/init.rst
@@ -29,6 +29,12 @@ OPTIONS
   Set the variable `default_deploy_target` from **kworkflow.config** to
   *<target>*, which can be any of vm, local or remote.
 
+\--guided-setup:
+  Initiates interactive setup mode. In this mode, kw will suggest a series of
+  configurations, explaining their purpose and recommending default options.
+  User confirmation and input is required to configure every feature.
+  Recommended for first time users.
+
 EXAMPLES
 ========
 For these examples, we suppose that the kernel directory is your current

--- a/src/mail.sh
+++ b/src/mail.sh
@@ -18,8 +18,6 @@ declare -ga essential_config_options=('user.name' 'user.email'
   'sendemail.smtpuser' 'sendemail.smtpserver' 'sendemail.smtpserverport')
 declare -ga optional_config_options=('sendemail.smtpencryption' 'sendemail.smtppass')
 
-declare -gr email_regex='[A-Za-z0-9_\.-]+@[A-Za-z0-9_-]+(\.[A-Za-z0-9]+)+'
-
 #shellcheck disable=SC2119
 function mail_main()
 {
@@ -126,35 +124,6 @@ function mail_send()
   [[ -n "$extra_opts" ]] && cmd+=" $extra_opts"
 
   cmd_manager "$flag" "$cmd"
-}
-
-# Validates the recipient list given by the user to the options `--to` and
-# `--cc` to make sure the all the recipients are valid.
-#
-# @raw: The list of email recipients to be validated
-#
-# Return:
-# 22 if there are invalid entries; 0 otherwise
-function validate_email_list()
-{
-  local raw="$1"
-  local -a list
-  local value
-  local error=0
-
-  IFS=',' read -ra list <<< "$raw"
-
-  for value in "${list[@]}"; do
-    if [[ ! "$value" =~ ${email_regex} ]]; then
-      warning -n 'The given recipient: '
-      printf '%s' "$value"
-      warning ' does not contain a valid e-mail.'
-      error=1
-    fi
-  done
-
-  [[ "$error" == 1 ]] && return 22 # EINVAL
-  return 0
 }
 
 # This function generates the patches beforehand, these are used to count the
@@ -401,26 +370,6 @@ function validate_encryption()
   warning 'Empty value defaults to plain smtp.'
 
   return 22 # EINVAL
-}
-
-# This function validates the encryption. If the passed encryption is not valid
-# this will warn the user and clear the option.
-#
-# @option: The option to determine if it should be an email
-# @value:  The value being passed
-#
-# Return:
-# Returns 0 if valid; 22 if invalid
-function validate_email()
-{
-  local value="$1"
-
-  if [[ ! "$value" =~ ^${email_regex}$ ]]; then
-    complain "Invalid email: $value"
-    return 22 #EINVAL
-  fi
-
-  return 0
 }
 
 # Gets the values associated to a certain config option and puts them in the

--- a/src/strings/init.txt
+++ b/src/strings/init.txt
@@ -1,0 +1,6 @@
+[text_interactive_start]:
+Welcome to the interactive mode! We will ask you a series of questions regarding
+how do you want to configure kernel workflow. Before each question there will be
+a brief explanation of the feature and why it is used. This is not exhaustive,
+we recommend you search for more information online. Please follow the prompts
+to continue.

--- a/tests/kw_string_test.sh
+++ b/tests/kw_string_test.sh
@@ -310,4 +310,67 @@ function test_concatenate_with_commas()
   assert_equals_helper 'Wrong output' "$LINENO" "$output" "$expected"
 }
 
+function test_validate_email()
+{
+  local expected
+  local output
+  local ret
+
+  # invalid values
+  output="$(validate_email 'invalid email')"
+  ret="$?"
+  expected='Invalid email: invalid email'
+  assert_equals_helper 'Invalid email was passed' "$LINENO" "$output" "$expected"
+  assert_equals_helper 'Expected an error' "$LINENO" "$ret" 22
+
+  output="$(validate_email 'lalala')"
+  ret="$?"
+  expected='Invalid email: lalala'
+  assert_equals_helper 'Invalid email was passed' "$LINENO" "$output" "$expected"
+  assert_equals_helper 'Expected an error' "$LINENO" "$ret" 22
+
+  # valid values
+  validate_email 'test@email.com'
+  ret="$?"
+  assert_equals_helper 'Expected a success' "$LINENO" "$ret" 0
+
+  validate_email 'test123@serious.gov'
+  ret="$?"
+  assert_equals_helper 'Expected a success' "$LINENO" "$ret" 0
+}
+
+function test_validate_email_list()
+{
+  local expected
+  local output
+  local ret
+
+  # invalid values
+  output="$(validate_email_list 'invalid email')"
+  ret="$?"
+  expected='The given recipient: invalid email does not contain a valid e-mail.'
+  assert_equals_helper 'Invalid email was passed' "$LINENO" "$output" "$expected"
+  assert_equals_helper 'Expected an error' "$LINENO" "$ret" 22
+
+  output="$(validate_email_list 'lalala')"
+  ret="$?"
+  expected='The given recipient: lalala does not contain a valid e-mail.'
+  assert_equals_helper 'Invalid email was passed' "$LINENO" "$output" "$expected"
+  assert_equals_helper 'Expected an error' "$LINENO" "$ret" 22
+
+  output="$(validate_email_list 'name1@lala.com,name2@lala.xpto,LastName, FirstName <last.first@lala.com>,test123@serious.gov')"
+  ret="$?"
+  expected='The given recipient: LastName does not contain a valid e-mail.'
+  assert_equals_helper 'Expected an error' "$LINENO" "$ret" 22
+
+  # valid values
+  validate_email_list 'test@email.com'
+  ret="$?"
+  assert_equals_helper 'Expected a success' "$LINENO" "$ret" 0
+
+  validate_email_list 'name1@lala.com,name2@lala.xpto,name3 second <name3second@lala.com>,test123@serious.gov'
+  ret="$?"
+  assert_equals_helper 'Expected a success' "$LINENO" "$ret" 0
+}
+
 invoke_shunit

--- a/tests/mail_test.sh
+++ b/tests/mail_test.sh
@@ -89,35 +89,6 @@ function test_validate_encryption()
   assert_equals_helper 'Expected no error for tls' "$LINENO" "$ret" 0
 }
 
-function test_validate_email()
-{
-  local expected
-  local output
-  local ret
-
-  # invalid values
-  output="$(validate_email 'invalid email')"
-  ret="$?"
-  expected='Invalid email: invalid email'
-  assert_equals_helper 'Invalid email was passed' "$LINENO" "$output" "$expected"
-  assert_equals_helper 'Expected an error' "$LINENO" "$ret" 22
-
-  output="$(validate_email 'lalala')"
-  ret="$?"
-  expected='Invalid email: lalala'
-  assert_equals_helper 'Invalid email was passed' "$LINENO" "$output" "$expected"
-  assert_equals_helper 'Expected an error' "$LINENO" "$ret" 22
-
-  # valid values
-  validate_email 'test@email.com'
-  ret="$?"
-  assert_equals_helper 'Expected a success' "$LINENO" "$ret" 0
-
-  validate_email 'test123@serious.gov'
-  ret="$?"
-  assert_equals_helper 'Expected a success' "$LINENO" "$ret" 0
-}
-
 function test_find_commit_references()
 {
   local output
@@ -168,40 +139,6 @@ function test_find_commit_references()
     fail "($LINENO): Failed to move back to original dir"
     exit "$ret"
   }
-}
-
-function test_validate_email_list()
-{
-  local expected
-  local output
-  local ret
-
-  # invalid values
-  output="$(validate_email_list 'invalid email')"
-  ret="$?"
-  expected='The given recipient: invalid email does not contain a valid e-mail.'
-  assert_equals_helper 'Invalid email was passed' "$LINENO" "$output" "$expected"
-  assert_equals_helper 'Expected an error' "$LINENO" "$ret" 22
-
-  output="$(validate_email_list 'lalala')"
-  ret="$?"
-  expected='The given recipient: lalala does not contain a valid e-mail.'
-  assert_equals_helper 'Invalid email was passed' "$LINENO" "$output" "$expected"
-  assert_equals_helper 'Expected an error' "$LINENO" "$ret" 22
-
-  output="$(validate_email_list 'name1@lala.com,name2@lala.xpto,LastName, FirstName <last.first@lala.com>,test123@serious.gov')"
-  ret="$?"
-  expected='The given recipient: LastName does not contain a valid e-mail.'
-  assert_equals_helper 'Expected an error' "$LINENO" "$ret" 22
-
-  # valid values
-  validate_email_list 'test@email.com'
-  ret="$?"
-  assert_equals_helper 'Expected a success' "$LINENO" "$ret" 0
-
-  validate_email_list 'name1@lala.com,name2@lala.xpto,name3 second <name3second@lala.com>,test123@serious.gov'
-  ret="$?"
-  assert_equals_helper 'Expected a success' "$LINENO" "$ret" 0
 }
 
 function test_reposition_commit_count_arg()

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -181,6 +181,8 @@ function mk_fake_git()
 
   git config --local user.name 'Xpto Lala'
   git config --local user.email 'test@email.com'
+  git config --local core.editor 'test_editor'
+  git config --local init.defaultBranch 'test_branch'
   git config --local test.config value
 
   git add first_file


### PR DESCRIPTION
  src: init: create interactive init feature
  
  In an attempt to make KW more user-friendly, this PR adds a new
  feature to help beginners users to configure what is needed to
  work with it.  To do so, it is necessary to set some tools that
  are commonly used by developers (such as git).
  
  The idea is to explain what are those configurations and suggest
  default options helping beginners to set their environment.
  This commit does it with git.
  
  We selected to configure user name, email, editor, and branch name
  since these are the configurations in this tutorial:
  https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup.
  
  Signed-off-by: Lucas Cardoso lucas.cardoso.santos@usp.br
  Signed-off-by: Paulo Guilherme Pinheiro pauloguilherme@usp.br
  Co-authored-by: Eduardo Brancher Urenha eduardo.urenha@usp.br
  Co-authored-by: Miguel de Mello Carpi miguelmello@usp.br
  Co-authored-by: Lourenço Henrique Moinheiro Martins louhmmsb@usp.br