### PR TITLE
Mail send

### DIFF
--- a/documentation/man/features/mail.rst
+++ b/documentation/man/features/mail.rst
@@ -23,8 +23,8 @@ OPTIONS
 =======
 -t, \--setup:
   Initialize and configure **mail** functionality. Each argument specifies a
-  <config> to be set with the corresponding <value>, multiple <config> <value>
-  pairs may be passed at once. Current accepted options are::
+  *<config>* to be set with the corresponding *<value>*, multiple *<config>*
+  *<value>* pairs may be passed at once. Current accepted options are::
 
     --name           <name>
     --email          <email>
@@ -57,7 +57,7 @@ OPTIONS
   Verify that all the settings needed are set and valid.
 
 \--template[=<template>]:
-  This loads the default configuration values based on the given <template>.
+  This loads the default configuration values based on the given *<template>*.
   If no template is given the user will be shown the available templates to
   choose from.
 

--- a/documentation/man/features/mail.rst
+++ b/documentation/man/features/mail.rst
@@ -6,7 +6,7 @@ kw-mail
 
 SYNOPSIS
 ========
-| *kw mail* (-s | \--send) [\--simulate] [\--to='<recipient>,...'] [\--cc='<recipient>,...'] [<rev-range>...] [-v<version>] [\-- <extra-args>...]
+| *kw mail* (-s | \--send) [\--simulate] [\--private] [\--to='<recipient>,...'] [\--cc='<recipient>,...'] [<rev-range>...] [-v<version>] [\-- <extra-args>...]
 | *kw mail* (-t | \--setup) [\--local | \--global] [-f | \--force] (<config> <value>)...
 | *kw mail* (-i | \--interactive) [\--local | \--global]
 | *kw mail* (-l | \--list)
@@ -54,6 +54,9 @@ OPTIONS
 \--simulate:
   Do everything without actually sending the e-mail. This is similar to
   ``git send-email``'s ``--dry-run`` option.
+
+\--private:
+  Supress auto generation of recipients.
 
 <rev-range>...:
   Specify the *<rev-range>* to be sent. The last commit is taken as the

--- a/documentation/man/features/mail.rst
+++ b/documentation/man/features/mail.rst
@@ -6,11 +6,11 @@ kw-mail
 
 SYNOPSIS
 ========
-| *kw mail* (-s | \--send) [\--simulate] [\--to='<recipient>,...'] [\--cc='<recipient>,...']
+| *kw mail* (-s | \--send) [\--simulate] [\--to='<recipient>,...'] [\--cc='<recipient>,...'] [<rev-range>...] [-v<version>] [\-- <extra-args>...]
 | *kw mail* (-t | \--setup) [\--local | \--global] [-f | \--force] (<config> <value>)...
 | *kw mail* (-i | \--interactive) [\--local | \--global]
-| *kw mail* (-v | \--verify) [\--local | \--global]
 | *kw mail* (-l | \--list)
+| *kw mail* \--verify [\--local | \--global]
 | *kw mail* \--template[=<template>] [-n | \--no-interactive] [\--local | \--global] [-f | \--force] [(<config> <value>)...]
 
 DESCRIPTION
@@ -20,11 +20,17 @@ It is common to deal with patch submissions to a mailing list, and
 **mail** functionality aims to wrap this tool to simplify its usage and
 integrate it with other **kw** functionalities.
 
+.. note::
+  Any option recognized by ``git send-email`` can be passed directly to it if
+  placed after the double dash (``--``) argument.
+
 OPTIONS
 =======
 -s, \--send:
-  Send the last commit as a patch using ``git send-email`` to the e-mail
-  adresses specified with ``--to`` and ``--cc``.
+  Send a patch by email using ``git send-email`` to the email adresses
+  specified with ``--to`` and ``--cc``. You can provide *<extra-args>* to be
+  passed directly to ``git send-email``, they should be placed after the double
+  dash (``--``) argument.
 
 \--to='<recipient>,...':
   Specify the recipients that will receive the patch via e-mail. The
@@ -37,6 +43,13 @@ OPTIONS
 \--simulate:
   Do everything without actually sending the e-mail. This is similar to
   ``git send-email``'s ``--dry-run`` option.
+
+<rev-range>...:
+  Specify the *<rev-range>* to be sent. The last commit is taken as the
+  default.
+
+-v<version>:
+  Specify a number *<version>* for your patch.
 
 -t, \--setup:
   Initialize and configure **mail** functionality. Each argument specifies a
