### PR TITLE
src: vm: Add dependency for vm deploy and update remote kw path

### DIFF
--- a/documentation/dependencies/arch.dependencies
+++ b/documentation/dependencies/arch.dependencies
@@ -25,3 +25,4 @@ sqlite3
 pv
 rsync
 ccache
+libguestfs

--- a/documentation/dependencies/debian.dependencies
+++ b/documentation/dependencies/debian.dependencies
@@ -26,3 +26,4 @@ sqlite3
 pv
 rsync
 ccache
+libguestfs-tools

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -394,7 +394,7 @@ function deploy_setup()
 
   if [[ "$target" == "$VM_TARGET" ]]; then
     cmd="guestfish --rw -a ${vm_config[qemu_path_image]} run : \
-      mount /dev/sda1 / : mkdir-p $kw_path"
+      mount /dev/sda1 / : mkdir-p $REMOTE_KW_DEPLOY"
     cmd_manager "$flag" "$cmd"
   fi
 

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -802,6 +802,29 @@ function test_kernel_install_to_vm_invalid_distro()
   }
 }
 
+function test_deploy_setup_to_vm()
+{
+  local original="$PWD"
+  local output
+
+  cd "$FAKE_KERNEL" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
+
+  output=$(deploy_setup 1 'TEST_MODE')
+  expected=(
+    "guestfish --rw -a /home/xpto/p/virty.qcow2 run :       mount /dev/sda1 / : mkdir-p /opt/kw"
+    "test -f /opt/kw/status"
+  )
+  compare_command_sequence '' "$LINENO" 'expected' "$output"
+
+  cd "$original" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
+}
+
 function test_kernel_modules()
 {
   local count=0


### PR DESCRIPTION
After commit dabb2854acfac399cc8284e32afa13e9f310a0ad, `kw_path` was deprecated.

See `update_deploy_variables` in `deploy.sh`.

This commit also adds missing dependency `libguestfs-tools` for `guestmount` and `guestfish`.

Closes #246
Closes #677

Signed-off-by: Haiqin Cui <i@18kas.com>