### PR TITLE
setup: add global config file

### DIFF
--- a/etc/kworkflow_template.config
+++ b/etc/kworkflow_template.config
@@ -1,0 +1,72 @@
+# Default configuration file
+# Note: You can customize the settings in this file but no setting should be
+# removed. Otherwise, KW may not work properly.
+
+#? Attention, when using "./setup.sh -i":
+#? - USERKW will be replaced by the current user
+#? - SOUNDPATH will be replaced by kw's install path
+
+# Default ssh user
+ssh_user=root
+
+# Default ssh ip
+ssh_ip=localhost
+
+# Default ssh port
+ssh_port=22
+
+# Optional ssh configuration file to be used
+#ssh_configfile=~/.ssh/config
+# Hostname of the target in ssh_configfile
+#hostname=
+
+# Defines the virtualization tool that should be used by kw. Current, we only
+# support QEMU
+virtualizer=qemu-system-x86_64
+
+# Defines the kw mount point, this directory is used by libguestfs during the
+# mount/umount operation of a VM
+mount_point=/home/USERKW/p/mount
+
+# Sets basic QEMU options
+qemu_hw_options=-enable-kvm -daemonize -smp 2 -m 1024
+
+# Defines the network configuration
+qemu_net_options=-nic user,hostfwd=tcp::2222-:22,smb=/home/USERKW
+
+# Specify the VM image path
+qemu_path_image=/home/USERKW/p/virty.qcow2
+
+# Default alert options (You should use vs, s, v or n. See README.md for details
+# on this options)
+alert=n
+
+# Command to run for sound completion alert (This command will be executed in
+# the background)
+sound_alert_command=paplay SOUNDPATH/bell.wav
+
+# Command to run for visual completion alert (This command will be executed in
+# the background)
+# Note: You may use $COMMAND, which will be replaced by the kw command
+#       whose conclusion the user wished to be alerted.
+# Note: The below command is an example that may work in many different
+#       distros, but we cannot guarantee it. For this reason, check if it works
+#       in your favorite OS or replaces it for your preferred notification
+#       tool.
+visual_alert_command=notify-send -i checkbox -t 10000 "kw" "Command: \\"$COMMAND\\" completed!"
+
+# Disable kw statistics collection, if you disable this data collection the
+# `statistics` options will be disabled as well. Add "yes" for disabling it.
+disable_statistics_data_track=no
+
+# Set a specific command to activate the GUI
+#gui_on=systemctl isolate graphical.target
+# Set a specific command to deactivate the GUI
+#gui_off=systemctl isolate multi-user.target
+
+# Send-email options to be used when sending a patch
+send_opts=--annotate --cover-letter --no-chain-reply-to --thread
+
+# You can choose to block certain emails from being added to the recipients
+# list of your patches, separate values with commas
+#blocked_emails=

--- a/setup.sh
+++ b/setup.sh
@@ -312,6 +312,8 @@ function synchronize_files()
   cmd_output_manager "rsync -vr $CONFIG_DIR/ $etcdir" "$verbose"
   ASSERT_IF_NOT_EQ_ZERO "The command 'rsync -vr $CONFIG_DIR/ $etcdir $verbose' failed" "$?"
 
+  setup_global_config_file
+
   # User data
   mkdir -p "$datadir"
   mkdir -p "$datadir/statistics"
@@ -396,6 +398,26 @@ function install_home()
   synchronize_files
   # Update version based on the current branch
   update_version
+}
+
+function setup_global_config_file()
+{
+  local config_files_path="$etcdir"
+  local config_file_template="$config_files_path/kworkflow_template.config"
+  local global_config_name='kworkflow.config'
+
+  if [[ -f "$config_file_template" ]]; then
+    mv "$config_file_template" "$config_files_path/$global_config_name"
+    sed -i -e "s/USERKW/$USER/g" -e "s,SOUNDPATH,$sounddir,g" \
+      -e "/^#?.*/d" "$config_files_path/$global_config_name"
+    ret="$?"
+    if [[ "$ret" != 0 ]]; then
+      return "$ret"
+    fi
+  else
+    warning "setup could not find $config_file_template"
+    return 2
+  fi
 }
 
 # Options


### PR DESCRIPTION
Some of kw's functions don't need to be used inside of a kernel tree,
for example, the `kw pomodoro` command that can be run on any folder,
but depend on values present in the config files. This means that we
need a global config file to ensure these functions work correctly.

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@alumni.usp.br>

Closes #635 