### PR TITLE
Feature implementation: environments

### DIFF
--- a/documentation/man/features/configm.rst
+++ b/documentation/man/features/configm.rst
@@ -17,57 +17,55 @@ DESCRIPTION
 The **configm** command manages different versions of the project's **.config**
 file. It provides the save, load, remove, and list operations of such files. By
 default, if the user does not provide any parameter, the configm will list all
-configs under kw management.
+configs under **kw**'s management.
 
 OPTIONS
 =======
 \--save <name> [-d <description>] [-f | \--force]:
-  The save option searches the current directory for a **.config** file to be
-  kept under the management of **kw**. The save option expects a name to identify
-  this version of the file. Additionally, users can add a description by
-  using ``-d`` flag. Finally, if the user tries to add the same name twice,
-  **kw** will issue a warning; ``-f`` will suppress this message.
+  The save option creates a snapshot of the **.config** file in the current
+  folder in **kw**'s management system under the specified *<name>*.
+  Additionally, users can add a description by using the ``-d`` flag. Finally,
+  if the user tries to add another config with a name that's already being
+  managed, **kw** will issue a warning; ``-f`` will suppress such a warning.
 
 -l, \--list:
-  Lists all the **.config** file versions available. If the user does not
-  provide any command option, kw will assume the list option.
+  Lists all the **.config** file versions available. This is also the default
+  behavior when no option is specified.
 
 \--get <name> [-f | \--force]:
-  Get a config file based on the *<name>* and paste it in the current
-  directory. It pop-up a warning message because this operation override the
-  current **.config** file. The user can suppress this warning by using ``-f``
-  flag.
+  Get a copy of the config file with the provided *<name>* in the current
+  directory. As this operation overwrites the current **.config** file a
+  warning is shown; ``-f`` will suppress such a warning and carry on any
+  destructive operations.
 
 -r <name> [-f | \--force], \--remove <name> [-f | \--force]:
-  Remove config labeled with *<name>*. It pop-up a warning message because it
-  will remove the config file from kw management. The user can suppress this
-  warning by using ``-f``.
+  Remove config labeled with *<name>* from **kw**'s management system. As this
+  operation removes a **.config** file from kw management a warning is shown;
+  ``-f`` will suppress such a warning and carry on any destructive operations.
 
 \--fetch [(-o | \--output) <filename>] [-f | \--force] [\--optimize] [\--remote [<remote>:<port>]]:
-  This option fetches a .config file from a target machine to your current
-  directory. If another .config is found in this directory, then it will ask you
-  whether you want to replace it or not. If you use the force option, the
-  .config file will be overwritten without any warnings. By using the output
-  option, you can specify the config file name. With the optimize option,
-  `make localmodconfig` will be run to generate an optimized version of a
-  previously fetched .config file.
-
+  Fetches a **.config** file from a target machine to your current directory.
+  If another config is found in this directory, then **kw** will ask you
+  whether you want to replace it or not; ``-f`` will suppress such a warning
+  and carry on any destructive operations. ``--output`` allows you to specify
+  the config file name, and ``--optimize`` will run `make localmodconfig` in
+  order to generate a config that's optimized for the target machine.
 
 EXAMPLES
 ========
-For these examples, we suppose the fields in your **kworkflow.config** file are
-already configured.
+In the following examples, we assume your **kworkflow.config** file is already
+properly configured.
 
-In case you want that kw saves your current **.config** file, you can use::
+In case you want **kw** to save your current **.config** file, you can use::
 
   cd <kernel-path>
   kw g --save my_current_config
 
-You can see the config's file maintained by kw with::
+You can see the config's file maintained by **kw** with::
 
   kw g --list
 
-If you want to fetch a .config file from a remote machine at localhost:2222 with
-user root, then you can run::
+If you want to fetch a config from a remote machine (available at
+``localhost:2222``) as root, you can run::
 
   kw configm --fetch --remote root@localhost:2222

