### PR TITLE
src: kwlib: Fix codestyle in the if condition

### DIFF
--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -128,7 +128,12 @@ function is_kernel_root()
   # tree root and not expected to change. Their presence (or abscense)
   # is used to tell if a directory is a linux tree root or not. (They
   # are the same ones used by get_maintainer.pl)
-  if [[ -f "${DIR}/COPYING" && -f "${DIR}/CREDITS" && -f "${DIR}/Kbuild" && -e "${DIR}/MAINTAINERS" && -f "${DIR}/Makefile" && -f "${DIR}/README" && -d "${DIR}/Documentation" && -d "${DIR}/arch" && -d "${DIR}/include" && -d "${DIR}/drivers" && -d "${DIR}/fs" && -d "${DIR}/init" && -d "${DIR}/ipc" && -d "${DIR}/kernel" && -d "${DIR}/lib" && -d "${DIR}/scripts" ]]; then
+  if [[ -f "${DIR}/COPYING" && -f "${DIR}/CREDITS" && -f "${DIR}/Kbuild" &&
+    -e "${DIR}/MAINTAINERS" && -f "${DIR}/Makefile" && -f "${DIR}/README" &&
+    -d "${DIR}/Documentation" && -d "${DIR}/arch" && -d "${DIR}/include" &&
+    -d "${DIR}/drivers" && -d "${DIR}/fs" && -d "${DIR}/init" &&
+    -d "${DIR}/ipc" && -d "${DIR}/kernel" && -d "${DIR}/lib" &&
+    -d "${DIR}/scripts" ]]; then
     return 0
   fi
   return 1


### PR DESCRIPTION
A long time ago, when we were making kw aligned with shellcheck and
shfmt we changed an if condition that put all checks in a single line.
This commit updates the if condition to have each check per line.

Signed-off-by: Rodrigo Siqueira <siqueirajordao@riseup.net>