@@ -70,7 +83,7 @@ OPTIONS
   Forces the configurations to be added, regardless of conflicts with the
   current values already set in the system. Implies ``--no-interactive``.
 
--v, \--verify:
+\--verify:
   Verify that all the settings needed are set and valid.
 
 \--template[=<template>]:
@@ -97,3 +110,11 @@ Then when you are sure the command executed as expected, drop the
 ``--simulate`` argument to actually send the patch::
 
   kw mail --send --to=some@email.com
+
+To send a range of commits the following can be used::
+
+  kw mail -s <SHA1>..<SHA2>
+
+Extra arguments can be passed directly to ``git send-email`` like this::
+
+  kw mail -s --to='some@email.com' -- --thread

--- a/documentation/man/features/mail.rst
+++ b/documentation/man/features/mail.rst
@@ -25,6 +25,11 @@ mailing lists fetched with the *get_maintainer.pl* script. It will also use
 the union of the recipients of each patch as the recipients of the cover-letter.
 
 .. note::
+  You can block certain e-mail addresses from being automatically added to the
+  recipients list of the patches using the *blocked_emails* option in the
+  *kworkflow.config* file.
+
+.. note::
   Any option recognized by ``git send-email`` can be passed directly to it if
   placed after the double dash (``--``) argument.
 

--- a/documentation/man/features/mail.rst
+++ b/documentation/man/features/mail.rst
@@ -6,6 +6,7 @@ kw-mail
 
 SYNOPSIS
 ========
+| *kw mail* (-s | \--send) [\--simulate] [\--to='<recipient>,...'] [\--cc='<recipient>,...']
 | *kw mail* (-t | \--setup) [\--local | \--global] [-f | \--force] (<config> <value>)...
 | *kw mail* (-i | \--interactive) [\--local | \--global]
 | *kw mail* (-v | \--verify) [\--local | \--global]
@@ -21,6 +22,22 @@ integrate it with other **kw** functionalities.
 
 OPTIONS
 =======
+-s, \--send:
+  Send the last commit as a patch using ``git send-email`` to the e-mail
+  adresses specified with ``--to`` and ``--cc``.
+
+\--to='<recipient>,...':
+  Specify the recipients that will receive the patch via e-mail. The
+  *<recipient>* list can be in any format accepted by ``git send-email``, e.g.:
+  ``some@email.com`` or ``Xpto Lala <lala.xpto@mail.com>``.
+
+\--cc='<recipient>,...':
+  Specify the recipients that will receive a copy of the patch via e-mail.
+
+\--simulate:
+  Do everything without actually sending the e-mail. This is similar to
+  ``git send-email``'s ``--dry-run`` option.
+
 -t, \--setup:
   Initialize and configure **mail** functionality. Each argument specifies a
   *<config>* to be set with the corresponding *<value>*, multiple *<config>*
@@ -71,3 +88,12 @@ variables at once::
 
   kw mail -t --name 'Xpto Lala' --email myemail@gmail.com --smtpencryption tls \
     --smtpserver smtp.gmail.com --smtpserverport 587 --smtpuser myemail@gmail.com
+
+To simulate sending the last commit as a patch just write::
+
+  kw mail --send --simulate --to=some@email.com
+
+Then when you are sure the command executed as expected, drop the
+``--simulate`` argument to actually send the patch::
+
+  kw mail --send --to=some@email.com

--- a/documentation/man/features/mail.rst
+++ b/documentation/man/features/mail.rst
@@ -19,6 +19,10 @@ It is common to deal with patch submissions to a mailing list, and
 ``git send-email`` is one of the most famous tools for handling that. The
 **mail** functionality aims to wrap this tool to simplify its usage and
 integrate it with other **kw** functionalities.
+If used inside of a linux kernel tree the send feature will auto populate the
+*to* and *cc* fields of each patch file with the appropriate maintainers and
+mailing lists fetched with the *get_maintainer.pl* script. It will also use
+the union of the recipients of each patch as the recipients of the cover-letter.
 
 .. note::
   Any option recognized by ``git send-email`` can be passed directly to it if
@@ -125,3 +129,9 @@ To send a range of commits the following can be used::
 Extra arguments can be passed directly to ``git send-email`` like this::
 
   kw mail -s --to='some@email.com' -- --thread
