### PR TITLE
src: explore: Add parameter amount check

### DIFF
--- a/src/explore.sh
+++ b/src/explore.sh
@@ -17,17 +17,40 @@ function explore()
   case "$ret" in
     1)        # LOG
       shift 1 # Remove 'log' string
+
+      if [[ "$#" -gt 2 && "$3" != "TEST_MODE" ]]; then
+        complain 'Too many parameters'
+        exit 22 # EINVAL
+      fi
+
       explore_git_log "$@"
       ;;
     2)        # Use GNU GREP
       shift 1 # Remove 'grep' string
+
+      if [[ "$#" -gt 2 && "$3" != "TEST_MODE" ]]; then
+        complain 'Too many parameters'
+        exit 22 # EINVAL
+      fi
+
       explore_files_gnu_grep "$@"
       ;;
     3) # Search in directories controlled or not by git
       shift 1
+
+      if [[ "$#" -gt 2 && "$3" != "TEST_MODE" ]]; then
+        complain 'Too many parameters'
+        exit 22 # EINVAL
+      fi
+
       explore_all_files_git "$@"
       ;;
     4) # Search in files under git control
+      if [[ "$#" -gt 2 && "$3" != "TEST_MODE" ]]; then
+        complain 'Too many parameters'
+        exit 22 # EINVAL
+      fi
+
       explore_files_under_git "$@"
       ;;
     *)


### PR DESCRIPTION
Without checking the number of arguments can cause unexpected arguments
to be passed into the function.

The `explore_git_log` function in the `explore.sh` file will treat the
third parameter `$3` (extra parameters given by the user) as a `flag`
parameter and pass it to `cmd_manager`.

Before the commit f16c80, this would cause an error as said
in issue #409.

After the commit f16c80, the error will not occur, but the flag was
still passed with a wrong value.

This commit will output an error when the user gives the wrong amount of
parameters.

Closes #409

Signed-off-by: Haiqin Cui <i@18kas.com>