### PR TITLE
dependencies: arch.dependencies: add arch dependency

### DIFF
--- a/documentation/dependencies/arch.dependencies
+++ b/documentation/dependencies/arch.dependencies
@@ -26,3 +26,4 @@ pv
 rsync
 ccache
 libguestfs
+python-setuptools


### PR DESCRIPTION
Add `python-setuptools` to the arch dependencies list.

The `setup.sh -i` commands uses a python-setuptools package to detect if all pip dependencies packages are installed but it is not at the depencendies list.

Closes issue #710.

Signed-off-by: Pedro Rabello Sato <kamorst@usp.br>