+
+If you are inside of a linux kernel tree, you can send the last three commits
+as a patchset to the maintainers of the subsystems and with copies to the
+appropriate mailing lists using::
+
+  kw mail -s -3

--- a/documentation/man/features/mail.rst
+++ b/documentation/man/features/mail.rst
@@ -30,7 +30,14 @@ OPTIONS
   Send a patch by email using ``git send-email`` to the email adresses
   specified with ``--to`` and ``--cc``. You can provide *<extra-args>* to be
   passed directly to ``git send-email``, they should be placed after the double
-  dash (``--``) argument.
+  dash (``--``) argument. By default this function assumes these arguments to
+  ``git send-email``::
+
+    --annotate --cover-letter --no-chain-reply-to --thread
+
+  .. note::
+    You can change the default arguments used to send emails in the
+    *kworkflow.config* file.
 
 \--to='<recipient>,...':
   Specify the recipients that will receive the patch via e-mail. The

--- a/etc/kworkflow_template.config
+++ b/etc/kworkflow_template.config
@@ -93,3 +93,7 @@ disable_statistics_data_track=no
 
 # Send-email options to be used when sending a patch
 send_opts=--annotate --cover-letter --no-chain-reply-to --thread
+
+# You can choose to block certain emails from being added to the recipients
+# list of your patches, separate values with commas
+#blocked_emails=

--- a/etc/kworkflow_template.config
+++ b/etc/kworkflow_template.config
@@ -90,3 +90,6 @@ disable_statistics_data_track=no
 #gui_on=systemctl isolate graphical.target
 # Set a specific command to deactivate the GUI
 #gui_off=systemctl isolate multi-user.target
+
+# Send-email options to be used when sending a patch
+send_opts=--annotate --cover-letter --no-chain-reply-to --thread

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -46,7 +46,7 @@ function _kw_autocomplete()
   kw_options['mail']='--setup --local --global --force --verify --list --email
                      --name --smtpuser --smtpencryption --smtpserver
                      --smtpserverport --smtppass --template --interactive
-                     --no-interactive'
+                     --no-interactive --send --to --cc --simulate'
 
   kw_options['maintainers']='--authors --update-patch'
   kw_options['m']="${kw_options['mantainers']}"

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -46,7 +46,7 @@ function _kw_autocomplete()
   kw_options['mail']='--setup --local --global --force --verify --list --email
                      --name --smtpuser --smtpencryption --smtpserver
                      --smtpserverport --smtppass --template --interactive
-                     --no-interactive --send --to --cc --simulate'
+                     --no-interactive --send --to --cc --simulate --private'
 
   kw_options['maintainers']='--authors --update-patch'
   kw_options['m']="${kw_options['mantainers']}"

--- a/src/kw_config_loader.sh
+++ b/src/kw_config_loader.sh
@@ -75,6 +75,7 @@ function show_variables()
 
   local -Ar mail=(
     [send_opts]='Options to be used when sending a patch'
+    [blocked_emails]='Blocked e-mail addresses'
   )
 
   local -Ar misc=(

--- a/src/kw_config_loader.sh
+++ b/src/kw_config_loader.sh
@@ -73,6 +73,10 @@ function show_variables()
     [reboot_after_deploy]='Reboot after deploy'
   )
 
