### PR TITLE
documentation: tutorial: Add note on the deploy.config for the RPI

### DIFF
--- a/documentation/tutorials/rpi-deploy-kernel.rst
+++ b/documentation/tutorials/rpi-deploy-kernel.rst
@@ -40,7 +40,7 @@ need to add these files in a specific location for a functional boot. For
 example, in the case of RPI 4 32 bits, it should be under the ``/boot`` folder,
 and for RPI 4 64 bits, it is ``/boot/broadcom``. However, these locations may
 vary, so we need to tell kw how to handle these files, but don't worry, this is
-a trivial task. Open your ``.kw/kworflow.config`` and search for::
+a trivial task. Open your ``.kw/deploy.config`` and search for::
 
   dtb_copy_pattern=
 
@@ -76,6 +76,11 @@ Or if you want to deploy your kernel to an RPI 4 64 bits, you can use::
 
 Build and deploy
 ----------------
+
+.. note::
+   The RPI needs to keep the modules after they are installed, so to have a
+   proper deploy on the RPI is ideal to set ``strip_modules_debug_option=no``
+   on ``.kw/deploy.config``.
 
 At this point, we suppose that you already compiled your kernel and added a
 very cool suffix name to your image. Additionally, we presume that your target

--- a/etc/init_templates/rpi4-raspbian-32-cross-x86-arm/deploy.config
+++ b/etc/init_templates/rpi4-raspbian-32-cross-x86-arm/deploy.config
@@ -17,7 +17,7 @@ deploy_default_compression=lzop
 
 # If defined, will cause modules to be stripped after they
 # are installed which will reduce the initramfs size.
-strip_modules_debug_option=yes
+strip_modules_debug_option=no
 
 # Use this parameter to configure how kw will handle the dtb files. Follows
 # some examples on how to use this parameter:

--- a/etc/init_templates/rpi4-raspbian-64-cross-x86-arm/deploy.config
+++ b/etc/init_templates/rpi4-raspbian-64-cross-x86-arm/deploy.config
@@ -17,7 +17,7 @@ deploy_default_compression=lzop
 
 # If defined, will cause modules to be stripped after they
 # are installed which will reduce the initramfs size.
-strip_modules_debug_option=yes
+strip_modules_debug_option=no
 
 # Use this parameter to configure how kw will handle the dtb files. Follows
 # some examples on how to use this parameter:


### PR DESCRIPTION
The RPI needs to keep the modules after they are installed, but the default kworkflow template states ``strip_modules_debug_option=yes``. So, explicitly tell the user that it is necessary to set ``strip_modules_debug_option=no`` on the config files.

Signed-off-by: Maíra Canal <mairacanal@riseup.net>