### PR TITLE
src: kw: Fix wrong include

### DIFF
--- a/kw
+++ b/kw
@@ -145,7 +145,7 @@ function kw()
       ;;
     kernel-config-manager | k)
       (
-        include "$KW_LIB_DIR/config_manager.sh"
+        include "$KW_LIB_DIR/kernel_config_manager.sh"
 
         kernel_config_manager_main "$@"
       )


### PR DESCRIPTION
Fixes: 305d9e1 ("src: configm: Rename configm to kernel-config-manager")
Signed-off-by: Rodrigo Siqueira <siqueirajordao@riseup.net>