### PR TITLE
setup.sh: Decrease setup time on Fedora

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -63,8 +63,8 @@ function check_dependencies()
     cmd="apt install -y $package_list"
   elif [[ "$distro" =~ 'fedora' ]]; then
     while IFS='' read -r package; do
-      installed=$(dnf list installed "$package" 2> /dev/null | grep -c "$package")
-      [[ "$installed" -eq 0 ]] && package_list="$package $package_list"
+      installed=$(rpm -q "$package" &> /dev/null)
+      [[ "$?" -ne 0 ]] && package_list="$package $package_list"
     done < "$DOCUMENTATION/dependencies/fedora.dependencies"
     cmd="dnf install -y $package_list"
   else


### PR DESCRIPTION
The command to check if a package is installed on a Fedora system take 10x the time of Arch and Ubuntu counterparts. This makes the 'setup.sh -i' take 4x slower on Fedora. The measure time assumes that all the all packages are already installed, because it would add unneeded variables.

As an example, my computer running takes 2.5s on average to run `setup.sh -i`. On Fedora, 11.8s. After the change Fedora takes 3s.

Some raw backing data:
```
# BEFORE CHANGE
[psato@fedora kworkflow-gitrepo]$ hyperfine './setup.sh -i'
Benchmark 1: ./setup.sh -i
  Time (mean ± σ):     11.896 s ±  0.182 s    [User: 9.642 s, System: 1.911 s]
  Range (min … max):   11.706 s … 12.376 s    10 runs

#AFTER CHANGE
[psato@fedora kworkflow-gitrepo]$ hyperfine './setup.sh -i'
Benchmark 1: ./setup.sh -i
  Time (mean ± σ):      3.006 s ±  0.379 s    [User: 2.245 s, System: 0.440 s]
  Range (min … max):    2.496 s …  3.572 s    10 runs
``` 