### PR TITLE
src: kw_time_and_date: fix get_week_beginning_day

### DIFF
--- a/src/kw_time_and_date.sh
+++ b/src/kw_time_and_date.sh
@@ -50,7 +50,7 @@ function get_week_beginning_day()
 
   format=${format:-'+%Y/%m/%d'}
   date_param=${date_param:-$(date '+%Y/%m/%d')}
-  week_day_num=$(date -d "$date_param" '+%u' 2> /dev/null)
+  week_day_num=$(date -d "$date_param" '+%w' 2> /dev/null)
 
   date --date="${date_param} - ${week_day_num} day" "$format" 2> /dev/null
 }

--- a/tests/kw_time_and_date_test.sh
+++ b/tests/kw_time_and_date_test.sh
@@ -56,9 +56,12 @@ function test_get_week_beginning_day()
   week_day=$(get_week_beginning_day "$ref_week" '+%m/%d')
   assert_equals_helper 'Day format is wrong' "$LINENO" '05/16' "$week_day"
 
+  week_day=$(get_week_beginning_day "$first_week_day")
+  assert_equals_helper 'First day of the week did not match' "$LINENO" "$first_week_day" "$week_day"
+
   # No parameters, means this week
   ref_week=$(date '+%Y/%m/%d')
-  this_week_day=$(date '+%u')
+  this_week_day=$(date '+%w')
   first_week_day=$(date --date="${ref_week} - ${this_week_day} day" '+%Y/%m/%d')
 
   week_day=$(get_week_beginning_day)


### PR DESCRIPTION
The previous implementation used the '%u' parameter to get the day of
the week of a given date, this returns 7 for sundays, this resulted in
the previous sunday being returned by the function, which is incorrect.
This changes the parameter to '%w', which returns 0 for sundays,
yielding the expected behavior.

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@usp.br>