### PR TITLE
src: explore: Add only-source only-header function

### DIFF
--- a/documentation/man/features/explore.rst
+++ b/documentation/man/features/explore.rst
@@ -6,7 +6,8 @@ kw-explore
 
 SYNOPSIS
 ========
-*kw* (*e* | *explore*) [(-l | \--log) | (-g | \--grep) | (-a | \--all)] <expr>
+*kw* (*e* | *explore*) [(-l | \--log) | (-g | \--grep) | (-a | \--all)]
+                       [(-c | \--only-source) | (-H | \--only-header)] <expr>
                        [-p] [<dir> | <file>]
 
 DESCRIPTION
@@ -37,3 +38,9 @@ OPTIONS
   ignores files inside .git, except if it is called inside .git directory. In
   other words, if you use this option you will notice that ``git grep`` is
   used first, and then GNU grep.
+
+-c | \--only-source:
+  With this option, it is possible to show only the results from the source.
+
+-H | \--only-header:
+  With this option, it is possible to show only the results from the header.

--- a/kw
+++ b/kw
@@ -182,7 +182,9 @@ function kw()
       (
         include "$KW_LIB_DIR/explore.sh"
 
-        explore "$@"
+        explore_main "$@"
+        local ret="$?"
+        return "$ret"
       )
       ;;
     man)

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -41,7 +41,7 @@ function _kw_autocomplete()
   kw_options['diff']='--no-interactive'
   kw_options['df']="${kw_options['diff']}"
 
-  kw_options['explore']='--log --grep --all'
+  kw_options['explore']='--log --grep --all --only-source --only-header'
   kw_options['e']="${kw_options['explore']}"
 
   kw_options['init']='--arch --force --remote --target --template'

--- a/tests/samples/codestyle_check.h
+++ b/tests/samples/codestyle_check.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * codestyle.h
+ *
+ * Copyright (C) 2018 John Doe
+ *
+ * This file is used for codestyle checking.
+ *
+ */
+
+#include <stdio.h>
+
+void camelCase(void);
+
+int main(int argc, char *args[]);


### PR DESCRIPTION
This commit introduces two options `--only-source` and `--only-header`.

This commit also adds a new sample header file to test this function.

Relevant documentations are also updated.

Closes #184

Signed-off-by: Haiqin Cui <i@18kas.com>