### PR TITLE
Add arch linux arm to list of supported systems

### DIFF
--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -280,7 +280,7 @@ function detect_distro()
   local distro_id='none'
   local etc_path
   declare -a debian_family=('debian' 'ubuntu' 'raspbian')
-  declare -a arch_family=('arch' 'manjaro')
+  declare -a arch_family=('arch' 'manjaro' 'archarm')
   declare -a fedora_family=('fedora')
 
   etc_path=$(join_path "$root_path" /etc)


### PR DESCRIPTION
As an Arch Linux derivative very close to the original, kw supports this
system.

Signed-off-by: Isabella Basso <isabbasso@riseup.net>