### PR TITLE
docs: dependencies: Add pv to Fedora dependencies

### DIFF
--- a/documentation/dependencies/fedora.dependencies
+++ b/documentation/dependencies/fedora.dependencies
@@ -19,3 +19,4 @@ lzop
 zstd
 bc
 git-email
+pv


### PR DESCRIPTION
kw deploy uses the pv command, which is not installed by default on Fedora. This makes it necessary to install the pv command during the setup process.

Closes #600 