### PR TITLE
src: kernel_config_manager: fix `kw --save | -s` behavior when `git commit` fails

### DIFF
--- a/src/kernel_config_manager.sh
+++ b/src/kernel_config_manager.sh
@@ -131,6 +131,7 @@ function save_config_file()
   if [[ "$ret" == 1 ]]; then
     warning "Warning: $name: there's nothing new in this file"
   elif [[ "$ret" -gt 0 ]]; then
+    git reset --hard # Aborts save operation
     complain "Could not save user config files"
   else
     success "Saved $name"

--- a/src/kernel_config_manager.sh
+++ b/src/kernel_config_manager.sh
@@ -131,7 +131,7 @@ function save_config_file()
   if [[ "$ret" == 1 ]]; then
     warning "Warning: $name: there's nothing new in this file"
   elif [[ "$ret" -gt 0 ]]; then
-    git reset --hard # Aborts save operation
+    git reset --hard > /dev/null 2>&1 # Aborts save operation
     complain 'Could not save user config files'
   else
     success "Saved $name"

--- a/src/kernel_config_manager.sh
+++ b/src/kernel_config_manager.sh
@@ -132,7 +132,7 @@ function save_config_file()
     warning "Warning: $name: there's nothing new in this file"
   elif [[ "$ret" -gt 0 ]]; then
     git reset --hard # Aborts save operation
-    complain "Could not save user config files"
+    complain 'Could not save user config files'
   else
     success "Saved $name"
   fi

--- a/src/kernel_config_manager.sh
+++ b/src/kernel_config_manager.sh
@@ -131,7 +131,7 @@ function save_config_file()
   if [[ "$ret" == 1 ]]; then
     warning "Warning: $name: there's nothing new in this file"
   elif [[ "$ret" -gt 0 ]]; then
-    fail "Could not save user config files"
+    complain "Could not save user config files"
   else
     success "Saved $name"
   fi

--- a/tests/kernel_config_manager_test.sh
+++ b/tests/kernel_config_manager_test.sh
@@ -81,8 +81,8 @@ function test_save_config_file_check_save_failures()
 {
   local current_path="$PWD"
   local ret=0
-  local git_name=$(git config user.name)
-  local git_email=$(git config user.email)
+  local git_name=""
+  local git_email=""
 
   # Test without config file -> should fail
   cd "$SHUNIT_TMPDIR" || {
@@ -101,9 +101,11 @@ function test_save_config_file_check_save_failures()
 
   # Test git commit fail scenario
   touch .config
+  git_name=$(git config user.name)
+  git_email=$(git config user.email)
   git config --global user.name ""
   git config --global user.email ""
-  ret=$(save_config_file "$NO_FORCE $NAME_1" "$DESCRITION_1")
+  ret=$(save_config_file "$NO_FORCE $NAME_1" "$DESCRIPTION_1")
   assert_equals_helper 'git commit should fail without username and/or email set' "$LINENO" "$ret" 'Could not save user config files'
   assertTrue "$LINENO: Failing git commit should not persist .config file" '[[ ! -f $configs_path/configs/$NAME_1 ]]'
   assertTrue "$LINENO: Failing git commit should not persist .config metadata" '[[ ! -f $configs_path/metadata/$NAME_1 ]]'


### PR DESCRIPTION
After this patch, failing `kw --save | -s` because of error in commiting save operation of .config file no longer throws wrong error (undefined function) neither consolidates the operation.

Closes: #696 