--- a/documentation/man/features/environment.rst
+++ b/documentation/man/features/environment.rst
@@ -1,0 +1,63 @@
+==============
+kw-environment
+==============
+
+.. _environment-doc:
+
+SYNOPSIS
+========
+| *kw* (*env* | *environment*) [(-s | \--switch) <name> [(-d | \--description) <description>]
+| *kw* (*env* | *environment*) [-l | \--list]
+| *kw* (*env* | *environment*) [(-c | --clean) <name>]
+| *kw* (*env* | *environment*) [(-D | \--destroy) <name>]
+
+DESCRIPTION
+===========
+The **environment** command switches between different outputs of the project.
+It provides the switch, clean, destroy, and list operations for such outputs.
+By default, if the user does not provide any parameter, the environment command
+will list all existing environments under the current project.
+
+OPTIONS
+=======
+-s, \--switch <name> [(-d | --description) <description>]:
+  The save option searches the current directory for a **.config** file to be
+  kept under the management of **kw**. The save option expects a name to identify
+  this version of the file. Additionally, users can add a description by
+  using ``-d`` flag. Finally, if the user tries to add the same name twice,
+  **kw** will issue a warning; ``-f`` will suppress this message.
+
+-l, \--list:
+  Lists all the **.config** file versions available. If the user does not
+  provide any command option, kw will assume the list option.
+
+-c, \--clean <name>:
+  Get a config file based on the *<name>* and paste it in the current
+  directory. It pop-up a warning message because this operation override the
+  current **.config** file. The user can suppress this warning by using ``-f``
+  flag.
+
+-D, \--destroy <name>:
+  Remove config labeled with *<name>*. It pop-up a warning message because it
+  will remove the config file from kw management. The user can suppress this
+  warning by using ``-f``.
+
+
+EXAMPLES
+========
+For these examples, we suppose the fields in your **kworkflow.config** file are
+already configured.
+
+In case you want that kw saves your current **.config** file, you can use::
+
+  cd <kernel-path>
+  kw env --switch kunit_build
+
+You can see the config's file maintained by kw with::
+
+  kw g --list
+
+If you want to fetch a .config file from a remote machine at localhost:2222 with
+user root, then you can run::
+
+  kw configm --fetch --remote root@localhost:2222

--- a/kw
+++ b/kw
@@ -114,6 +114,11 @@ function kw()
 
       diff_manager "$@"
       ;;
+    environment | env)
+      include "$KW_LIB_DIR/environment.sh"
+
+      env_manager "$@"
+      ;;
     ssh | s)
       (
         include "$KW_LIB_DIR/kw_config_loader.sh"

--- a/src/config_manager.sh
+++ b/src/config_manager.sh
@@ -687,6 +687,6 @@ function config_manager_help()
     '  configm --fetch [(-o | --output) <filename>] [-f | --force] [--optimize] [--remote [<user>@<ip>:<port>]] - Fetch a config' \
     '  configm (-s | --save) <name> [(-d | --description) <description>] [-f | --force] - Save a config' \
     '  configm (-l | --list) - List config files under kw management' \
-    '  configm --get <name> [-f | --force] - Get a config file based named <name>' \
+    '  configm --get <name> [-f | --force] - Get a config labeled with <name>' \
     '  configm (-r | --remove) <name> [-f | --force] - Remove config labeled with <name>'
 }

--- a/src/config_manager.sh
+++ b/src/config_manager.sh
@@ -91,7 +91,7 @@ function save_config_file()
   local -r name="$2"
   local -r description="$3"
   local -r original_path="$PWD"
-  local -r dot_configs_dir="$KW_DATA_DIR/configs"
+  local -r dot_configs_dir="$KW_DATA_DIR/$configs_dir"
 
   if [[ ! -f "$original_path/.config" ]]; then
     complain 'There is no .config file in the current directory'
