### PR TITLE
src: build: hide error generated by make

### DIFF
--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -178,7 +178,7 @@ function find_kernel_root()
 function get_kernel_release()
 {
   local flag="$1"
-  local cmd='make kernelrelease'
+  local cmd='make kernelrelease 2> /dev/null'
 
   [[ "$flag" != 'TEST_MODE' ]] && flag='SILENT'
 
@@ -195,7 +195,7 @@ function get_kernel_release()
 function get_kernel_version()
 {
   local flag="$1"
-  local cmd='make kernelversion'
+  local cmd='make kernelversion 2> /dev/null'
 
   flag=${flag:-'SILENT'}
 


### PR DESCRIPTION
When CONFIG_X86_X32 is enabled but the corresponding tool is not
installed, an error `CONFIG_X86_X32 enabled but no binutils support`
will be reported when executing `make kernelrelease`, although no error
was reported when compiling the kernel.

Since this build_info function only gets the current kernel version by
executing the `make kernelrelease` command, and this error does not
affect the getting process of the version, this commit simply hides the
error message.

Closes #398

Signed-off-by: Haiqin Cui <i@18kas.com>