### PR TITLE
etc: init_templates: x86_64: Drop cross compile option

### DIFF
--- a/etc/init_templates/x86-64/build_template.config
+++ b/etc/init_templates/x86-64/build_template.config
@@ -7,7 +7,7 @@ arch=x86_64
 kernel_img_name=bzImage
 
 # Specify cross-compile toolchain
-cross_compile=aarch64-linux-gnu-
+#cross_compile=aarch64-linux-gnu-
 
 # Default kernel menu config option
 menu_config=nconfig

--- a/tests/build_test.sh
+++ b/tests/build_test.sh
@@ -109,7 +109,6 @@ function test_parse_build_config_standard_config()
   declare -A expected_build_configurations=(
     [arch]='x86_64'
     [kernel_img_name]='bzImage'
-    [cross_compile]='aarch64-linux-gnu-'
     [menu_config]='nconfig'
     [doc_type]='htmldocs'
   )


### PR DESCRIPTION
Fixes: e827eb1 ("build_template: Add a separate config file for build options")
Signed-off-by: Rodrigo Siqueira <siqueirajordao@riseup.net>