### PR TITLE
Add support to Fedora-based systems

### DIFF
--- a/documentation/tutorials/deploy-kernel.rst
+++ b/documentation/tutorials/deploy-kernel.rst
@@ -38,7 +38,7 @@ Kw Deploy Limitations
 Let's start by setting the expectations around `kw deploy` and describing its
 current limitations:
 
-* The target machine must be Debian or Arch Linux family (by family, we are
+* The target machine must be Debian, Fedora or Arch Linux family (by family, we are
   talking about derivative distros). For example, Ubuntu and Mint are derivated
   from Debian, meaning that kw supports those distros.
 * Right now, kw only supports the GRUB2 bootloader.

--- a/src/plugins/kernel_install/bootloader_utils.sh
+++ b/src/plugins/kernel_install/bootloader_utils.sh
@@ -296,6 +296,7 @@ function identify_mbr_per_partition()
 function identify_bootloader_from_files()
 {
   local path_prefix="$1"
+  local target="$2"
   local bootloader=''
 
   path_prefix=${path_prefix:-'/'}
@@ -305,7 +306,12 @@ function identify_bootloader_from_files()
 
     for file in "${bootloader_files[@]}"; do
       file="$path_prefix/$file"
-      [[ -e "$file" ]] && bootloader="$bootloader_target"
+
+      if [[ "$target" == 2 || "$target" == 'local' ]]; then
+        sudo [ -e "$file" ] && bootloader="$bootloader_target"
+      else
+        [[ -e "$file" ]] && bootloader="$bootloader_target"
+      fi
     done
 
     [[ -n "$bootloader" ]] && break

--- a/src/plugins/kernel_install/fedora.sh
+++ b/src/plugins/kernel_install/fedora.sh
@@ -1,0 +1,96 @@
+# Kworkflow treats this script as a plugin for installing a new Kernel or
+# module in a target system. It is essential to highlight that this file
+# follows an API that can be seen in the "deploy.sh" file, if you make any
+# change here, you have to do it inside the install_modules() and
+# install_kernel().
+#
+# Note: We use this script for Fedora based distros
+
+# Fedora package names
+declare -ag required_packages=(
+  'rsync'
+  'screen'
+  'pv'
+  'bzip2'
+  'lzip'
+  'xz'
+  'lzop'
+  'zstd'
+)
+
+# Fedora package manager command
+declare -g package_manager_cmd='dnf install -y'
+
+function generate_fedora_temporary_root_file_system()
+{
+  local flag="$1"
+  local name="$2"
+  local target="$3"
+  local bootloader_type="$4"
+  local path_prefix="$5"
+  local cmd='dracut --force --kver'
+  local cmd_prefix=''
+  local grub_regex='s/GRUB_ENABLE_BLSCFG=true/GRUB_ENABLE_BLSCFG=false/g'
+  local prefix='/'
+
+  if [[ -n "$path_prefix" ]]; then
+    prefix="${path_prefix}"
+  fi
+
+  # We do not support initramfs outside grub scope
+  [[ "$bootloader_type" != 'GRUB' ]] && return
+
+  cmd+=" $name"
+
+  if [[ "$target" == 'local' ]]; then
+    cmd_prefix="sudo -E"
+  fi
+
+  if [[ "$target" != 'vm' ]]; then
+    cmd_manager "$flag" "$cmd_prefix grub2-editenv - unset menu_auto_hide"
+    cmd_manager "$flag" "$cmd_prefix sed -i -e '$grub_regex' /etc/default/grub"
+
+    # Update initramfs
+    cmd_manager "$flag" "$cmd_prefix $cmd"
+  else
+    generate_rootfs_with_libguestfs "$flag" "$name"
+  fi
+}
+
+function generate_rootfs_with_libguestfs()
+{
+  local flag="$1"
+  local name="$2"
+  local mount_root=': mount /dev/sda1 /'
+  local cmd_init="dracut --force --kver $name"
+
+  flag=${flag:-'SILENT'}
+
+  if [[ ! -f "${configurations[qemu_path_image]}" ]]; then
+    complain "There is no VM in ${configurations[qemu_path_image]}"
+    return 125 # ECANCELED
+  fi
+
+  # For executing libguestfs commands we need to umount the vm
+  if [[ $(findmnt "${configurations[mount_point]}") ]]; then
+    vm_umount
+  fi
+
+  cmd="guestfish --rw -a ${configurations[qemu_path_image]} run \
+      $mount_root : command '$cmd_init'"
+
+  warning " -> Generating rootfs $name on VM. This can take a few minutes."
+
+  cmd_manager "$flag" 'sleep 0.5s'
+  {
+    cmd_manager "$flag" "$cmd"
+  } 1> /dev/null # No visible stdout but still shows errors
+
+  # TODO: The below line is here for test purpose. We need a better way to
+  # do that.
+  [[ "$flag" == 'TEST_MODE' ]] && printf '%s\n' "$cmd"
+
+  say 'Done.'
+
+  return 0
+}

--- a/src/plugins/kernel_install/grub.sh
+++ b/src/plugins/kernel_install/grub.sh
@@ -4,7 +4,29 @@
 # 1. run_bootloader_update: Update GRUB in a local and remote machine.
 # 2. run_bootloader_for_vm: Update GRUB in a virtual machine.
 
-declare -rg DEFAULT_GRUB_CMD_UPDATE='grub-mkconfig -o /boot/grub/grub.cfg'
+declare -g DEFAULT_GRUB_CMD_UPDATE='grub-mkconfig -o /boot/grub/grub.cfg'
+
+# Some distributions, such as Fedora, use GRUB2 as the default bootloader. On
+# those systems, grub-mkconfig command is replaced by grub2-mkconfig. This function
+# checks if the grub-mkconfig command exists and if doesn't, the default grub
+# update command is set to grub2-mkconfig.
+#
+# Returns:
+# 0 if a grub update command exists and 2 otherwise.
+function define_grub_cmd_update()
+{
+  local grub_cmd='grub-mkconfig'
+  local grub2_cmd='grub2-mkconfig'
+
+  if ! command_exists "$grub_cmd"; then
+    if ! command_exists "$grub2_cmd"; then
+      return 2 # ENOENT
+    fi
+    DEFAULT_GRUB_CMD_UPDATE='grub2-mkconfig -o /boot/grub2/grub.cfg'
+  fi
+
+  return 0
+}
 
 # Update grub bootloader in a target machine.
 function run_bootloader_update()
@@ -21,6 +43,12 @@ function run_bootloader_update()
   elif [[ "$target" == 'vm' ]]; then
     run_bootloader_for_vm "$flag"
     return "$?"
+  fi
+
+  define_grub_cmd_update
+  if [[ "$?" -gt 0 ]]; then
+    complain "There is no grub-mkconfig command in the system."
+    return 125 # ECANCELED
   fi
 
   cmd_grub+="$DEFAULT_GRUB_CMD_UPDATE"
@@ -81,6 +109,12 @@ function run_bootloader_for_vm()
   # For executing libguestfs commands we need to umount the vm
   if [[ $(findmnt "${configurations[mount_point]}") ]]; then
     vm_umount
+  fi
+
+  define_grub_cmd_update
+  if [[ "$?" -gt 0 ]]; then
+    complain "There is no grub-mkconfig command in the system."
+    return 125 # ECANCELED
   fi
 
   cmd="guestfish --rw -a ${configurations[qemu_path_image]} run \

--- a/src/plugins/kernel_install/remote_deploy.sh
+++ b/src/plugins/kernel_install/remote_deploy.sh
@@ -111,6 +111,8 @@ if [[ -f 'debian.sh' ]]; then
   . 'debian.sh' --source-only
 elif [[ -f 'arch.sh' ]]; then
   . 'arch.sh' --source-only
+elif [[ -f 'fedora.sh' ]]; then
+  . 'fedora.sh' --source-only
 else
   printf '%s\n' 'It looks like kw does not support your distro'
   exit 95 # Not supported

--- a/src/plugins/kernel_install/utils.sh
+++ b/src/plugins/kernel_install/utils.sh
@@ -54,7 +54,7 @@ function collect_deploy_info()
     . "$REMOTE_KW_DEPLOY/bootloader_utils.sh" --source-only
   fi
 
-  bootloader=$(identify_bootloader_from_files "$prefix")
+  bootloader=$(identify_bootloader_from_files "$prefix" "$target")
   bootloader="[bootloader]=$bootloader"
 
   # Get distro

--- a/tests/plugins/kernel_install/fedora_test.sh
+++ b/tests/plugins/kernel_install/fedora_test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+include './src/plugins/kernel_install/utils.sh'
+include './src/plugins/kernel_install/fedora.sh'
+include './src/kwio.sh'
+include './tests/utils.sh'
+
+function setUp()
+{
+  FAKE_VM_IMG="$SHUNIT_TMPDIR/fake_vm"
+
+  mk_fake_boot "$SHUNIT_TMPDIR"
+
+  touch "$FAKE_VM_IMG"
+}
+
+function tearDown()
+{
+  rm -rf "$SHUNIT_TMPDIR"
+}
+
+function test_update_fedora_boot_loader()
+{
+
+  declare -a cmd_sequence=(
+    'grub2-editenv - unset menu_auto_hide'
+    'sed -i -e '\'s/GRUB_ENABLE_BLSCFG=true/GRUB_ENABLE_BLSCFG=false/g\'' /etc/default/grub'
+    'dracut --force --kver xpto'
+  )
+
+  output=$(generate_fedora_temporary_root_file_system 'TEST_MODE' 'xpto' '' 'GRUB')
+  compare_command_sequence 'Check simple flow' "$LINENO" 'cmd_sequence' "$output"
+
+  declare -a cmd_sequence=(
+    'sudo -E grub2-editenv - unset menu_auto_hide'
+    'sudo -E sed -i -e '\'s/GRUB_ENABLE_BLSCFG=true/GRUB_ENABLE_BLSCFG=false/g\'' /etc/default/grub'
+    'sudo -E dracut --force --kver xpto'
+  )
+
+  output=$(generate_fedora_temporary_root_file_system 'TEST_MODE' 'xpto' 'local' 'GRUB')
+  compare_command_sequence 'Check local deploy' "$LINENO" 'cmd_sequence' "$output"
+}
+
+function test_generate_rootfs_with_libguestfs()
+{
+  local name='xpto'
+  local qemu_mock_img="$SHUNIT_TMPDIR/mock_image"
+  local mount_root=': mount /dev/sda1 /'
+  local cmd_init="dracut --force --kver $name"
+  local guest_fish_cmd
+
+  # No vm
+  output=$(generate_rootfs_with_libguestfs 'TEST_MODE' "$name")
+  assertEquals "($LINENO)" 125 "$?"
+
+  # Normal flow
+  configurations[qemu_path_image]="$FAKE_VM_IMG"
+  guest_fish_cmd="guestfish --rw -a ${configurations[qemu_path_image]} run \
+      $mount_root : command '$cmd_init'"
+
+  declare -a cmd_sequence=(
+    "-> Generating rootfs $name on VM. This can take a few minutes."
+    'sleep 0.5s'
+    "$guest_fish_cmd"
+    'Done.'
+  )
+
+  # Let's replace vm_umount function
+  function vm_umount()
+  {
+    printf 'vm_umount'
+  }
+
+  output=$(generate_rootfs_with_libguestfs 'TEST_MODE' "$name")
+  compare_command_sequence '' "$LINENO" 'cmd_sequence' "$output"
+}
+
+invoke_shunit

--- a/tests/plugins/kernel_install/grub_test.sh
+++ b/tests/plugins/kernel_install/grub_test.sh
@@ -16,12 +16,64 @@ function test_grub()
   local output
   local expected_cmd
 
+  function command_exists()
+  {
+    local command="$1"
+    local package=${command%% *}
+
+    return 22 # EINVAL
+  }
+
+  output=$(run_bootloader_update 'TEST_MODE' 'local')
+  ret="$?"
+  assert_equals_helper 'Local update' "$LINENO" '125' "$ret"
+
+  output=$(run_bootloader_update 'TEST_MODE' 'remote')
+  ret="$?"
+  assert_equals_helper 'Remote update' "$LINENO" '125' "$ret"
+
+  function command_exists()
+  {
+    local command="$1"
+    local package=${command%% *}
+
+    if [[ $command == 'grub-mkconfig' ]]; then
+      return 0
+    fi
+
+    return 22 # EINVAL
+  }
+
   output=$(run_bootloader_update 'TEST_MODE' 'local')
   expected_cmd='sudo -E grub-mkconfig -o /boot/grub/grub.cfg'
+
   assert_equals_helper 'Local update' "$LINENO" "$expected_cmd" "$output"
 
   output=$(run_bootloader_update 'TEST_MODE' 'remote')
   expected_cmd='grub-mkconfig -o /boot/grub/grub.cfg'
+
+  assert_equals_helper 'Remote update' "$LINENO" "$expected_cmd" "$output"
+
+  function command_exists()
+  {
+    local command="$1"
+    local package=${command%% *}
+
+    if [[ $command == 'grub2-mkconfig' ]]; then
+      return 0
+    fi
+
+    return 22 # EINVAL
+  }
+
+  output=$(run_bootloader_update 'TEST_MODE' 'local')
+  expected_cmd='sudo -E grub2-mkconfig -o /boot/grub2/grub.cfg'
+
+  assert_equals_helper 'Local update' "$LINENO" "$expected_cmd" "$output"
+
+  output=$(run_bootloader_update 'TEST_MODE' 'remote')
+  expected_cmd='grub2-mkconfig -o /boot/grub2/grub.cfg'
+
   assert_equals_helper 'Remote update' "$LINENO" "$expected_cmd" "$output"
 }
 


### PR DESCRIPTION
Currently, kw deploy only works for Debian and ArchLinux families. This
commit expands kw distro support and adds Fedora-based systems as a target.

Closes #567

Signed-off-by: Maíra Canal <maira.canal@usp.br>

---

The remote and local deploy were tested on Fedora 35. VM deployment was not tested as I could not set up a VM with kw yet (even if other distros).

Unit tests are still missing and I'm currently working on them, but I decided to post the PR while developing them in order to get feedback from the kw community. Any feedback is welcomed!
