### PR TITLE
documentation: dependencies: fedora.dependencies: add missing deps

### DIFF
--- a/documentation/dependencies/fedora.dependencies
+++ b/documentation/dependencies/fedora.dependencies
@@ -22,3 +22,5 @@ git-email
 pv
 rsync
 ccache
+patch
+sqlite


### PR DESCRIPTION
Add "patch" and "sqlite" to the Fedora dependencies file which provides respectively "patch" and "sqlite3". Those dependencies are not installed by default on Fedora and should be installed with kw.