### PR TITLE
src: deploy: Fix sudo issue in local deploy

### DIFF
--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -805,7 +805,7 @@ function modules_install_to()
   fi
 
   if [[ "$local_deploy" == 'local' ]]; then
-    cmd='sudo -E make modules_install'
+    cmd='sudo true && sudo -E make modules_install'
   else
     cmd="make INSTALL_MOD_PATH=$install_to modules_install"
   fi

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -846,7 +846,7 @@ function test_kernel_modules()
   output=$(modules_install 'TEST_MODE' 2)
   declare -a expected_cmd=(
     "$PREPARING_MODULES_MSG"
-    'sudo -E make modules_install'
+    'sudo true && sudo -E make modules_install'
   )
 
   compare_command_sequence '' "$LINENO" 'expected_cmd' "$output"


### PR DESCRIPTION
Some users reported that `kw bd --local` and `kw d --local` had some
weird behavior during the deploy. Something that looks like this:

    * Preparing modules
    [sudo] password for siqueira: [>

    [>

As a result, sometimes, users type the wrong password and have to type
it multiple times. This problem happens due to the pipe between the
modules_install command and the pv command. This commit fixes this issue
by running a simple sudo command before the task that requires the pipe
utilization.

Signed-off-by: Rodrigo Siqueira <siqueirajordao@riseup.net>