### PR TITLE
Remove alert notification from some subcommands

### DIFF
--- a/kw
+++ b/kw
@@ -105,7 +105,7 @@ function kw()
 
         kernel_build && deploy_main 1 "$@"
         local ret="$?"
-        alert_completion 'kw db' "$1"
+        alert_completion 'kw bd' "$1"
         return "$ret"
       )
       ;;

--- a/src/build.sh
+++ b/src/build.sh
@@ -57,7 +57,7 @@ function kernel_build()
   if [[ $? -gt 0 ]]; then
     complain "Invalid option: ${options_values['ERROR']}"
     build_help
-    return 22 # EINVAL
+    exit 22 # EINVAL
   fi
 
   cross_compile="${options_values['CROSS_COMPILE']}"
@@ -95,7 +95,7 @@ function kernel_build()
   if [[ -n "$menu_config" ]]; then
     command="make -j ${llvm}ARCH=${platform_ops} ${menu_config}"
     cmd_manager "$flag" "$command"
-    return
+    exit
   fi
 
   if ! is_kernel_root "$PWD"; then

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -89,7 +89,7 @@ function deploy_main()
   parse_deploy_options "$@"
   if [[ "$?" -gt 0 ]]; then
     complain "${options_values['ERROR']}"
-    return 22 # EINVAL
+    exit 22 # EINVAL
   fi
 
   flag="${options_values['TEST_MODE']}"
@@ -111,7 +111,7 @@ function deploy_main()
 
     runtime=$((end - start))
     statistics_manager 'list' "$runtime"
-    return "$?"
+    exit "$?"
   fi
 
   [[ -n "${options_values['VERBOSE']}" ]] && flag='VERBOSE'


### PR DESCRIPTION
Some subcommands from both `kw build` and `kw deploy` don't really need to have an alert for completion (such as `kw b -n`, or even an invalid one like `kw d -`), so remove the notification by exiting instead of returning when these subcommands are called.

Also a minor change to one of the arguments of alert_completion, instead of `kw db` say `kw bd`.