### PR TITLE
github: workflow: Fix CI failure caused by sphinx-book-theme

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -37,8 +37,6 @@ jobs:
 
       - name: Check documentation
         run: |
-          # FIXME: Workaround, see https://github.com/kworkflow/kworkflow/issues/583
-          echo '' > 'documentation/dependencies/pip.dependencies'
           ./setup.sh --docs --force
 
       - name: Check installation

--- a/documentation/dependencies/pip.dependencies
+++ b/documentation/dependencies/pip.dependencies
@@ -1,1 +1,2 @@
+jinja2>=3
 sphinx-book-theme

--- a/setup.sh
+++ b/setup.sh
@@ -86,8 +86,8 @@ function check_dependencies()
   fi
 
   while IFS='' read -r package; do
-    pip list | grep -F "$package" > /dev/null
-    [[ "$?" != 0 ]] && pip_package_list="$package $pip_package_list"
+    python3 -c "import pkg_resources; pkg_resources.require('$package')" &> /dev/null
+    [[ "$?" != 0 ]] && pip_package_list="\"$package\" $pip_package_list"
   done < "$DOCUMENTATION/dependencies/pip.dependencies"
 
   if [[ -n "$pip_package_list" ]]; then


### PR DESCRIPTION
A sphinx-book-theme maintainer changed the way of getting the theme path.

Ref: https://github.com/executablebooks/sphinx-book-theme/blame/940d562fad0c8e9d4056b575c68d972ac0f9b2f4/src/sphinx_book_theme/__init__.py#L26

For jinja2>=3, it changes the way the variable is wrapped.

Ref: https://github.com/pallets/jinja/blob/5962edeb271d93687eb93f32d53ffe53f86871e0/src/jinja2/loaders.py#L184

This commit fixes the CI failure by updating jinja2 to the version that can work with sphinx-book-theme in `pip.dependencies`.

A pair of double quotes encloses the package name to prevent the shell from misrecognizing angle brackets in `setup.sh`.

Fix: https://github.com/kworkflow/kworkflow/issues/583

Signed-off-by: lookas <i@18kas.com>