### PR TITLE
src: update: add self-update mechanism to kw

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -176,6 +176,7 @@ man_pages = [
     ('man/features/report', 'report', 'user data report support', [author], 1),
     ('man/features/ssh', 'ssh', 'ssh access', [author], 1),
     ('man/features/vars', 'vars', 'view kw config values', [author], 1),
+    ('man/features/self-update', 'self-update', 'kw self-update mechanism', ['David Tadokoro, Everaldo Junior'], 1),
 ]
 
 

--- a/documentation/man/features/self-update.rst
+++ b/documentation/man/features/self-update.rst
@@ -1,0 +1,40 @@
+==============
+kw-self-update
+==============
+
+.. _self-update-doc:
+
+SYNOPSIS
+========
+| *kw* (*u* | *self-update*)
+| *kw* (*u* | *self-update*) [(-u | --unstable)]
+| *kw* (*u* | *self-update*) [(-h | --help)]
+
+DESCRIPTION
+===========
+The `kw self-update` feature facilitates the process of updating kw.
+
+By just running `kw self-update`, the user can update `kw` based on the
+master or unstable branch in a simple way.
+
+By default, `kw self-update` updates `kw` based on the master branch. If
+the user wants to update based on the unstable branch, the `--unstable`
+option should be used.
+
+OPTIONS
+=======
+-u, \--unstable:
+  Update kw based on the unstable branch
+
+\--help:
+  Show this man page
+
+EXAMPLES
+========
+Updating based on the master branch::
+
+  kw self-update
+
+Updating based on the unstable branch::
+
+  kw self-update --unstable

--- a/documentation/man/kw.rst
+++ b/documentation/man/kw.rst
@@ -92,6 +92,7 @@ the previous sections.
   | :ref:`kw-report<report-doc>`
   | :ref:`kw-pomodoro<pomodoro-doc>`
   | :ref:`kw-mail<mail-doc>`
+  | :ref:`kw-self-update<self-update-doc>`
 
 clear-cache
 ~~~~~~~~~~~

--- a/kw
+++ b/kw
@@ -127,6 +127,13 @@ function kw()
         execute_checkpatch "$@"
       )
       ;;
