### PR TITLE
src: remote: Accept new key from remote

### DIFF
--- a/src/remote.sh
+++ b/src/remote.sh
@@ -23,11 +23,11 @@ function is_ssh_connection_configured()
   local user=${4:-${remote_parameters['REMOTE_USER']}}
   local remote_file=${5:-${remote_parameters[REMOTE_FILE]}}
   local remote_file_host=${5:-${remote_parameters[REMOTE_FILE_HOST]}}
-  local ssh_cmd="ssh -q -o BatchMode=yes -o ConnectTimeout=5 -p $port $user@$remote exit"
+  local ssh_cmd="ssh -q -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=5 -p $port $user@$remote exit"
 
   if [[ -z "$remote" && -z "$port" && -z "$user" ]]; then
     if [[ -n "${remote_file}" ]]; then
-      ssh_cmd="ssh -q -o BatchMode=yes -o ConnectTimeout=5 -F ${remote_file} ${remote_file_host} exit"
+      ssh_cmd="ssh -q -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=5 -F ${remote_file} ${remote_file_host} exit"
     fi
   fi
 

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -220,9 +220,9 @@ function test_setup_remote_ssh_with_passwordless()
     '-> Trying to set up passwordless access'
     '' # Extra line due to \n in the say message
     'ssh-copy-id root@127.0.0.1'
-    'ssh -q -o BatchMode=yes -o ConnectTimeout=5 -p 3333 root@127.0.0.1 exit'
+    'ssh -q -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=5 -p 3333 root@127.0.0.1 exit'
     'ssh-copy-id juca@127.0.0.1'
-    'ssh -q -o BatchMode=yes -o ConnectTimeout=5 -p 3333 juca@127.0.0.1 exit'
+    'ssh -q -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=5 -p 3333 juca@127.0.0.1 exit'
   )
 
   remote_parameters['REMOTE_USER']='juca'

--- a/tests/kw_ssh_test.sh
+++ b/tests/kw_ssh_test.sh
@@ -92,7 +92,7 @@ function test_kw_ssh_main_no_parameter()
   local output
 
   declare -a expected_cmd=(
-    "ssh -q -o BatchMode=yes -o ConnectTimeout=5 -F ${SHUNIT_TMPDIR}/.kw/remote.config origin exit"
+    "ssh -q -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=5 -F ${SHUNIT_TMPDIR}/.kw/remote.config origin exit"
     "ssh -F ${SHUNIT_TMPDIR}/.kw/remote.config origin"
   )
 
@@ -106,7 +106,7 @@ function test_kw_ssh_main_command()
   local output
 
   declare -a expected_cmd=(
-    "ssh -q -o BatchMode=yes -o ConnectTimeout=5 -F ${SHUNIT_TMPDIR}/.kw/remote.config origin exit"
+    "ssh -q -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=5 -F ${SHUNIT_TMPDIR}/.kw/remote.config origin exit"
     "ssh -F ${SHUNIT_TMPDIR}/.kw/remote.config origin pwd"
   )
 
@@ -129,7 +129,7 @@ function test_kw_ssh_main_script()
     '[[ $ret =~ "$msg" ]]'
 
   declare -a expected_cmd=(
-    "ssh -q -o BatchMode=yes -o ConnectTimeout=5 -F ${SHUNIT_TMPDIR}/.kw/remote.config origin exit"
+    "ssh -q -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=5 -F ${SHUNIT_TMPDIR}/.kw/remote.config origin exit"
     "ssh -F ${SHUNIT_TMPDIR}/.kw/remote.config origin \"bash -s\" -- < $TEST_PATH/dmesg"
   )
 


### PR DESCRIPTION
After this commit, ssh will accept new key from remote and save the key to `known_hosts`.

Ref: https://unix.stackexchange.com/questions/33271/how-to-avoid-ssh-asking-permission

Closes #610

Signed-off-by: Haiqin Cui <i@18kas.com>