### PR TITLE
src: lib: Add function to get config option and improve fix for #398

### DIFF
--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -188,7 +188,7 @@ function deploy_main()
   if [[ "$modules" == 0 ]]; then
     start=$(date +%s)
     # Update name: release + alias
-    name=$(make kernelrelease)
+    name=$(get_kernel_release "$flag")
 
     run_kernel_install "$reboot" "$name" "$flag" "$target" '' "$build_and_deploy"
     end=$(date +%s)


### PR DESCRIPTION
This commit will detect kernel version and ignore error messages only in v5.13~v5.17 with `CONFIG_X86_X32` enabled.

Take v5.13 kernel source for example, `Makefile:274` says kernelrelease will not using compiler helper where `try-run` function locate (Also see `Makefile:274` and `Makefile:601`). But in`arch/x86/Makefile`, it uses `try-run` which is not defined causing `x32_ld_ok` is blank failing next `if`.

To fix this problem, we need patch the kernel. Rather than it, hiding the error will less invasive to kernel code.

In kernel v5.18 and later, `CONFIG_X86_X32` was removed so warning was also removed.

In addition, helper function `get_kernel_config` will use `./scripts/config` in kernel source, so it is hard to add tests for it.

See: #398

Signed-off-by: Haiqin Cui <i@18kas.com>