+  local -Ar mail=(
+    [send_opts]='Options to be used when sending a patch'
+  )
+
   local -Ar misc=(
     [disable_statistics_data_track]='Disable tracking of statistical data'
     [gui_on]='Command to activate GUI'
@@ -82,6 +86,7 @@ function show_variables()
   local -Ar group_descriptions=(
     [build]='Kernel build options'
     [deploy]='Kernel deploy options'
+    [mail]='Send-email options'
     [ssh]='SSH options'
     [qemu]='QEMU options'
     [notification]='Notification options'
@@ -91,7 +96,7 @@ function show_variables()
   say 'kw configuration variables:'
   printf '%s\n' "  Local config file: $has_local_config_path"
 
-  for group in 'build' 'deploy' 'qemu' 'ssh' 'notification' 'misc'; do
+  for group in 'build' 'deploy' 'qemu' 'mail' 'ssh' 'notification' 'misc'; do
     printf '%s\n' "  ${group_descriptions["$group"]}:"
     local -n descriptions="$group"
 

--- a/src/mail.sh
+++ b/src/mail.sh
@@ -80,6 +80,7 @@ function mail_main()
 function mail_send()
 {
   local flag="$1"
+  local opts="${configurations[send_opts]}"
   local to_recipients="${options_values['TO']}"
   local cc_recipients="${options_values['CC']}"
   local dryrun="${options_values['SIMULATE']}"
@@ -100,6 +101,7 @@ function mail_send()
     cmd+=" --cc=\"$cc_recipients\""
   fi
 
+  [[ -n "$opts" ]] && cmd+=" $opts"
   [[ -n "$extra_opts" ]] && cmd+=" $extra_opts"
 
   cmd_manager "$flag" "$cmd"

--- a/src/mail.sh
+++ b/src/mail.sh
@@ -17,6 +17,7 @@ declare -ga essential_config_options=('user.name' 'user.email'
   'sendemail.smtpuser' 'sendemail.smtpserver' 'sendemail.smtpserverport')
 declare -ga optional_config_options=('sendemail.smtpencryption' 'sendemail.smtppass')
 
+#shellcheck disable=SC2119
 function mail_main()
 {
   if [[ "$1" =~ -h|--help ]]; then
@@ -34,7 +35,7 @@ function mail_main()
   get_configs
 
   if [[ "${options_values['VERIFY']}" == 1 ]]; then
-    mail_verify ''
+    mail_verify
     exit
   fi
 
@@ -50,12 +51,12 @@ function mail_main()
   fi
 
   if [[ -n "${options_values['INTERACTIVE']}" ]]; then
-    interactive_setup ''
+    interactive_setup
     exit
   fi
 
   if [[ "${options_values['SETUP']}" == 1 ]]; then
-    mail_setup ''
+    mail_setup
     exit
   fi
 

--- a/src/plugins/kw_mail/to_cc_cmd.sh
+++ b/src/plugins/kw_mail/to_cc_cmd.sh
@@ -1,0 +1,40 @@
+# This file reads the files generated containing the recipients for any given
+# patch, this is supposed to be used by `git send-email` in the `--to-cmd` and
+# `--cc-cmd` arguments after the appropriate files have been created using the
+# `generate_kernel_recipients` function in the `src/mail.sh` file.
+
+# This reads the list of recipients stored in a file corresponding to the given
+# patch
+#
+# @kw_cache:   Path to KW_CACHE_DIR
+# @to_cc:      Should be either `to` or `cc` and defines which list to read, passed
+#                by kw.
+# @patch_path: Path to the current patch, passed by `git send-email`. Always
+#                the last argument.
+#
+# Returns:
+# Relevant list of recipients to the patch
+function to_cc_main()
+{
+  local kw_cache="$1"
+  local to_cc="$2"
+  local patch_path="$3"
+  local patch
+  local patch_cache="${kw_cache}/patches/${to_cc}"
+  local recipients_path
+  local recipients
+
+  [[ -z "$to_cc" || -z "$patch_path" ]] && return 22 # EINVAL
+
+  patch="$(basename "$patch_path")"
+
+  if [[ "$patch" =~ cover-letter ]]; then
+    cat "${patch_cache}/cover-letter"
+    exit 0
+  fi
+
+  cat "${patch_cache}/${patch}"
+  exit 0
+}
+
+to_cc_main "$@"

--- a/tests/kw_config_loader_test.sh
+++ b/tests/kw_config_loader_test.sh
@@ -83,6 +83,7 @@ function test_parse_configuration_output()
     [gui_on]='turn on'
     [gui_off]='turn off'
     [doc_type]='htmldocs'
+    [send_opts]='--annotate --cover-letter --no-chain-reply-to --thread'
   )
 
   cp tests/samples/kworkflow.config "$TMP_DIR/"
@@ -125,6 +126,7 @@ function test_parse_configuration_standard_config()
     [reboot_after_deploy]='no'
     [disable_statistics_data_track]='no'
     [doc_type]='htmldocs'
+    [send_opts]='--annotate --cover-letter --no-chain-reply-to --thread'
   )
 
   parse_configuration "$TMP_DIR/kworkflow.config"

--- a/tests/kw_config_loader_test.sh
+++ b/tests/kw_config_loader_test.sh
@@ -84,6 +84,7 @@ function test_parse_configuration_output()
     [gui_off]='turn off'
     [doc_type]='htmldocs'
     [send_opts]='--annotate --cover-letter --no-chain-reply-to --thread'
+    [blocked_emails]='test@email.com'
   )
 
   cp tests/samples/kworkflow.config "$TMP_DIR/"

--- a/tests/mail_test.sh
+++ b/tests/mail_test.sh
@@ -407,6 +407,13 @@ function test_mail_send()
   output=$(mail_send 'TEST_MODE')
   expected='git send-email --to="mail@test.com" extra_args --other_arg -13 -v2'
   assert_equals_helper 'Testing no options option' "$LINENO" "$output" "$expected"
+
+  parse_mail_options '--to=mail@test.com'
+  parse_configuration "$KW_CONFIG_SAMPLE"
+
+  output=$(mail_send 'TEST_MODE')
+  expected='git send-email --to="mail@test.com" --annotate --cover-letter --no-chain-reply-to --thread @^'
+  assert_equals_helper 'Testing default option' "$LINENO" "$output" "$expected"
 }
 
 function test_get_configs()