@@ -446,7 +446,7 @@ function fetch_config()
 
 function list_configs()
 {
-  local -r dot_configs_dir="$KW_DATA_DIR/configs"
+  local -r dot_configs_dir="$KW_DATA_DIR/$configs_dir"
   local name
   local content
 
@@ -481,7 +481,7 @@ function basic_config_validations()
   local force="$2"
   local operation="$3" && shift 3
   local message="$*"
-  local -r dot_configs_dir="$KW_DATA_DIR/configs/configs"
+  local -r dot_configs_dir="$KW_DATA_DIR/$configs_dir/$configs_dir"
 
   if [[ ! -f "$dot_configs_dir/$target" ]]; then
     complain "No such file or directory: $target"
@@ -513,7 +513,7 @@ function get_config()
 {
   local target="$1"
   local force="$2"
-  local -r dot_configs_dir="$KW_DATA_DIR/configs/configs"
+  local -r dot_configs_dir="$KW_DATA_DIR/$configs_dir/$configs_dir"
   local -r msg='This operation will override the current .config file'
 
   force=${force:-0}
@@ -539,7 +539,7 @@ function remove_config()
   local target="$1"
   local force="$2"
   local original_path="$PWD"
-  local -r dot_configs_dir="$KW_DATA_DIR/configs"
+  local -r dot_configs_dir="$KW_DATA_DIR/$configs_dir"
   local -r msg="This operation will remove $target from kw management"
 
   basic_config_validations "$target" "$force" 'Remove' "$msg"

--- a/src/debug.sh
+++ b/src/debug.sh
@@ -990,7 +990,7 @@ function parser_debug_options()
         ;;
       --list | -l)
         # Handling optional parameter
-        if [[ -z "$2" ]]; then
+        if [[ "$2" =~ ^- || -z "${2// /}" ]]; then
           options_values['LIST']=1
           shift 2
         else

--- a/src/environment.sh
+++ b/src/environment.sh
@@ -1,0 +1,275 @@
+include "$KW_LIB_DIR/kwlib.sh"
+include "$KW_LIB_DIR/kwio.sh"
+
+declare -gr metadata_dir='.metadata'
+declare -gr envs_dir='envs'
+declare -gr dot_envs_dir="$KW_DATA_DIR/$envs_dir"
+declare -gA options_values
+
+function env_manager()
+{
+  if [[ -z "$*" ]]; then
+    if [[ ! -v "$KW_ENV" ||
+      ! -d "$dot_envs_dir" && ! -d "$dot_configs_dir/$metadata_dir" ]]; then
+      say 'There are no environments in the current folder'
+      return 0
+    fi
+
+    list_envs
+    return "$?"
+  fi
+
+  if [[ "$1" =~ -h|--help ]]; then
+    env_help "$1"
+    exit 0
+  fi
+
+  parse_env_options "$@"
+
+  if [[ "$?" -gt 0 ]]; then
+    complain "${options_values['ERROR']}"
+    exit 22 # EINVAL
+  fi
+
+  if [[ ! -v "$KW_ENV" ||
+    ! -d "$dot_envs_dir" && ! -d "$dot_configs_dir/$metadata_dir" ]]; then
+    complain 'There are no environments in the current folder'
+    return 2 # ENOENT
+  fi
+
+  if [[ -n "${options_values['SWITCH']}" ]]; then
+    switch_env "${options_values['SWITCH']}" "${options_values['DESCRIPTION']}"
+    return "$?"
+  fi
+
+  if [[ -n "${options_values['LIST']}" ]]; then
+    list_envs
+    return "$?"
+  fi
+
+  if [[ -n "${options_values['CLEAN']}" ]]; then
+    clean_env "${options_values['CLEAN']}"
+    return "$?"
+  fi
+
+  if [[ -n "${options_values['DESTROY']}" ]]; then
+    destroy_env "${options_values['DESTROY']}"
+    return "$?"
+  fi
+}
+
+function list_envs()
+{
+  local -r dot_envs_dir="$KW_DATA_DIR/$envs_dir"
+  local name
+  local content
+
+  printf '%-30s | %-30s\n' 'Name' $'Description\n'
+  for filename in "$dot_configs_dir/$metadata_dir"/*; do
+    [[ ! -f "$filename" ]] && continue
+    name=$(basename "$filename")
+    content=$(< "$filename")
+    printf '%-30s | %-30s\n' "$name" "$content"
+  done
+}
+
+function switch_envs()
+{
+  local -r name="$1"
+  local -r description="$2"
+  local -r current_output="$dot_envs_dir/$name"
+  local -r original_folder="$PWD"
+
+  # Create folders if missing
+  if [[ ! -d "$dot_envs_dir/$metadata_dir" ]]; then
+    mkdir -p "$dot_envs_dir/$metadata_dir"
+    cmd_manager "" "make mrproper -j"
+  fi
+
+  pushd "$dot_envs_dir" || exit_msg 'It was not possible to move to envs dir'
+
+  # Check if the metadata related to .config file already exists and if so
+  # check if the user wants to update description
+  if [[ -f "$metadata_dir/$name" &&
+    -n "$description" &&
+    $(ask_yN "$name already exists. Update description?") =~ '0' ]]; then
+    complain 'Switch operation aborted'
+    popd || exit_msg 'It was not possible to move back from envs dir'
+    return 0
+  fi
+
+  # Get valid .config location
+  get_current_env
+
+  if [[ "$?" != 0 ]]; then
+    if [[ -f "$original_folder/.config" ]]; then
+      cp "$original_folder/.config" "$dot_envs_dir/$name"
+    else
+      complain "Switch operation aborted. No valid config to be used in env $name"
+      popd || exit_msg 'It was not possible to move back from envs dir'
+      return 2 # ENOENT
+    fi
+  else
+    cp "$dot_envs_dir/$KW_ENV/.config" "$dot_envs_dir/$name"
+  fi
+
+  cmd_manager "" "make prepare archprepare O=$current_output -j"
+
+  # Save current env
+  printf '%s\n' "$name" > "$metadata_dir/current.meta"
+
+  [[ -n "$description" ]] &&
+    printf '%s\n' "$description" > "$metadata_dir/$name"
+
+  popd || exit_msg 'It was not possible to move back from envs dir'
+}
+
+function get_current_env()
+{
+  if [[ ! -v "KW_ENV" ]]; then
+    [[ ! -f "$metadata_dir/current.meta" ]] && return 2 # ENOENT
+    KW_ENV="$(< "$metadata_dir/current.meta")"
+  fi
+}
+
+function clean_env()
+{
+  local -r name="$1"
+  local -r current_output
+
+  if [[ -z "$name" ]]; then
+    if [[ "$(get_current_env)" != 0 ]]; then
+      complain "No env set"
+      return 2 # ENOENT
+    fi
+    current_output="$dot_envs_dir/$KW_ENV"
+  else
+    if [[ ! -d "$dot_envs_dir/$name" ]]; then
+      complain "Invalid arg"
+      return 22 # EINVAL
+    fi
+    current_output="$dot_envs_dir/$name"
+  fi
+
+  cmd_manager "" "make clean O=$current_output -j"
+}
+
+function destroy_env()
+{
+  local -r name="$1"
+  local -r current_output
+
+  get_current_env
+
+  if [[ "$KW_ENV" = "$name" ]]; then
+    complain "Cannot delete current env"
+    return 22 # EINVAL
+  fi
+
+  if [[ ! -d "$dot_envs_dir/$name" ]]; then
+    complain "Invalid arg"
+    return 22 # EINVAL
+  fi
+  current_output="$dot_envs_dir/$name"
+
+  rm -rf "$current_output"
+}
+
+function parse_env_options()
+{
+  local short_options
+  local long_options
+  local options
+
+  long_options='switch:,description:,list,clean::,destroy:'
+  short_options='s:,d:,l,c::,D:'
+
+  options="$(kw_parse "$short_options" "$long_options" "$@")"
+
+  if [[ "$?" != 0 ]]; then
+    options_values['ERROR']="$(kw_parse_get_errors 'kw environment' "$short_options" \
+      "$long_options" "$@")"
+    return 22 # EINVAL
+  fi
+
+  options_values['SWITCH']=''
+  options_values['DESCRIPTION']=''
+  options_values['LIST']=''
+  options_values['CLEAN']=''
+  options_values['DESTROY']=''
+
+  eval "set -- $options"
+
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --switch | -s)
+        # Validate string name
+        if [[ "$2" =~ ^- || -z "${2// /}" ]]; then
+          complain 'Invalid argument'
+          return 22 # EINVAL
+        fi
+        options_values['SWITCH']="$2"
+        shift 2
+        ;;
+      --description | -d)
+        # Validate string name
+        if [[ "$2" =~ ^- || -z "${2// /}" ]]; then
+          complain 'Invalid argument'
+          return 22 # EINVAL
+        fi
+        options_values['DESCRIPTION']="$2"
+        shift 2
+        ;;
+      --list | -l)
+        options_values['LIST']=1
+        shift
+        ;;
+      --clean | -c)
+        # Handling optional parameter
+        if [[ "$2" =~ ^- || -z "${2// /}" ]]; then
+          options_values['CLEAN']='1'
+          shift
+        else
+          options_values['CLEAN']="$2"
+          shift 2
+        fi
+        ;;
+      --destroy | -D)
+        # Validate string name
+        if [[ "$2" =~ ^- || -z "${2// /}" ]]; then
+          complain 'Invalid argument'
+          return 22 # EINVAL
+        fi
+        options_values['DESTROY']="$2"
+        shift 2
+        ;;
+      --)
+        shift
+        ;;
+      *)
+        complain "Invalid option: $1"
+        exit 22 # EINVAL
+        ;;
+    esac
+  done
+
+  if [[ -z "${options_values['SWITCH']}" &&
+    -n "${options_values['DESCRIPTION']}" ]]; then
+    complain '-d|--description can only be used with --switch'
+    return 22 # EINVAL
+  fi
+}
+
+function env_help()
+{
+  if [[ "$1" == --help ]]; then
+    include "$KW_LIB_DIR/help.sh"
+    kworkflow_man 'environment'
+    return
+  fi
+  printf '%s\n' 'kw environments:' \
+    '  env (-s | --switch) <name> [-d | --description <description>] - Switch to another (new) environment' \
+    '  env (-l | --list) - List existing kw environments' \
+    '  env (-c | --clean) <name> - Clean an environment' \
+    '  env (-D | --destroy) <name> - Destroy an environment'
+}

--- a/src/help.sh
+++ b/src/help.sh
@@ -22,6 +22,7 @@ function kworkflow_help()
     '  device - Show basic hardware information' \
     '  diff,df - Diff files' \
     '  drm - Set of commands to work with DRM drivers ' \
+    '  environment,env - Manage build output folders' \
     '  explore,e - Explore string patterns' \
     '  help,h - displays this help mesage' \
     '  init - Initialize kworkflow config file' \


### PR DESCRIPTION
This aims at implementing the environments feature (roughly described in #114).

There are some non-related commits in this branch as I made small improvements to other parts of the code I had been investigating, and those should be separated in other PR's as needed.

Tasklist:
- [x] Add feature base, having a clearer idea of what its API should be doing
    
    For this I've mainly been thinking in the following behavior:
    ```bash
    kw env (-s | --switch) <name> [(-d | \--description) <description>] [--keep-local] [(-g | --config) <config-name>] - Switch to another (new) environment
    kw env (-l | --list) - List existing kw environments
    kw env (-c | --clean) {name|(-a | --all)} - Clean an environment
    kw env (-D | --destroy) {name|(-a | --all)} [-f | --force] - Destroy an environment
    ```
    
    - One of the main problems I have with this API is the `--keep-local` flag, for which I couldn't think of an easy implementation.
    
    - Also, another thing that should be discussed is some sort of integration between the config manager's metadata and this one's as they should be very much related (one compilation output per config/arch).
- [ ] Implement feature details and integrations
- [ ] Clean up details, review git history, and separate (likely) other PR's