### PR TITLE
setup: Change the order of the installation steps

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -74,11 +74,6 @@ function check_dependencies()
     return 0
   fi
 
-  while IFS='' read -r package; do
-    pip list | grep -F "$package" > /dev/null
-    [[ "$?" != 0 ]] && pip_package_list="$package $pip_package_list"
-  done < "$DOCUMENTATION/dependencies/pip.dependencies"
-
   if [[ -n "$package_list" ]]; then
     if [[ "$FORCE" == 0 ]]; then
       if [[ $(ask_yN "Can we install the following dependencies $package_list?") =~ '0' ]]; then
@@ -89,6 +84,11 @@ function check_dependencies()
     # Install system packages
     eval "sudo $cmd"
   fi
+
+  while IFS='' read -r package; do
+    pip list | grep -F "$package" > /dev/null
+    [[ "$?" != 0 ]] && pip_package_list="$package $pip_package_list"
+  done < "$DOCUMENTATION/dependencies/pip.dependencies"
 
   if [[ -n "$pip_package_list" ]]; then
     if [[ "$FORCE" == 0 ]]; then


### PR DESCRIPTION
When installing kw without `pip` installed in the system, the following error occurs:

`./setup.sh: line 78: pip: command not found`

That happens because setup.sh runs a pip command before checking and installing the package dependencies -- pip included.

This commit simply changes the order of the steps, so that pip is not used before it is installed.