### PR TITLE
Update contributor's guide URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We are happy that you want to help us! If you are looking for a good starting
 point, check
 [those issues](https://github.com/kworkflow/kworkflow/labels/good%20first%20issue)
 and don't forget to read our
-[Contribuitor's Guide](https://flusp.ime.usp.br/doc/kw/content/howtocontribute.html)
+[Contribuitor's Guide](https://kworkflow.org/content/howtocontribute.html)
 (or [howtocontribute file](documentation/content/howtocontribute.rst)).
 
 # Reach Out


### PR DESCRIPTION
Update contributor's guide URL in the README with the official kw domain