### PR TITLE
src: report: fix descriptions with commas

### DIFF
--- a/src/report.sh
+++ b/src/report.sh
@@ -185,7 +185,7 @@ function grouping_day_data()
     tag=$(printf '%s\n' "$line" | cut -d ',' -f1)
     timebox=$(printf '%s\n' "$line" | cut -d ',' -f2)
     start_time=$(printf '%s\n' "$line" | cut -d ',' -f3)
-    details=$(printf '%s\n' "$line" | cut -d ',' -f4)
+    details=$(printf '%s\n' "$line" | cut -d ',' -f1,2,3 --complement)
 
     time_label=$(expand_time_labels "$timebox")
     [[ "$?" != 0 ]] && continue

--- a/tests/report_test.sh
+++ b/tests/report_test.sh
@@ -160,6 +160,7 @@ function test_grouping_day_data()
 {
   local count=0
   local line
+  local expected
 
   # Here we use $'...' to evaluate the newline at the end of the strings
   declare -a expected_content=(
@@ -186,6 +187,10 @@ function test_grouping_day_data()
     assert_equals_helper "Loop $count failed" "$LINENO" "${tags_details[$tag]}" "$line"
     ((count++))
   done
+
+  expected=$' - 2021/04/05\n   * [06:00:40-06:20:40][20m]: Description, with comma\n'
+  grouping_day_data '2021/04/05'
+  assert_equals_helper 'Did not parse commas correctly' "$LINENO" "${tags_details['comma_tag']}" "$expected"
 
   # Try to process file with bad data
   count=0

--- a/tests/samples/pomodoro_data/2021/04/05
+++ b/tests/samples/pomodoro_data/2021/04/05
@@ -1,0 +1,1 @@
+comma_tag,20m,06:00:40,Description, with comma


### PR DESCRIPTION
Since the data fields in the pomodoro files are separated by commas,
when `cut -d ',' -f4` was used to retrieve the descriptions, if they
contained one or more commas, any part of the description that was after
the first comma would be left out. Now the description is retrieved as
the complement of the rest of the data.

Closes #495

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@alumni.usp.br>