### PR TITLE
src: build: Add renaming feature in `build.sh` and unify  naming of `kernel_name` in `deploy.sh`

### DIFF
--- a/documentation/man/features/build.rst
+++ b/documentation/man/features/build.rst
@@ -14,6 +14,7 @@ SYNOPSIS
 | *kw* (*b* | *build*) [(-w | \--warnings)] [warning-levels] [\--alert=(s | v | (sv | vs) | n)]
 | *kw* (*b* | *build*) [(-s | \--save-log-to)] <path> [\--alert=(s | v | (sv | vs) | n)]
 | *kw* (*b* | *build*) [\--llvm] [\--alert=(s | v | (sv | vs) | n)]
+| *kw* (*b* | *build*) [\--name] <kernel_name> [\--alert=(s | v | (sv | vs) | n)]
 
 DESCRIPTION
 ===========
@@ -69,6 +70,10 @@ OPTIONS
   This option can be set to enable the usage of the LLVM toolchain during
   compilation/linking tasks. You can enable it by default via `use_llvm` option
   in the `build.config` file.
+
+\--name <kernel_name>:
+  This option can naming the kernel by setting CONFIG_LOCALVERSION in .config
+  during the building process. 
 
 \--alert=(s | v | (sv | vs) | n):
   Defines the alert behaviour upon the command completion.

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -20,7 +20,7 @@ function _kw_autocomplete()
   kw_options['backup']='--restore --force --help'
 
   kw_options['build']='--menu --info --doc --cpu-scaling --ccache --warnings
-                       --save-log-to --llvm --help'
+                       --save-log-to --llvm --name --help'
   kw_options['b']="${kw_options['build']}"
 
   kw_options['kernel-config-manager']='--fetch --get --list --remove --save --force

--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -173,6 +173,28 @@ function find_kernel_root()
   printf '%s\n' "$kernel_root"
 }
 
+# Set value for specific config option
+#
+# @flag How to display a command, the default value is
+#   "SILENT". For more options see `src/kwlib.sh` function `cmd_manager`
+# @name Name of option in config
+# @value Value of option in config
+#
+# Note: Make sure that you called is_kernel_root before trying to execute this
+# function.
+function set_kernel_config_str()
+{
+  local flag="$1"
+  local name="$2"
+  local value="$3"
+  local cmd="./scripts/config --set-str $name $value"
+
+  [[ "$flag" != 'TEST_MODE' ]] && flag='SILENT'
+
+  echo "$cmd"
+  cmd_manager "$flag" "$cmd"
+}
+
 # Get the kernel release based on the command kernelrelease.
 #
 # @flag How to display a command, the default value is


### PR DESCRIPTION
After this commit, user can easily change kernel name simply adding a param after build command. Comparing to naming in deploy, naming in build process will keep consistency in grub uname etc.

Closes: #189

Some legacy variables like `mkinitcpio_name` is never used and the kernel name is called in different ways in many place such as `name`, `kernel_name` and both `name` and `kernel_name` which is confusing.

This commit unify naming of them.
