### PR TITLE
src: remote: handle error of remote config file not found

### DIFF
--- a/src/remote.sh
+++ b/src/remote.sh
@@ -28,6 +28,8 @@ function is_ssh_connection_configured()
   if [[ -z "$remote" && -z "$port" && -z "$user" ]]; then
     if [[ -n "${remote_file}" ]]; then
       ssh_cmd="ssh -q -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=5 -F ${remote_file} ${remote_file_host} exit"
+    else
+      return 2 # ENOENT
     fi
   fi
 

--- a/tests/remote_test.sh
+++ b/tests/remote_test.sh
@@ -127,6 +127,85 @@ function test_populate_remote_info()
   }
 }
 
+function test_is_ssh_connection_configured()
+{
+  local remote='test_remote'
+  local user='test_user'
+  local port='22'
+  local flag='TEST_MODE'
+  local current_path="$PWD"
+
+  cd "$TEST_PATH" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
+
+  remote_parameters['REMOTE_IP']="$remote"
+  remote_parameters['REMOTE_USER']="$user"
+  remote_parameters['REMOTE_PORT']="$port"
+
+  is_ssh_connection_configured "$flag" > /dev/null
+
+  assertEquals "($LINENO):" 0 "$?"
+
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move to the original path"
+    return
+  }
+}
+
+function test_is_ssh_connection_configured_with_remote_config_file()
+{
+  local flag='TEST_MODE'
+  local current_path="$PWD"
+
+  cd "$TEST_PATH" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
+
+  remote_parameters['REMOTE_IP']=''
+  remote_parameters['REMOTE_USER']=''
+  remote_parameters['REMOTE_PORT']=''
+  remote_parameters['REMOTE_FILE']="${TEST_PATH}/.kw/remote.config"
+  remote_parameters['REMOTE_FILE_HOST']='origin'
+
+  is_ssh_connection_configured "$flag" > /dev/null
+
+  assertEquals "($LINENO):" 0 "$?"
+
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move to the original path"
+    return
+  }
+}
+
+function test_is_ssh_connection_configured_no_remote_config_file()
+{
+  local flag='TEST_MODE'
+  local current_path="$PWD"
+
+  cd "$TEST_PATH" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
+
+  remote_parameters['REMOTE_IP']=''
+  remote_parameters['REMOTE_USER']=''
+  remote_parameters['REMOTE_PORT']=''
+  remote_parameters['REMOTE_FILE']=''
+  remote_parameters['REMOTE_FILE_HOST']=''
+
+  is_ssh_connection_configured "$flag"
+
+  assertEquals "($LINENO):" 2 "$?"
+
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move to the original path"
+    return
+  }
+}
+
 function test_ssh_connection_failure_message()
 {
   local expected_remote='deb-tm'


### PR DESCRIPTION
In the `is_ssh_connection_configured` function there was no error handling when kw did not find a remote config file. With this commit, rather than ignoring this case and trying to establish a connection anyway we return an error code of no entry (`ENOENT`) and avoid extra computation when we know that it will fail.

Signed-off-by: David Tadokoro <davidbtadokoro@usp.br>
Co-authored-by: Everaldo Gomes Junior <everaldogjr@gmail.com>