### PR TITLE
src: checkpatch_wrapper: Fix bug in the parser

### DIFF
--- a/src/checkpatch_wrapper.sh
+++ b/src/checkpatch_wrapper.sh
@@ -13,11 +13,10 @@ function execute_checkpatch()
   local FILE_OR_DIR_CHECK="$1"
   local flag="$2"
 
-  if [[ "$FILE_OR_DIR_CHECK" =~ -h|--help ]]; then
+  if [[ "$FILE_OR_DIR_CHECK" =~ ^-h|^--help ]]; then
     codestyle_help "$1"
     return 0
   fi
-
   # TODO: Note that codespell file is not specified yet because of the poluted
   # output. It could be nice if we can add another option just for this sort
   # of check.


### PR DESCRIPTION
I tried to check the command similar to this:

 kw c /path/to/my/patch/0001-someting-hello-bla.patch

The above command is treated as help because of the substring `-h`. This
commit fixes this issue by making the regex a little more precise.

Signed-off-by: Rodrigo Siqueira <siqueirajordao@riseup.net>