### PR TITLE
tests: plugins: fixup tests

### DIFF
--- a/tests/plugins/kernel_install/rpi_test.sh
+++ b/tests/plugins/kernel_install/rpi_test.sh
@@ -131,7 +131,7 @@ function test_local_remove_kernel()
     "sudo sh -c 'printf \"%s\n\" kernel=kernel-${KERNEL_NAME}.img >> ${FAKE_RPI_PATH}/config.txt'"
   )
 
-  compare_command_sequence 'expected_cmd' "$output" "$LINENO"
+  compare_command_sequence '' "$LINENO" 'expected_cmd' "$output"
 }
 
 invoke_shunit

--- a/tests/plugins/kernel_install/utils_test.sh
+++ b/tests/plugins/kernel_install/utils_test.sh
@@ -72,6 +72,7 @@ function setUp()
 function tearDown()
 {
   rm -rf "$SHUNIT_TMPDIR"
+  mkdir -p "$SHUNIT_TMPDIR"
 }
 
 function total_of_installed_kernels_mock()


### PR DESCRIPTION
This commit fixes both the utils test and the raspberry pi deploy test.

The Raspberry pi test was broken due to the shunit2 temp folder not
being recreated every time it was destroyed, and the utils test was
using a previous format of the `compare_command_sequence` function.

Signed-off-by: Isabella Basso <isabbasso@riseup.net>