### PR TITLE
src: deploy: Add `--no-reboot` option

### DIFF
--- a/documentation/man/features/deploy.rst
+++ b/documentation/man/features/deploy.rst
@@ -8,7 +8,8 @@ SYNOPSIS
 ========
 *kw* (*d* | *deploy*) [\--remote <remote>:<port> | \--local | \--vm]
                       [\--setup]
-                      [-r | \--reboot] [-m | \--modules] [-s | \--ls-line]
+                      [-r | \--reboot] [\--no-reboot]
+                      [-m | \--modules] [-s | \--ls-line]
                       [-l | \--list] [-a | \--list-all]
                       [(-u | \--uninstall) <kernel-name>[,...]] [-f \--force]
                       [\--alert=(s | v | (sv | vs) | n)]
@@ -64,6 +65,9 @@ OPTIONS
 
 -r, \--reboot:
   Reboot machine after deploy.
+
+\--no-reboot:
+  Do not reboot machine after deploy.
 
 \--setup:
   This command runs a basic setup in the target machine, including installing

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -33,7 +33,8 @@ function _kw_autocomplete()
   kw_options['bd']='--verbose'
 
   kw_options['deploy']='--force --list --list-all --local --ls-line --modules
-                        --reboot --remote --uninstall --vm --setup --verbose'
+                        --reboot --no-reboot --remote --uninstall --vm --setup
+                        --verbose'
   kw_options['d']="${kw_options['deploy']}"
 
   kw_options['device']='--local --remote --vm'

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -1021,6 +1021,16 @@ function test_parse_deploy_options()
 
   unset options_values
   declare -gA options_values
+  parse_deploy_options --no-reboot
+  assert_equals_helper 'Could not set deploy REBOOT' "($LINENO)" '0' "${options_values['REBOOT']}"
+
+  unset options_values
+  declare -gA options_values
+  parse_deploy_options --reboot --no-reboot
+  assert_equals_helper 'Could not set deploy REBOOT' "($LINENO)" '0' "${options_values['REBOOT']}"
+
+  unset options_values
+  declare -gA options_values
   parse_deploy_options -r
   assert_equals_helper 'Could not set deploy REBOOT' "($LINENO)" '1' "${options_values['REBOOT']}"
 


### PR DESCRIPTION
This commit add `--no-reboot` option and improved the way kw combine cmd option and config file for reboot action. Cmd option will override config file for reboot action.

Docs and tests are also updated.

Closes #542

Signed-off-by: Haiqin Cui <i@18kas.com>