### PR TITLE
Fix errors in listing kernels

### DIFF
--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -102,6 +102,17 @@ function deploy_main()
   uninstall_force="${options_values['UNINSTALL_FORCE']}"
   setup="${options_values['SETUP']}"
 
+  if [[ "$list" == 1 || "$single_line" == 1 || "$list_all" == 1 ]]; then
+    say 'Available kernels:'
+    start=$(date +%s)
+    run_list_installed_kernels "$flag" "$single_line" "$target" "$list_all"
+    end=$(date +%s)
+
+    runtime=$((end - start))
+    statistics_manager 'list' "$runtime"
+    return "$?"
+  fi
+
   [[ -n "${options_values['VERBOSE']}" ]] && flag='VERBOSE'
 
   update_deploy_variables
@@ -131,17 +142,6 @@ function deploy_main()
   fi
 
   collect_target_info_for_deploy "$target" "$flag"
-
-  if [[ "$list" == 1 || "$single_line" == 1 || "$list_all" == 1 ]]; then
-    say 'Available kernels:'
-    start=$(date +%s)
-    run_list_installed_kernels "$flag" "$single_line" "$target" "$list_all"
-    end=$(date +%s)
-
-    runtime=$((end - start))
-    statistics_manager 'list' "$runtime"
-    return "$?"
-  fi
 
   if [[ -n "$uninstall" ]]; then
     start=$(date +%s)
@@ -552,13 +552,13 @@ function run_list_installed_kernels()
       fi
 
       include "$KW_PLUGINS_DIR/kernel_install/utils.sh"
-      list_installed_kernels "$single_line" "$all" "${configurations[mount_point]}"
+      list_installed_kernels "$flag" "$single_line" "$all" "${configurations[mount_point]}"
 
       vm_umount
       ;;
     2) # LOCAL_TARGET
       include "$KW_PLUGINS_DIR/kernel_install/utils.sh"
-      list_installed_kernels "$single_line" "$all"
+      list_installed_kernels "$flag" "$single_line" "$all"
       ;;
     3) # REMOTE_TARGET
       local cmd="$REMOTE_INTERACE_CMD_PREFIX"


### PR DESCRIPTION
When I run `kw deploy -a --local`, I get the following errors: 
```
$ kw deploy -a --local
-> Basic distro set up

E: Could not open lock file /var/lib/dpkg/lock-frontend - open (13: Permission denied)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root?
/home/magali/.local/lib/kw/plugins/kernel_install/utils.sh: line 38: /opt/kw/status: Permission denied
Available kernels:
0
sudo mkdir -p /opt/kw
/home/magali/.local/lib/kw/plugins/kernel_install/utils.sh: line 38: 0: command not found
0
sudo touch /opt/kw/INSTALLED_KERNELS
/home/magali/.local/lib/kw/plugins/kernel_install/utils.sh: line 38: 0: command not found
None of the installed kernels are managed by kw.
Pass --list-all|-a to see all installed kernels.
```
The command to list installed kernels does some checks and setups that are meant to be done when deploying a new kernel, but are unnecessary when the intention is a different one, which ends up throwing some errors. This commit ensures that the command to list kernels is run before the deploy-related set-up, and also adds a missing argument from the `list_installed_kernel` function.