### PR TITLE
Add missing dependencies on arch.deps

### DIFF
--- a/documentation/dependencies/arch.dependencies
+++ b/documentation/dependencies/arch.dependencies
@@ -23,3 +23,4 @@ perl-authen-sasl
 perl-io-socket-ssl
 sqlite3
 pv
+rsync


### PR DESCRIPTION
This commit fixes the dependencies for the Arch install, as noted on _https://aur.archlinux.org/packages/kworkflow-git#comment-856570_