### PR TITLE
doc: index: fix index links

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -11,10 +11,10 @@ developing for Linux. **kw** is composed of different software components
 unified in a single interface. After installation, ``kw`` commands become
 available in the command line interface.
 
-The kw project is available at
-`GitHub <https://github.com/kworkflow/kworkflow>`, and we also have a blog post
-which can be accessed at `here <https://blog.kworkflow.org/>`. For more
-information, check:
+The kw project is available at `GitHub
+<https://github.com/kworkflow/kworkflow>`_, and we also have a blog post which
+can be accessed at `here <https://blog.kworkflow.org/>`_. For more information,
+check:
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Some of the links were not properly configured to be rendered as links,
this fixes them so they now work.

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@alumni.usp.br>