### PR TITLE
Fix issue #715

### DIFF
--- a/documentation/dependencies/fedora.dependencies
+++ b/documentation/dependencies/fedora.dependencies
@@ -1,5 +1,5 @@
 qemu
-libguestfs-tools
+virt-win-reg
 git
 tar
 python3-docutils


### PR DESCRIPTION
In the fedora dependencies file `/documentation/dependencies/fedora.dependencies` the dependency `libguestfs-tools` was wrong. Now the right depednecy, `virt-win-reg` was added to the dependecy file.

