### PR TITLE
src: kernel_config_manager: fix `kw (--save | -s)` behavior when git commit fails (CLONE)

### DIFF
--- a/src/kernel_config_manager.sh
+++ b/src/kernel_config_manager.sh
@@ -138,7 +138,7 @@ function save_config_file()
   ret="$?"
 
   if [[ "$ret" -gt 0 ]]; then
-    fail "Could not save user config files"
+    complain "Could not save user config files"
   else
     success "Saved $name"
   fi


### PR DESCRIPTION
After this patch, failing `kw (--save | -s)` because of error in commiting save operation of .config file no longer throws wrong error (undefined function) neither consolidates the operation.

Closes #696 

Obs.: This PR is a clone of PR #697. Check this thread for more info.