### PR TITLE
src: plugins: kernel_install: utils: Add command_exists function

### DIFF
--- a/src/plugins/kernel_install/utils.sh
+++ b/src/plugins/kernel_install/utils.sh
@@ -38,6 +38,17 @@ function cmd_manager()
   eval "$@"
 }
 
+function command_exists()
+{
+  local command="$1"
+  local package=${command%% *}
+
+  if [[ ! -x "$(command -v "$package")" ]]; then
+    return 22 # EINVAL
+  fi
+  return 0
+}
+
 function collect_deploy_info()
 {
   local flag="$1"


### PR DESCRIPTION
Recently we introduced support to GRUB2, but the way that we check this
is the target system uses the function `command_exists`. However, this
function is not available for remote deploy, so we broke this feature.
This commit fix this issue by introducing such function the the utils.sh
file.

Fixes: 5b9c1c3 (src: plugins: kernel_install: Add support to grub2)

Signed-off-by: Rodrigo Siqueira <siqueirajordao@riseup.net>