### PR TITLE
Small refactor of vm_test.sh

### DIFF
--- a/src/vm.sh
+++ b/src/vm.sh
@@ -1,7 +1,7 @@
 include "$KW_LIB_DIR/kw_config_loader.sh"
 include "$KW_LIB_DIR/kwlib.sh"
 
-declare -g prefix='/'
+declare -g PREFIX='/'
 declare -gA options_values
 
 function vm_main()
@@ -58,17 +58,17 @@ function vm_mount()
   qemu_img_path="${qemu_img_path:-${vm_config[qemu_path_image]}}"
   mount_point_path="${mount_point_path:-${vm_config[mount_point]}}"
 
-  if [[ ! -r "${prefix}boot/vmlinuz-$(uname -r)" ]]; then
+  if [[ ! -r "${PREFIX}boot/vmlinuz-$(uname -r)" ]]; then
     say 'To mount the VM, the kernel image needs to be readable'
     if [[ $(ask_yN 'Do you want to make your host kernel image readable?') =~ 0 ]]; then
       return 125 # ECANCELED
     fi
 
-    distro=$(detect_distro "${prefix}")
+    distro=$(detect_distro "${PREFIX}")
     if [[ "$distro" =~ 'debian' ]]; then
-      cmd_manager "$flag" "sudo dpkg-statoverride --update --add root root 0644 ${prefix}boot/vmlinuz-$(uname -r)"
+      cmd_manager "$flag" "sudo dpkg-statoverride --update --add root root 0644 ${PREFIX}boot/vmlinuz-$(uname -r)"
     else
-      cmd_manager "$flag" "sudo chmod +r ${prefix}boot/vmlinuz-$(uname -r)"
+      cmd_manager "$flag" "sudo chmod +r ${PREFIX}boot/vmlinuz-$(uname -r)"
     fi
   fi
 

--- a/tests/vm_test.sh
+++ b/tests/vm_test.sh
@@ -6,13 +6,13 @@ include './src/vm.sh'
 
 function setUp()
 {
+  export PREFIX="$SHUNIT_TMPDIR/"
   mkdir -p "$SHUNIT_TMPDIR/.kw/"
   cp -f "$KW_VM_CONFIG_SAMPLE" "$SHUNIT_TMPDIR/.kw/"
 
   tests="$PWD/tests"
   etc="${PREFIX}etc"
 
-  export PREFIX="$SHUNIT_TMPDIR/"
   mkdir -p "${PREFIX}boot"
   mkdir -p "$etc"
 }

--- a/tests/vm_test.sh
+++ b/tests/vm_test.sh
@@ -44,9 +44,6 @@ function test_vm_mount()
     printf '5.1'
   }
 
-  tearDown
-  setUp
-
   cd "$SHUNIT_TMPDIR" || {
     fail "($LINENO) It was not possible to move to temporary directory"
     return

--- a/tests/vm_test.sh
+++ b/tests/vm_test.sh
@@ -10,10 +10,10 @@ function setUp()
   cp -f "$KW_VM_CONFIG_SAMPLE" "$SHUNIT_TMPDIR/.kw/"
 
   tests="$PWD/tests"
-  etc="${prefix}etc"
+  etc="${PREFIX}etc"
 
-  export prefix="$SHUNIT_TMPDIR/"
-  mkdir -p "${prefix}boot"
+  export PREFIX="$SHUNIT_TMPDIR/"
+  mkdir -p "${PREFIX}boot"
   mkdir -p "$etc"
 }
 
@@ -54,17 +54,17 @@ function test_vm_mount()
   }
 
   # Mock vmlinuz
-  touch "${prefix}boot/vmlinuz-$(uname)"
+  touch "${PREFIX}boot/vmlinuz-$(uname)"
 
   # Removing read permission from our mock vmlinuz
-  chmod a-r "${prefix}boot/vmlinuz-$(uname)"
+  chmod a-r "${PREFIX}boot/vmlinuz-$(uname)"
 
   # Suppose it's a debian system
-  cp -f "$tests/samples/os/debian/etc/os-release" "$prefix/etc"
+  cp -f "$tests/samples/os/debian/etc/os-release" "$PREFIX/etc"
 
   expected_cmd=(
     'To mount the VM, the kernel image needs to be readable'
-    "sudo dpkg-statoverride --update --add root root 0644 ${prefix}boot/vmlinuz-$(uname -r)"
+    "sudo dpkg-statoverride --update --add root root 0644 ${PREFIX}boot/vmlinuz-$(uname -r)"
     "$say_msg"
     "$guestmount_cmd"
   )
@@ -74,14 +74,14 @@ function test_vm_mount()
 
   # Suppose it's not debian
   rm -rf "${etc:?}/"*
-  cp -f "$tests/samples/os/arch/etc/os-release" "$prefix/etc"
+  cp -f "$tests/samples/os/arch/etc/os-release" "$PREFIX/etc"
 
-  expected_cmd[1]="sudo chmod +r ${prefix}boot/vmlinuz-$(uname -r)"
+  expected_cmd[1]="sudo chmod +r ${PREFIX}boot/vmlinuz-$(uname -r)"
   output=$(printf '%s\n' 'y' | vm_mount 'TEST_MODE' "$qemu_path" "$mount_point")
   compare_command_sequence '' "$LINENO" 'expected_cmd' "$output"
 
   # Adding back read permission
-  chmod +r "${prefix}boot/vmlinuz-$(uname)"
+  chmod +r "${PREFIX}boot/vmlinuz-$(uname)"
 
   expected_cmd=(
     "$say_msg"

--- a/tests/vm_test.sh
+++ b/tests/vm_test.sh
@@ -20,7 +20,6 @@ function setUp()
 function tearDown()
 {
   rm -rf "$SHUNIT_TMPDIR"
-  mkdir -p "$SHUNIT_TMPDIR"
 }
 
 function test_vm_mount()


### PR DESCRIPTION
The motivation to these modifications started because there were a variable being used before being assigned. Fixing this variable made useless a setUp and tearDown mid test which I believe is a workaround.
