### PR TITLE
src: mail: add --rfc option

### DIFF
--- a/documentation/man/features/mail.rst
+++ b/documentation/man/features/mail.rst
@@ -6,7 +6,7 @@ kw-mail
 
 SYNOPSIS
 ========
-| *kw mail* (-s | \--send) [\--simulate] [\--private] [\--to='<recipient>,...'] [\--cc='<recipient>,...'] [<rev-range>...] [-v<version>] [\-- <extra-args>...]
+| *kw mail* (-s | \--send) [\--simulate] [\--private] [--rfc] [\--to='<recipient>,...'] [\--cc='<recipient>,...'] [<rev-range>...] [-v<version>] [\-- <extra-args>...]
 | *kw mail* (-t | \--setup) [\--local | \--global] [-f | \--force] (<config> <value>)...
 | *kw mail* (-i | \--interactive) [\--local | \--global]
 | *kw mail* (-l | \--list)
@@ -62,6 +62,9 @@ OPTIONS
 
 \--private:
   Supress auto generation of recipients.
+
+\--rfc:
+  Add a request for comment prefix to the e-mail's subject.
 
 <rev-range>...:
   Specify the *<rev-range>* to be sent. The last commit is taken as the

--- a/src/mail.sh
+++ b/src/mail.sh
@@ -89,6 +89,7 @@ function mail_send()
   local version="${options_values['PATCH_VERSION']}"
   local extra_opts="${options_values['PASS_OPTION_TO_SEND_EMAIL']}"
   local private="${options_values['PRIVATE']}"
+  local rfc="${options_values['RFC']}"
   local kernel_root
   local patch_count=0
   local cmd='git send-email'
@@ -123,6 +124,7 @@ function mail_send()
 
   [[ -n "$opts" ]] && cmd+=" $opts"
   [[ -n "$private" ]] && cmd+=" $private"
+  [[ -n "$rfc" ]] && cmd+=" $rfc"
   [[ -n "$extra_opts" ]] && cmd+=" $extra_opts"
 
   cmd_manager "$flag" "$cmd"
@@ -911,7 +913,7 @@ function parse_mail_options()
   local commit_count=''
   local short_options='s,t,f,v:,i,l,n,'
   local long_options='send,simulate,to:,cc:,setup,local,global,force,verify,'
-  long_options+='template::,interactive,no-interactive,list,private,'
+  long_options+='template::,interactive,no-interactive,list,private,rfc,'
 
   long_options+='email:,name:,'
   long_options+='smtpuser:,smtpencryption:,smtpserver:,smtpserverport:,smtppass:,'
@@ -944,6 +946,7 @@ function parse_mail_options()
   options_values['CMD_SCOPE']=''
   options_values['PATCH_VERSION']=''
   options_values['PASS_OPTION_TO_SEND_EMAIL']=''
+  options_values['RFC']=''
   options_values['COMMIT_RANGE']=''
   options_values['PRIVATE']=''
 
@@ -1036,6 +1039,10 @@ function parse_mail_options()
       --no-interactive | -n)
         options_values['INTERACTIVE']=''
         options_values['NO_INTERACTIVE']=1
+        shift
+        ;;
+      --rfc)
+        options_values['RFC']='--rfc'
         shift
         ;;
       -v)

--- a/tests/mail_test.sh
+++ b/tests/mail_test.sh
@@ -302,6 +302,10 @@ function test_mail_parser()
   expected='--suppress-cc=all'
   assert_equals_helper 'Set private flag' "$LINENO" "${options_values['PRIVATE']}" "$expected"
 
+  parse_mail_options '--rfc'
+  expected='--rfc'
+  assert_equals_helper 'Set rfc flag' "$LINENO" "${options_values['RFC']}" "$expected"
+
   parse_mail_options '--to=some@mail.com'
   expected='some@mail.com'
   assert_equals_helper 'Set to flag' "$LINENO" "${options_values['TO']}" "$expected"
@@ -451,6 +455,12 @@ function test_mail_send()
   output=$(mail_send 'TEST_MODE')
   expected="git send-email --suppress-cc=all @^"
   assert_equals_helper 'Testing send with to option' "$LINENO" "$output" "$expected"
+
+  parse_mail_options '--rfc'
+
+  output=$(mail_send 'TEST_MODE')
+  expected="git send-email --rfc @^"
+  assert_equals_helper 'Testing send with rfc option' "$LINENO" "$output" "$expected"
 
   parse_mail_options '--to=mail@test.com' 'HEAD~'
 


### PR DESCRIPTION
This allows users to set this option that adds a request for comment tag
to the prefix of the email subject.

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@alumni.usp.br>

Part of #588