### PR TITLE
src: config: add configurations listing

### DIFF
--- a/documentation/man/features/config.rst
+++ b/documentation/man/features/config.rst
@@ -6,8 +6,10 @@ kw-config
 
 SYNOPSIS
 ========
+| *kw* (*g* | *config*)
 | *kw* (*g* | *config*) [(-g | \--global)] <config.option value>
 | *kw* (*g* | *config*) [(-l | \--local)] <config.option value>
+| *kw* (*g* | *config*) (-s | \--show) [<config_target>]...
 
 
 DESCRIPTION
@@ -18,6 +20,12 @@ the following syntax to identify the target configuration::
 
   <config file name>.<valid option for specific config file> <value>
 
+You can also use `kw config` to show all or some of the current configurations
+displayed in a similar fashion to the `git config --list` command::
+
+  kw (g | config) [(-s | \--show)]                    # show all configurations
+  kw (g | config) (-s | \--show) <config_target>...   # show configurations of target(s) 
+
 OPTIONS
 =======
 -g, \--global:
@@ -26,6 +34,9 @@ OPTIONS
 -l, \--local:
   This is the default option, and it sets `<config.option value>` to the local
   configuration.
+
+-s, \--show:
+  Display current configurations
 
 EXAMPLES
 ========
@@ -38,3 +49,11 @@ use::
 Let's say you want to enable the visual and sonorous alert. You can use::
 
   kw config kworkflow.alert vs
+
+If you want to display all configurations you could use::
+
+  kw config
+
+If you want to display deploy configurations you could use::
+
+  kw config -s deploy

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -279,6 +279,41 @@ function assert_substring_match()
   fi
 }
 
+# This function asserts an exact line match (case sensitive).
+#
+# @lineno $LINENO variable
+# @expected_line Expected line
+# @result_to_compare Raw output to be compared
+function assert_line_match()
+{
+  local lineno="$1"
+  local expected_line="$2"
+  local result_to_compare="$3"
+
+  if ! grep -qFx "$expected_line" <<< "$result_to_compare"; then
+    fail "line ${lineno}: expected exact match of line '${expected_line}'"
+    return
+  fi
+}
+
+# This function asserts that an exact line is a no match (case sensitive).
+# Its the inverse of assert_line_match() function.
+#
+# @lineno $LINENO variable
+# @not_expected_line Not expected line
+# @result_to_compare Raw output to be compared
+function assert_no_line_match()
+{
+  local lineno="$1"
+  local not_expected_line="$2"
+  local result_to_compare="$3"
+
+  if grep -qFx "$not_expected_line" <<< "$result_to_compare"; then
+    fail "line ${lineno}: expected NO exact match of line '${not_expected_line}'"
+    return
+  fi
+}
+
 # This function expects an array of string with the command sequence and a
 # string containing the output.
 #


### PR DESCRIPTION
As requested in #701, this PR implements a feature in `kw config` for listing the configurations in the `kw` environment.

Considering the requests of the issue, there are two differences:
1. Instead of using the suggested option `--list` I went for `--show`, because the clear short option for `--list` (`-l`) was already in use in contrast with `-s` that was available.
2. The issue requested that the `kw vars` functionality was incorporated in the feature. However, I think some of the output of `kw vars` is not consistent with the options configurable through `kw config` and this output seems kind of innacurate.

Given those, how should I proceed? This implementation of the feature is satisfying or should I address these two differences?

**Use:**
`kw (config | config --show | config -s)`: list all options configurable through `kw config` including those there are not set.
`kw config (--show | -s) <config_target>...`: list all options of the targets configurable through `kw config` including those there are not set.

Closes #701 