+    self-update | u)
+      (
+        include "${KW_LIB_DIR}/self_update.sh"
+
+        self_update_main "$@"
+      )
+      ;;
     maintainers | m)
       (
         include "${KW_LIB_DIR}/maintainers.sh"

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -72,6 +72,9 @@ function _kw_autocomplete()
 
   kw_options['env']='--create --list --use'
 
+  kw_options['self-update']='--unstable --help'
+  kw_options['u']="${kw_options['self-update']}"
+
   mapfile -t COMPREPLY < <(compgen -W "${kw_options[${previous_command}]} " -- "${current_command}")
 
   # TODO:

--- a/src/help.sh
+++ b/src/help.sh
@@ -33,6 +33,7 @@ function kworkflow_help()
     '  man - Show manual pages' \
     '  pomodoro,p - kw pomodoro support' \
     '  report,r - Show kw pomodoro reports and kw usage statistics' \
+    '  self-update,u - kw self-update mechanism' \
     '  ssh,s - SSH support' \
     '  vars - Show variables' \
     '  version,--version,-v - Show kw version'

--- a/src/self_update.sh
+++ b/src/self_update.sh
@@ -1,0 +1,169 @@
+include "${KW_LIB_DIR}/kwlib.sh"
+include "${KW_LIB_DIR}/kwio.sh"
+include "${KW_LIB_DIR}/help.sh"
+
+declare -gA options_values
+
+function self_update_main()
+{
+  local target_branch='master'
+  local path_to_tmp_dir
+  local ret
+
+  parse_self_update_options "$@"
+  if [[ "$?" != 0 ]]; then
+    complain "Invalid option: ${options_values['ERROR']}"
+    self_update_help
+    return 22 # EINVAL
+  fi
+
+  if [[ -n "${options_values['UNSTABLE']}" ]]; then
+    target_branch='unstable'
+  fi
+
+  printf '%s\n' "Updating kw based on the branch ${target_branch}"
+  if [[ $(ask_yN 'Do you want to continue?') =~ '0' ]]; then
+    complain 'Update aborted.'
+    return 125 # ECANCELED
+  fi
+
+  path_to_tmp_dir=$(mktemp --directory)
+  update_from_official_repo "${target_branch}" "${path_to_tmp_dir}"
+
+  ret="$?"
+  if [[ "$ret" != 0 ]]; then
+    complain "Update from branch ${target_branch} failed"
+    return "$ret"
+  fi
+
+  success "Update based on the branch ${target_branch} successful!"
+}
+
+# Updates kw using the official kw repository.
+#
+# @target_branch Branch used to update
+# @path_to_tmp_dir Path to temp dir used for cloning repo
+# @flag Variable for testing
+#
+# Return:
+# In case of success return 0, otherwise, return the error
+# code.
+function update_from_official_repo()
+{
+  local target_branch="$1"
+  local path_to_tmp_dir="$2"
+  local flag="$3"
+  local original_pwd="$PWD"
+  local cmd
+  local ret
+
+  flag=${flag:-'SILENT'}
+
+  # Just to be sure temp dir is not root dir
+  if [ "${path_to_tmp_dir}" == '/' ]; then
+    complain "Aborting update! Invalid path to temporary directory: '${path_to_tmp_dir}'"
+    return 1 # EPERM
+  fi
+
+  cmd="git -C ${path_to_tmp_dir} clone --quiet 'https://github.com/kworkflow/kworkflow.git'"
+  cmd_manager "$flag" "$cmd"
+  ret="$?"
+  if [[ "$ret" != 0 ]]; then
+    complain 'Could not clone kworkflow repository'
+    return "$ret"
+  fi
+
+  cmd="git -C ${path_to_tmp_dir}/kworkflow checkout --quiet ${target_branch}"
+  cmd_manager "$flag" "$cmd"
+  if [[ "$?" != 0 ]]; then
+    complain "Could not checkout to branch ${target_branch}"
+    return 95 # EOPNOTSUPP
+  fi
+
+  cmd="git -C ${path_to_tmp_dir}/kworkflow pull --quiet 'origin' ${target_branch}"
+  cmd_manager "$flag" "$cmd"
+  if [[ "$?" != 0 ]]; then
+    complain "Could not pull from branch ${target_branch}"
+    return 95 # EOPNOTSUPP
+  fi
+
+  cmd="cd ${path_to_tmp_dir}/kworkflow"
+  cmd_manager "$flag" "$cmd"
+  if [[ "$?" != 0 ]]; then
+    complain 'Could not change to kworkflow directory'
+    return 2 # ENOENT
+  fi
+
+  cmd='bash setup.sh --install'
+  cmd_manager "$flag" "$cmd"
+  ret="$?"
+  if [[ "$ret" != 0 ]]; then
+    complain 'Could not update kw'
+    cd "${original_dir}" || complain 'Could not change back to original directory'
+    return "$ret"
+  fi
+
+  cmd="cd ${original_dir}"
+  cmd_manager "$flag" "$cmd"
+  if [[ "$?" != 0 ]]; then
+    complain 'Could not change back to original directory'
+    return 2 # ENOENT
+  fi
+
+  cmd="rm -rf ${path_to_tmp_dir}"
+  cmd_manager "$flag" "$cmd"
+  if [[ "$?" != 0 ]]; then
+    complain 'Could not remove temporary directory'
+    return 1 # EPERM
+  fi
+
+  return 0
+}
+
+function parse_self_update_options()
+{
+  local long_options='unstable,help'
+  local short_options='u,h'
+
+  options="$(kw_parse "$short_options" "$long_options" "$@")"
+
+  if [[ "$?" != 0 ]]; then
+    options_values['ERROR']="$(kw_parse_get_errors 'kw update' "$short_options" \
+      "$long_options" "$@")"
+    return 22 # EINVAL
+  fi
+
+  eval "set -- $options"
+
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --unstable | -u)
+        options_values['UNSTABLE']=1
+        shift
+        ;;
+      --help | -h)
+        self_update_help "$1"
+        exit
+        ;;
+      --)
+        shift
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+}
+
+function self_update_help()
+{
+  if [[ "$1" == --help ]]; then
+    include "${KW_LIB_DIR}/help.sh"
+    kworkflow_man 'self-update'
+    return
+  fi
+  printf '%s\n' 'kw self-update:' \
+    '  kw self-update - Update kw based on the master branch' \
+    '  kw self-update (-u | --unstable) - Update kw based on the unstable branch' \
+    '  kw self-update --help - Show the man page for kw self-update'
+}

