### PR TITLE
documentation: Change en-dash to double dashes

### DIFF
--- a/documentation/man/features/backup.rst
+++ b/documentation/man/features/backup.rst
@@ -7,7 +7,7 @@ kw-backup
 SYNOPSIS
 ========
 | *kw* *backup* [<path>]
-| *kw* *backup* (-r | \--restore) <path> [(-f | --force)]
+| *kw* *backup* (-r | \--restore) <path> [(-f | \--force)]
 
 DESCRIPTION
 ===========

--- a/documentation/man/features/mail.rst
+++ b/documentation/man/features/mail.rst
@@ -6,7 +6,7 @@ kw-mail
 
 SYNOPSIS
 ========
-| *kw mail* (-s | \--send) [\--simulate] [\--private] [--rfc] [\--to='<recipient>,...'] [\--cc='<recipient>,...'] [<rev-range>...] [-v<version>] [\-- <extra-args>...]
+| *kw mail* (-s | \--send) [\--simulate] [\--private] [\--rfc] [\--to='<recipient>,...'] [\--cc='<recipient>,...'] [<rev-range>...] [-v<version>] [\-- <extra-args>...]
 | *kw mail* (-t | \--setup) [\--local | \--global] [-f | \--force] (<config> <value>)...
 | *kw mail* (-i | \--interactive) [\--local | \--global]
 | *kw mail* (-l | \--list)

--- a/documentation/man/features/remote.rst
+++ b/documentation/man/features/remote.rst
@@ -6,7 +6,7 @@ kw-remote
 
 SYNOPSIS
 ========
-| *kw remote* [-v | --verbose ]
+| *kw remote* [-v | \--verbose ]
 | *kw remote add* <name> <user@remote:port>
 | *kw remote remove* <name>
 | *kw remote rename* <old-name> <new-name>
@@ -31,7 +31,7 @@ rename <old-name> <new-name>:
   Rename the remote named <old> to <new>. If you try a name already in use, kw
   will fail with a message.
 
-\-v, --verbose:
+\-v, \--verbose:
   Be a little more verbose and show remote url after name.
 
 EXAMPLES

--- a/documentation/tutorials/deploy-kernel.rst
+++ b/documentation/tutorials/deploy-kernel.rst
@@ -129,7 +129,7 @@ Local Machine Deploy
 
 In this scenario, a target kernel might be the one in your host machine. For
 example, suppose that you want to install the latest stable kernel from
-Torvalds' tree in your laptop; in this case, kw deploy `--local` is what you are
+Torvalds' tree in your laptop; in this case, kw deploy `\--local` is what you are
 looking for.
 
 Ok, in this case, let's start by entering in your kernel code::

--- a/documentation/tutorials/kernel-config-manager.rst
+++ b/documentation/tutorials/kernel-config-manager.rst
@@ -27,13 +27,13 @@ Save your config file
 ---------------------
 
 If you are in a kernel tree with an important `.config` file, you can save it
-under kw by using the `--save` option, which requires giving a name for your
+under kw by using the `\--save` option, which requires giving a name for your
 config. For example, let's suppose that you are working in the Raspberry Pi
 tree and you have a good config file; you can save it by using::
 
   kw kernel-config-manager --save "RASP4"
 
-The name you used in the `--save` option will be used later to retrieve the
+The name you used in the `\--save` option will be used later to retrieve the
 config file. You probably noticed that just using the name does not describe
 your config file well, and for this reason, `kernel-config-manager` also provides a
 description option to better describe your config file. For example, you could

--- a/documentation/tutorials/kernel-debug.rst
+++ b/documentation/tutorials/kernel-debug.rst
@@ -67,15 +67,15 @@ The debug option provides a standard set of features that can be used with
 repeatedly, this section introduces the following shared behavior: ``--follow``,
 ``--history``, and ``--cmd``.
 
-Follow log (`--follow | -f`)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Follow log (`\--follow | -f`)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you want to follow the log in real-time, you probably want to use the
 ``--follow | -f`` option, which will keep polling the data and provide you with
 a live feed of it.
 
-Save (`--history | -k`)
-~~~~~~~~~~~~~~~~~~~~~~~
+Save (`\--history | -k`)
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 This option will create a folder named ``kw_debug`` in the folder that you run
 this command and a sub-folder that follows this pattern::
@@ -86,8 +86,8 @@ If you use this feature, kw will automatically save your debug log in the
 folder as described above. This is useful if you want to compare debug when
 changing some configuration.
 
-Command (`--cmd | -c`)
-~~~~~~~~~~~~~~~~~~~~~~
+Command (`\--cmd | -c`)
+~~~~~~~~~~~~~~~~~~~~~~~
 
 This option expects a parameter which is a command to be executed in the target
 machine. The idea is something like this:


### PR DESCRIPTION
`--force` will be rendered as `-force` (en-dash), which was confusing.

This commit checked all documentation and escape the `--` with `\--`

Signed-off-by: Haiqin Cui <i@18kas.com>