### PR TITLE
src: remote: fix error message thrown when `kw ssh` fails using a remote config file

### DIFF
--- a/src/remote.sh
+++ b/src/remote.sh
@@ -28,6 +28,8 @@ function is_ssh_connection_configured()
   if [[ -z "$remote" && -z "$port" && -z "$user" ]]; then
     if [[ -n "${remote_file}" ]]; then
       ssh_cmd="ssh -q -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=5 -F ${remote_file} ${remote_file_host} exit"
+    else
+      return 2 # ENOENT
     fi
   fi
 

--- a/tests/remote_test.sh
+++ b/tests/remote_test.sh
@@ -127,6 +127,47 @@ function test_populate_remote_info()
   }
 }
 
+function test_is_ssh_connection_configured()
+{
+  local remote='test_remote'
+  local user='test_user'
+  local port='22'
+  local flag='TEST_MODE'
+
+  cd "$TEST_PATH" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
+
+  # Case 1: IP, user and port passed as command line arguments (kw ssh -r)
+  remote_parameters['REMOTE_IP']="$remote"
+  remote_parameters['REMOTE_USER']="$user"
+  remote_parameters['REMOTE_PORT']="$port"
+
+  is_ssh_connection_configured "$flag" > /dev/null
+
+  assertEquals "($LINENO):" '0' "$?"
+
+  # Case 2: Using a remote config file
+  remote_parameters['REMOTE_IP']=''
+  remote_parameters['REMOTE_USER']=''
+  remote_parameters['REMOTE_PORT']=''
+  remote_parameters['REMOTE_FILE']="${TEST_PATH}/.kw/remote.config"
+  remote_parameters['REMOTE_FILE_HOST']='origin'
+
+  is_ssh_connection_configured "$flag" > /dev/null
+
+  assertEquals "($LINENO):" '0' "$?"
+
+  # Case 3: No remote config file found
+  remote_parameters['REMOTE_FILE']=''
+  remote_parameters['REMOTE_FILE_HOST']=''
+
+  is_ssh_connection_configured "$flag"
+
+  assertEquals "($LINENO):" '2' "$?"
+}
+
 function test_ssh_connection_failure_message()
 {
   local expected_remote='deb-tm'


### PR DESCRIPTION
This patch corrects the error message when a failed `kw ssh` occurs using a remote config file instead of explicitly typing the IP, user and port of the host (using `kw ssh --remote | -r`). It also adds a test to verify if the correct error message is being thrown to the user in three distinct cases:
- Explicitly typing the IP, user and port;
- Using a remote config file;
- When no remote config file is found (without explicitly declaring the host infos).

Closes #695