### PR TITLE
Fix `debug` parameter handling

### DIFF
--- a/src/debug.sh
+++ b/src/debug.sh
@@ -905,7 +905,7 @@ function parser_debug_options()
   local transition_variables
 
   long_options='remote:,event:,ftrace:,dmesg,cmd:,local,history,disable,list::,follow,reset,help'
-  short_options='f,e,t,g,c,h,d,l,k'
+  short_options='e:,t:,g,f,c:,k,d,l::,h'
 
   options=$(kw_parse "$short_options" "$long_options" "$@")
 
@@ -990,7 +990,7 @@ function parser_debug_options()
         ;;
       --list | -l)
         # Handling optional parameter
-        if [[ -z "$2" ]]; then
+        if [[ "$2" =~ ^- || -z "${2// /}" ]]; then
           options_values['LIST']=1
           shift 2
         else


### PR DESCRIPTION
Previously, calling `kw debug -l -` or even with a whitespace as an argument `' '` would be considered an optional argument for the list subcomand.
    
This change fixes that, removing whitespaces or strings starting in dashes from being considered as possible (optional) arguments, and instead handling those with the parser itself, which doesn't at all affect functionality but provides more coherence in parameter handling throughout the project.
    
This commit also fixes previously incoherent parameter input in long/short options.