### PR TITLE
src: report: fix per tag hours of focus

### DIFF
--- a/src/report.sh
+++ b/src/report.sh
@@ -279,7 +279,7 @@ function grouping_year_data()
   done
 }
 
-function show_total_work_hours()
+function calculate_total_work_hours()
 {
   local work_hours_sec="$1"
   local hours
@@ -290,7 +290,7 @@ function show_total_work_hours()
   minutes=$((work_hours_sec % 3600 / 60))
   seconds=$((work_hours_sec % 60))
 
-  printf ' * Total hours of focus: %02d:%02d:%02d\n' "$hours" "$minutes" "$seconds"
+  printf '%02d:%02d:%02d' "$hours" "$minutes" "$seconds"
 }
 
 # Show report data after processing.
@@ -302,6 +302,7 @@ function show_data
   local tag_time
   local tag_repetition=0
   local total_focus_time=0
+  local total_focus_hours
 
   printf '%s\n' "# Report: $date"
 
@@ -313,7 +314,8 @@ function show_data
     total_repetition=$((total_repetition + tag_repetition))
   done
 
-  show_total_work_hours "$total_focus_time"
+  total_focus_hours=$(calculate_total_work_hours "$total_focus_time")
+  printf '%s\n' " * Total hours of focus: ${total_focus_hours}"
   printf '%s\n\n' " * Total focus session(s): $total_repetition"
 
   for tag in "${!tags_details[@]}"; do
@@ -321,7 +323,7 @@ function show_data
     total_time=$(printf '%s\n' "${tags_metadata[$tag]}" | cut -d ',' -f1)
     total_repetition=$(printf '%s\n' "${tags_metadata[$tag]}" | cut -d ',' -f2)
 
-    total_time=$(sec_to_format "$total_time")
+    total_time=$(calculate_total_work_hours "$total_time")
     printf '%s\n' " - Total focus time: $total_time" \
       " - Total repetitions: $total_repetition" \
       '' \

--- a/tests/report_test.sh
+++ b/tests/report_test.sh
@@ -315,6 +315,32 @@ function test_grouping_year_data()
   assert_equals_helper "We expect 366 (leap year) keys" "$LINENO" "$output" 366
 }
 
+function test_calculate_total_work_hours()
+{
+  local output
+  local expected
+
+  output=$(calculate_total_work_hours 1)
+  expected='00:00:01'
+  assert_equals_helper 'We expected 1 second' "$LINENO" "$output" "$expected"
+
+  output=$(calculate_total_work_hours 60)
+  expected='00:01:00'
+  assert_equals_helper 'We expected 1 minute' "$LINENO" "$output" "$expected"
+
+  output=$(calculate_total_work_hours 3600)
+  expected='01:00:00'
+  assert_equals_helper 'We expected 1 hour' "$LINENO" "$output" "$expected"
+
+  output=$(calculate_total_work_hours 89999)
+  expected='24:59:59'
+  assert_equals_helper 'We expected full clock' "$LINENO" "$output" "$expected"
+
+  output=$(calculate_total_work_hours 360000)
+  expected='100:00:00'
+  assert_equals_helper 'We expected 100 hours' "$LINENO" "$output" "$expected"
+}
+
 function test_show_data()
 {
   local count=0
@@ -331,6 +357,11 @@ function test_show_data()
   assertTrue "$LINENO: We expected to find at least one Summary entry" '[[ "$output" =~ 'Summary:' ]]'
   assertTrue "$LINENO: We expected to find tag_2" '[[ "$output" =~ 'tag_2' ]]'
   assertTrue "$LINENO: We expected to find 06:00:40-" '[[ "$output" =~ '06:00:40-' ]]'
+
+  grouping_day_data '2020/04/05'
+  output=$(show_data)
+
+  assertTrue "$LINENO: We expected to find per tag output over 24h" "[[ \"$output\" =~ 'time: 72:00:00' ]]"
 }
 
 function test_save_data_to()

--- a/tests/samples/pomodoro_data/2020/04/05
+++ b/tests/samples/pomodoro_data/2020/04/05
@@ -1,0 +1,1 @@
+super_long,72h,06:00:40,Tag 1 description


### PR DESCRIPTION
The hours of focus per tag were previously displayed the output of using
the `date` command to convert the value from seconds, this had the side
effect of being capped at 24h. This is because the `date` command
converts seconds as the amount of seconds since the epoch, and so
returns the time of the corresponding date.

Closes #598

Signed-off-by: Rubens Gomes Neto <rubens.gomes.neto@alumni.usp.br>