### PR TITLE
Enhance docs for kw-pomodoro and kw-report

### DIFF
--- a/documentation/man/features/report.rst
+++ b/documentation/man/features/report.rst
@@ -79,7 +79,7 @@ disable_statistics_data_track option in your kworkflow.config enabled for a
 while.
 
 You can see data related to your kw usage by using the report option, see
-some examples below:
+some examples below::
 
   kw report
   kw report --day

--- a/documentation/tutorials/pomodoro-report.rst
+++ b/documentation/tutorials/pomodoro-report.rst
@@ -100,7 +100,9 @@ Or just::
 
   $ kw r --week
 
-The report will look like this::
+The report will look like this:
+
+.. code-block:: md
 
     # Report: YYYY/MM/DDD
      * Total hours of focus: 48:43:00

--- a/documentation/tutorials/pomodoro-report.rst
+++ b/documentation/tutorials/pomodoro-report.rst
@@ -46,7 +46,7 @@ Since you are working on a highly complex bug, you decide to dedicate 30
 minutes to make sure that you know how to reproduce the issue; you can start
 with::
 
-  kw pomodoro --time 30m --tag "Super weird bug" --description "Let's make sure that I know how to reproduce this bug..."
+  kw pomodoro --set-timer 30m --tag "Super weird bug" --description "Let's make sure that I know how to reproduce this bug..."
 
 Notice that you can use the short version of the above command::
 

--- a/documentation/tutorials/pomodoro-report.rst
+++ b/documentation/tutorials/pomodoro-report.rst
@@ -46,11 +46,11 @@ Since you are working on a highly complex bug, you decide to dedicate 30
 minutes to make sure that you know how to reproduce the issue; you can start
 with::
 
-  kw pomodoro --set-timer 30m --tag "Super weird bug" --description "Let's make sure that I know how to reproduce this bug..."
+  $ kw pomodoro --set-timer 30m --tag "Super weird bug" --description "Let's make sure that I know how to reproduce this bug..."
 
 Notice that you can use the short version of the above command::
 
-  kw p -t 30m -g "Super weird bug" -d "Let's make sure that I know how to reproduce this bug..."
+  $ kw p -t 30m -g "Super weird bug" -d "Let's make sure that I know how to reproduce this bug..."
 
 .. note::
     From now on, this tutorial will use the short version
@@ -58,7 +58,7 @@ Notice that you can use the short version of the above command::
 Now that you created this session, you can check how many minutes are left by
 using::
 
-  kw p --list # kw p -l
+  $ kw p --list # kw p -l
 
 
 Now, forget about the world and focus on your task for 30 minutes; don't worry,
@@ -70,18 +70,18 @@ Suppose that you already know how to reproduce that bug, and now you want to
 implement a workaround to fix it; let's create a new focus session associated
 with the same tag::
 
-  kw p -t 30m -g "Super weird bug" -d "I know how to reproduce the bug! I'm going to try THIS WORKAROUND to see if it fixes the issue"
+  $ kw p -t 30m -g "Super weird bug" -d "I know how to reproduce the bug! I'm going to try THIS WORKAROUND to see if it fixes the issue"
 
 Notice that typing "Super weird bug" is tedious and error-prone, but don't
 worry, kw provides a feature to list all tags and associates them with an ID.
 To see all the tags that you already created, use this command::
 
-  kw p -g
+  $ kw p -g
   1.Super weird bug
 
 In other words, you can use::
 
-  kw p -t 30m -g 1 -d "I know how to reproduce the bug! I'm going to try THIS WORKAROUND to see if it fixes the issue"
+  $ kw p -t 30m -g 1 -d "I know how to reproduce the bug! I'm going to try THIS WORKAROUND to see if it fixes the issue"
 
 You can create as many focus sessions as you want at any time and day.
 
@@ -94,11 +94,11 @@ a report on your last week, and you worked on so many things that you don't
 even know where to start; don't worry, kw has your back. It is now time to use
 the report feature. If you want to get this week's summary, you can use::
 
-  kw report --week
+  $ kw report --week
 
 Or just::
 
-  kw r --week
+  $ kw r --week
 
 The report will look like this::
 
@@ -140,10 +140,10 @@ you to generate reports with the following granularity:
 By default, if you do not provide specific dates, kw report will assume the
 closest date; for example::
 
-    kw report         # Shows today's report
-    kw report --week  # Shows this week's report
-    kw report --month # Shows this month's report
-    kw report --year  # Shows this year's report
+    $ kw report         # Shows today's report
+    $ kw report --week  # Shows this week's report
+    $ kw report --month # Shows this month's report
+    $ kw report --year  # Shows this year's report
 
 Conclusion
 ----------


### PR DESCRIPTION
# Fixes kw-report code-block

## Before (https://kworkflow.org/man/features/report.html)
![image](https://user-images.githubusercontent.com/8299832/167271443-5f7ea448-8cfb-404d-ad71-acb3a417235f.png)

## Now
![image](https://user-images.githubusercontent.com/8299832/167271435-6bce40b6-01c4-43b6-ad63-d7d85a97ab4f.png)

# Fixes kw-pomodoro tutorial code-block "console" syntax highlight
 
## Before (https://kworkflow.org/tutorials/pomodoro-report.html#start-a-focus-session)
![image](https://user-images.githubusercontent.com/8299832/167271581-11f3d1d6-0b0f-4e7b-9e42-bda65dc54e8f.png)

## Now
![image](https://user-images.githubusercontent.com/8299832/167271495-f623df96-c6b4-4291-a1ea-bc8cb49898df.png)

# Enhance kw-report tutorial examples with "markdown" syntax highlight

## Before (https://kworkflow.org/tutorials/pomodoro-report.html#generate-a-report)
![image](https://user-images.githubusercontent.com/8299832/167271636-233ec169-c1c2-4fe7-a074-7db2322cc074.png)

## Now
![image](https://user-images.githubusercontent.com/8299832/167271620-221cce10-4b24-4f8b-b040-d1830bf3cbc6.png)

# Fixes kw-pomodoro flag in its tutorial

`--time` -> `--set-timer` 


---
Thanks for the review