--- a/tests/mail_test.sh
+++ b/tests/mail_test.sh
@@ -226,6 +226,33 @@ function test_reposition_commit_count_arg()
   assert_equals_helper 'Should handle multiple arguments' "$LINENO" "$output" "$expected"
 }
 
+function test_remove_blocked_recipients()
+{
+  local output
+  local expected
+  local recipients=$'test@mail.com\nXpto Lala <xpto@mail.com>\nlala@mail.com\n'
+  recipients+=$'xpto.lala@mail.com'
+
+  output="$(remove_blocked_recipients '' test)"
+  assertTrue "($LINENO) Empty recipients." '[[ -z "$output" ]]'
+
+  output="$(remove_blocked_recipients "$recipients" test)"
+  expected="$recipients"
+  multilineAssertEquals "($LINENO) Expected no change." "$expected" "$output"
+
+  output="$(remove_blocked_recipients "$recipients" test@mail.com)"
+  expected=$'Xpto Lala <xpto@mail.com>\nlala@mail.com\nxpto.lala@mail.com'
+  multilineAssertEquals "($LINENO) Removing one email." "$expected" "$output"
+
+  output="$(remove_blocked_recipients "$recipients" lala@mail.com)"
+  expected=$'test@mail.com\nXpto Lala <xpto@mail.com>\nxpto.lala@mail.com'
+  multilineAssertEquals "($LINENO) Removing one email." "$expected" "$output"
+
+  output="$(remove_blocked_recipients "$recipients" test@mail.com,xpto@mail.com)"
+  expected=$'lala@mail.com\nxpto.lala@mail.com'
+  multilineAssertEquals "($LINENO) Removing two emails." "$expected" "$output"
+}
+
 function test_mail_parser()
 {
   local output

--- a/tests/mail_test.sh
+++ b/tests/mail_test.sh
@@ -271,6 +271,10 @@ function test_mail_parser()
   parse_mail_options '--send'
   assert_equals_helper 'Set send flag' "$LINENO" "${options_values['SEND']}" 1
 
+  parse_mail_options '--private'
+  expected='--suppress-cc=all'
+  assert_equals_helper 'Set private flag' "$LINENO" "${options_values['PRIVATE']}" "$expected"
+
   parse_mail_options '--to=some@mail.com'
   expected='some@mail.com'
   assert_equals_helper 'Set to flag' "$LINENO" "${options_values['TO']}" "$expected"
@@ -408,6 +412,12 @@ function test_mail_send()
   output=$(mail_send 'TEST_MODE')
   expected='git send-email --dry-run @^'
   assert_equals_helper 'Testing send with simulate option' "$LINENO" "$output" "$expected"
+
+  parse_mail_options '--private'
+
+  output=$(mail_send 'TEST_MODE')
+  expected="git send-email --suppress-cc=all @^"
+  assert_equals_helper 'Testing send with to option' "$LINENO" "$output" "$expected"
 
   parse_mail_options '--to=mail@test.com' 'HEAD~'
 

--- a/tests/mail_test.sh
+++ b/tests/mail_test.sh
@@ -140,6 +140,25 @@ function test_mail_parser()
   assert_equals_helper 'Invalid option passed' "$LINENO" "$ret" 22
 
   # valid options
+  parse_mail_options '--send'
+  assert_equals_helper 'Set send flag' "$LINENO" "${options_values['SEND']}" 1
+
+  parse_mail_options '--to=some@mail.com'
+  expected='some@mail.com'
+  assert_equals_helper 'Set to flag' "$LINENO" "${options_values['TO']}" "$expected"
+
+  parse_mail_options '--cc=some@mail.com'
+  expected='some@mail.com'
+  assert_equals_helper 'Set cc flag' "$LINENO" "${options_values['CC']}" "$expected"
+
+  parse_mail_options '--simulate'
+  expected='--dry-run'
+  assert_equals_helper 'Set simulate flag' "$LINENO" "${options_values['SIMULATE']}" "$expected"
+
+  parse_mail_options '--to=name1@lala.com,name2@lala.xpto,name3 second <name3second@lala.com>'
+  expected='name1@lala.com,name2@lala.xpto,name3 second <name3second@lala.com>'
+  assert_equals_helper 'Set to flag' "$LINENO" "${options_values['TO']}" "$expected"
+
   parse_mail_options '--setup'
   expected=1
   assert_equals_helper 'Set setup flag' "$LINENO" "${options_values['SETUP']}" "$expected"
@@ -218,6 +237,35 @@ function test_mail_parser()
   parse_mail_options '-t' '--smtppass' 'verySafePass'
   expected='verySafePass'
   assert_equals_helper 'Set smtp pass' "$LINENO" "${options_values['sendemail.smtppass']}" "$expected"
+}
+
+function test_mail_send()
+{
+  local expected
+  local output
+  local ret
+
+  output=$(mail_send 'TEST_MODE')
+  expected='git send-email @^'
+  assert_equals_helper 'Testing send without options' "$LINENO" "$output" "$expected"
+
+  parse_mail_options '--to=mail@test.com'
+
+  output=$(mail_send 'TEST_MODE')
+  expected='git send-email --to="mail@test.com" @^'
+  assert_equals_helper 'Testing send with to option' "$LINENO" "$output" "$expected"
+
+  parse_mail_options '--cc=mail@test.com'
+
+  output=$(mail_send 'TEST_MODE')
+  expected='git send-email --cc="mail@test.com" @^'
+  assert_equals_helper 'Testing send with c option' "$LINENO" "$output" "$expected"
+
+  parse_mail_options '--simulate'
+
+  output=$(mail_send 'TEST_MODE')
+  expected='git send-email --dry-run @^'
+  assert_equals_helper 'Testing send with simulate option' "$LINENO" "$output" "$expected"
 }
 
 function test_get_configs()

