### PR TITLE
src: diff: remove obsolete `load_kworkflow_config` call

### DIFF
--- a/src/diff.sh
+++ b/src/diff.sh
@@ -137,5 +137,3 @@ function diff_help()
     '  diff <file1> <file2>                  - interactive diff' \
     '  diff --no-interactive <file1> <file2> - static diff'
 }
-
-load_kworkflow_config


### PR DESCRIPTION
This commit removes an obsolete call at the end of the `diff.sh` file.

Closes #699 