### PR TITLE
src: kernel_install: Add missing dependencies

### DIFF
--- a/src/plugins/kernel_install/arch.sh
+++ b/src/plugins/kernel_install/arch.sh
@@ -10,6 +10,11 @@ declare -ga required_packages=(
   'rsync'
   'screen'
   'pv'
+  'bzip2'
+  'lzip'
+  'lzop'
+  'zstd'
+  'xz'
 )
 
 # ArchLinux package manager

--- a/src/plugins/kernel_install/debian.sh
+++ b/src/plugins/kernel_install/debian.sh
@@ -11,6 +11,11 @@ declare -ag required_packages=(
   'rsync'
   'screen'
   'pv'
+  'bzip2'
+  'lzip'
+  'xz-utils'
+  'lzop'
+  'zstd'
 )
 
 # Debian package manager command

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -177,7 +177,7 @@ function test_prepare_distro_for_deploy()
   expected_cmd=(
     '-> Basic distro set up'
     '' # Extra space for the \n
-    'yes | pacman -Syu rsync screen pv'
+    'yes | pacman -Syu rsync screen pv bzip2 lzip lzop zstd xz'
   )
 
   compare_command_sequence 'expected_cmd' "$output" "$LINENO"


### PR DESCRIPTION
While deploying a new kernel to a freshly installed machine, I realized
that we missed some of the compression packages in the deploy list. This
commit adds those missing packages for Arch and Debian.

Signed-off-by: Rodrigo Siqueira <siqueirajordao@riseup.net>