--- a/tests/mail_test.sh
+++ b/tests/mail_test.sh
@@ -377,6 +377,12 @@ function test_mail_send()
   local output
   local ret
 
+  cd "$FAKE_GIT" || {
+    ret="$?"
+    fail "($LINENO): Failed to move to fake git repo"
+    exit "$ret"
+  }
+
   parse_mail_options
 
   output=$(mail_send 'TEST_MODE')
@@ -435,8 +441,21 @@ function test_mail_send()
   parse_configuration "$KW_CONFIG_SAMPLE"
 
   output=$(mail_send 'TEST_MODE')
-  expected='git send-email --to="mail@test.com" --annotate --cover-letter --no-chain-reply-to --thread @^'
+  expected='git send-email --to="mail@test.com" --annotate  --no-chain-reply-to --thread @^'
   assert_equals_helper 'Testing default option' "$LINENO" "$output" "$expected"
+
+  parse_mail_options '--to=mail@test.com' '@^^'
+  parse_configuration "$KW_CONFIG_SAMPLE"
+
+  output=$(mail_send 'TEST_MODE')
+  expected='git send-email --to="mail@test.com" --annotate --cover-letter --no-chain-reply-to --thread @^^'
+  assert_equals_helper 'Testing default option' "$LINENO" "$output" "$expected"
+
+  cd "$ORIGINAL_DIR" || {
+    ret="$?"
+    fail "($LINENO): Failed to move back to original dir"
+    exit "$ret"
+  }
 }
 
 function test_get_configs()

