### PR TITLE
src: report: fix path validation in the report parameter.

### DIFF
--- a/src/report.sh
+++ b/src/report.sh
@@ -350,9 +350,21 @@ function save_data_to()
     exit "$ret"
   fi
 
-  truncate -s 0 "$path"
-  [[ -n "${options_values['POMODORO']}" ]] && show_data "$target_time" >> "$path"
-  [[ -n "${options_values['STATISTICS']}" ]] && show_statistics >> "$path"
+  if [[ -d "$path" ]]; then
+    output='report_output'
+
+    [[ -n "${options_values['POMODORO']}" ]] && show_data "$target_time" >> "${path}/${output}"
+    [[ -n "${options_values['STATISTICS']}" ]] && show_statistics >> "${path}/${output}"
+
+    success -n "The report output was saved in: "
+    success "${path}/${output}" | tr -s '/'
+  else
+    [[ -n "${options_values['POMODORO']}" ]] && show_data "$target_time" >> "$path"
+    [[ -n "${options_values['STATISTICS']}" ]] && show_statistics >> "$path"
+
+    success -n "The report output was saved in: "
+    success "${path}" | tr -s '/'
+  fi
 }
 
 function parse_report_options()

--- a/tests/report_test.sh
+++ b/tests/report_test.sh
@@ -367,6 +367,7 @@ function test_show_data()
 function test_save_data_to()
 {
   local output
+  local expected
 
   grouping_day_data '2020/04/04'
   save_data_to "$SHUNIT_TMPDIR/test"
@@ -375,10 +376,34 @@ function test_save_data_to()
   output=$(cat "$SHUNIT_TMPDIR/test")
   [[ ! "$output" =~ 'Summary:' ]] && fail "$LINENO: We expected to find at least one Summary entry"
 
-  # Try to use an invalid path
+  # Try to use an invalid path.
   output=$(save_data_to '/this/is/An/InvaLid/Path')
   ret="$?"
   assert_equals_helper "We expect an invalid path error" "$LINENO" "$ret" 1
+
+  # Try to use a valid directory path.
+  output=$(save_data_to './')
+  ret="$?"
+  assert_equals_helper "We expect a valid path" "$LINENO" "$ret" 0
+
+  # Verifying that the correct message is displayed.
+  expected='The report output was saved in:'
+  message=${output::-16}
+  assert_equals_helper "We expect a valid message" "$LINENO" "$message" "$expected"
+
+  # Verifying that the correct filename is displayed.
+  filename=${output:(-13)}
+  [[ ! -f "./$filename" ]] && fail "$LINENO: We expect to find a test file"
+
+  # Try to use an invalid root directory path.
+  output=$(save_data_to '/root/')
+  ret="$?"
+  assert_equals_helper "We expect a root path invalid" "$LINENO" "$ret" 1
+
+  # Try to use an invalid folder path error.
+  output=$(save_data_to '/tmp/folder_not_created/')
+  ret="$?"
+  assert_equals_helper "We expect an invalid path error where the folder was not created." "$LINENO" "$ret" 1
 }
 
 invoke_shunit


### PR DESCRIPTION
When generating a output report file, an error occurs if the user specifies only the directory, the error occurs because a standard output file is not created.

How to reproduce the error:

Execute `kw report -o ./`

This commit implements validation for the given path and auto-generate a file name if a directory is given. After this commit, the user can create an output file containing the pomodoro and statistics data in any desired directory.

Closes: #532

Signed-off-by: Aquila Macedo <aquilamacedo@riseup.net>