### PR TITLE
plugins: kernel_install: arch: Fix mkinitcpio template path

### DIFF
--- a/src/plugins/kernel_install/arch.sh
+++ b/src/plugins/kernel_install/arch.sh
@@ -38,7 +38,7 @@ function generate_arch_temporary_root_file_system()
       cmd="$sudo_cmd "
       ;;
     'remote') # REMOTE_TARGET
-      template_path="$kw_path/template_mkinitcpio.preset"
+      template_path="$REMOTE_KW_DEPLOY/template_mkinitcpio.preset"
       ;;
   esac
 

--- a/tests/plugins/kernel_install/arch_test.sh
+++ b/tests/plugins/kernel_install/arch_test.sh
@@ -11,6 +11,7 @@ function setUp()
 
   export kw_path='/fake/remote/path'
   export KW_ETC_DIR='/fake/local/path'
+  export REMOTE_KW_DEPLOY='/fake/run/kw/etc'
 }
 
 function tearDown()
@@ -39,7 +40,7 @@ function test_generate_arch_temporary_root_file_system()
 
   # Remote
   declare -a cmd_sequence=(
-    "bash -c \"sed 's/NAME/$name/g' '$kw_path/template_mkinitcpio.preset' > /etc/mkinitcpio.d/$name.preset\""
+    "bash -c \"sed 's/NAME/$name/g' '$REMOTE_KW_DEPLOY/template_mkinitcpio.preset' > /etc/mkinitcpio.d/$name.preset\""
     "depmod --all $name"
     "mkinitcpio --preset $name"
   )


### PR DESCRIPTION
The template path for ArchLinux based system is wrong; as a result,
deploy to remote ArchLinux machines are not working. This commit fixes
this issue by using the right path.

Signed-off-by: Rodrigo Siqueira <siqueirajordao@riseup.net>