--- a/tests/plugins/kw_mail/to_cc_cmd_test.sh
+++ b/tests/plugins/kw_mail/to_cc_cmd_test.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+include './tests/utils.sh'
+
+function oneTimeSetUp()
+{
+  declare -gr ORIGINAL_DIR="$PWD"
+  declare -gr FAKE_CACHE="${SHUNIT_TMPDIR}/cache"
+  declare -gr PATCH_CACHE="${FAKE_CACHE}/patches"
+
+  declare -gr TO_LIST=$'to@one.com\nto@two.com\nto@three.com'
+
+  declare -gr CC_LIST=$'cc@one.com\ncc@two.com'
+
+  mkdir -p "${PATCH_CACHE}/to/" "${PATCH_CACHE}/cc/"
+
+  printf '%s\n' "$TO_LIST" > "${PATCH_CACHE}/to/to_list"
+  printf '%s\n' "$CC_LIST" > "${PATCH_CACHE}/cc/cc_list"
+
+  printf '%s\n' "$TO_LIST" > "${PATCH_CACHE}/to/cover-letter"
+  printf '%s\n' "$CC_LIST" >> "${PATCH_CACHE}/to/cover-letter"
+}
+
+function oneTimeTearDown()
+{
+  rm -rf "$FAKE_CACHE"
+}
+
+function test_to_cc_main()
+{
+  local to_cc_cmd="${ORIGINAL_DIR}/src/plugins/kw_mail/to_cc_cmd.sh"
+  local expected
+  local output
+  local ret
+
+  bash "$to_cc_cmd" "$FAKE_CACHE" 'to' ''
+  ret="$?"
+  assert_equals_helper 'Empty patch path should return an error' "$LINENO" "$ret" 22
+
+  bash "$to_cc_cmd" "$FAKE_CACHE" '' 'to_list'
+  ret="$?"
+  assert_equals_helper 'Empty to_cc should return an error' "$LINENO" "$ret" 22
+
+  output="$(bash "$to_cc_cmd" "$FAKE_CACHE" to to_list)"
+  expected="$TO_LIST"
+  multilineAssertEquals "($LINENO) Testing to_cc_cmd to output" "$expected" "$output"
+
+  output="$(bash "$to_cc_cmd" "$FAKE_CACHE" to longer/path/to_list)"
+  expected="$TO_LIST"
+  multilineAssertEquals "($LINENO) Testing to_cc_cmd to output" "$expected" "$output"
+
+  output="$(bash "$to_cc_cmd" "$FAKE_CACHE" cc cc_list)"
+  expected="$CC_LIST"
+  multilineAssertEquals "($LINENO) Testing to_cc_cmd cc output" "$expected" "$output"
+
+  output="$(bash "$to_cc_cmd" "$FAKE_CACHE" cc longer/path/cc_list)"
+  expected="$CC_LIST"
+  multilineAssertEquals "($LINENO) Testing to_cc_cmd cc output" "$expected" "$output"
+
+  output="$(bash "$to_cc_cmd" "$FAKE_CACHE" to cover-letter)"
+  expected="$TO_LIST"$'\n'"$CC_LIST"
+  multilineAssertEquals "($LINENO) Testing to_cc_cmd cover-letter output" "$expected" "$output"
+}
+
+invoke_shunit

--- a/tests/samples/kworkflow.config
+++ b/tests/samples/kworkflow.config
@@ -12,3 +12,4 @@ reboot_after_deploy=no
 gui_on=turn on
 gui_off=turn off
 doc_type=htmldocs
+send_opts=--annotate --cover-letter --no-chain-reply-to --thread

--- a/tests/samples/kworkflow.config
+++ b/tests/samples/kworkflow.config
@@ -13,3 +13,4 @@ gui_on=turn on
 gui_off=turn off
 doc_type=htmldocs
 send_opts=--annotate --cover-letter --no-chain-reply-to --thread
+blocked_emails=test@email.com

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -177,6 +177,11 @@ function mk_fake_git()
 
   git add first_file
   git commit -q -m 'Initial commit'
+
+  git add --all
+  git commit --allow-empty -q -m 'Second commit'
+
+  git commit --allow-empty -q -m 'Third commit'
 }
 
 # This function expects an array of string with the command sequence and a

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -178,9 +178,12 @@ function mk_fake_git()
   git add first_file
   git commit -q -m 'Initial commit'
 
+  printf 'Second change\n' >> "$path/first_file"
   git add --all
   git commit --allow-empty -q -m 'Second commit'
 
+  printf 'Third change\n' >> "$path/first_file"
+  git add --all
   git commit --allow-empty -q -m 'Third commit'
 }
 


### PR DESCRIPTION
Add send capabilities to the mail feature.

If inside a kernel root will add default options and populate the `to` and `cc` fields.

I believe this to be fully functional now. Some tests could be improved still. I believe it would be beneficial to have a sample `.git` folder so we have control over the resulting patch files.