### PR TITLE
src: build: Add olddefconfig to build

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -92,6 +92,9 @@ function kernel_build()
     parallel_cores=$(grep -c ^processor /proc/cpuinfo)
   fi
 
+  # Let's avoid menu question by default
+  cmd_manager "$flag" "make ARCH=$arch $cross_compile olddefconfig --silent"
+
   command="make -j$parallel_cores ARCH=$arch $cross_compile"
 
   start=$(date +%s)


### PR DESCRIPTION
We tried to add olddefconfig as a step to be executed before building
the kernel to avoid the interactive menu. However, the first
implementation did not work well in a cross-compiled environment, and we
had to revert it. This commit brings it back and reworks the build tests
to make them more readable.

Closes #393

Signed-off-by: Rodrigo Siqueira <siqueirajordao@riseup.net>