### PR TITLE
Add rsync dependency

### DIFF
--- a/documentation/dependencies/debian.dependencies
+++ b/documentation/dependencies/debian.dependencies
@@ -24,3 +24,4 @@ bc
 git-email
 sqlite3
 pv
+rsync

--- a/documentation/dependencies/fedora.dependencies
+++ b/documentation/dependencies/fedora.dependencies
@@ -20,3 +20,4 @@ zstd
 bc
 git-email
 pv
+rsync


### PR DESCRIPTION
Arch dependencies had already been fixed, but one can see that kw setup
continues to fail on the CI given that ubuntu machines (especially
docker ones) don't have this dependency by default. This commit fixes
this.

Signed-off-by: Isabella Basso <isabbasso@riseup.net>