--- a/tests/self_update_test.sh
+++ b/tests/self_update_test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+include './src/self_update.sh'
+include './tests/utils.sh'
+
+function oneTimeSetUp()
+{
+  export TEST_PATH="${SHUNIT_TMPDIR}/test_path"
+  export original_dir="$PWD"
+  export fake_dir_path="${SHUNIT_TMPDIR}/fake_dir"
+}
+
+function setUp()
+{
+  mkdir -p "${fake_dir_path}" || {
+    fail "($LINENO) It was not possible to create the fake directory"
+    return
+  }
+
+  cd "${SHUNIT_TMPDIR}" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
+}
+
+function tearDown()
+{
+  rm -rf "${fake_dir_path}" || {
+    fail "($LINENO) It was not possible to remove the fake directory"
+    return
+  }
+
+  cd "${original_dir}" || {
+    fail "($LINENO) It was not possible to back to the kw folder"
+    return
+  }
+}
+
+function test_update_from_official_repo_based_on_master()
+{
+  update_from_official_repo 'master' "${fake_dir_path}" 'TEST_MODE' > /dev/null 2>&1
+  assertEquals "($LINENO) It should be able to update based on the master." 0 "$?"
+}
+
+function test_update_from_official_repo_based_on_unstable()
+{
+  update_from_official_repo 'unstable' "${fake_dir_path}" 'TEST_MODE' > /dev/null 2>&1
+  assertEquals "($LINENO) It should be able to update based on the unstable." 0 "$?"
+}
+
+function test_update_from_official_repo_root_as_tmp_dir()
+{
+  update_from_official_repo 'unstable' '/' 'TEST_MODE' > /dev/null 2>&1
+  assertEquals "($LINENO) It should be abort the update." 1 "$?"
+}
+
+function test_parse_self_update_options()
+{
+  local expected_output=''
+  local output=''
+
+  unset options_values
+  declare -gA options_values
+  parse_self_update_options '--unstable'
+  assertEquals "($LINENO) UNSTABLE could not be set" 1 "${options_values['UNSTABLE']}"
+
+  unset options_values
+  declare -gA options_values
+  parse_self_update_options '-u'
+  assertEquals "($LINENO) UNSTABLE could not be set" 1 "${options_values['UNSTABLE']}"
+
+  expected_output='kw self-update:'$'\n'
+  expected_output+='  kw self-update - Update kw based on the master branch'$'\n'
+  expected_output+='  kw self-update (-u | --unstable) - Update kw based on the unstable branch'$'\n'
+  expected_output+='  kw self-update --help - Show the man page for kw self-update'
+  output=$(parse_self_update_options '-h')
+  assertEquals "($LINENO) Should show help" "${expected_output}" "$output"
+}
+
+invoke_shunit


### PR DESCRIPTION
Now the user can update kw by just running `kw update` instead of having to go to a kw repo, checking out to the given branch and running the `setup.sh` script. By default, `kw update` clones the official kw repo in the `/tmp` and installs it from the given branch (just works with the master and unstable branch). If the user wants to update using a local repo, passing the path to this repo with the flag `--local` does the job. Also, if the user wants to install the current unstable version of kw, the flag `--unstable` can be used.

Closes #303

Co-authored-by: Everaldo Gomes Junior <everaldogjr@gmail.com>
Signed-off-by: David Tadokoro <davidbtadokoro@usp.br>