### PR TITLE
 Add an option to display all available remotes

### DIFF
--- a/report_output
+++ b/report_output
@@ -1,0 +1,31 @@
+# Report: 
+ * Total hours of focus: 222:25:44
+ * Total focus session(s): 451
+
+## tag_6
+ - Total focus time: 00:30:00
+ - Total repetitions: 3
+
+Summary:
+ - 2020/04/04
+   * [15:00:00-15:10:00][10m]
+
+## tag_2
+ - Total focus time: 00:45:00
+ - Total repetitions: 3
+
+Summary:
+ - 2020/04/04
+   * [08:30:50-08:45:50][15m]: Tag 2 description
+
+## tag_1
+ - Total focus time: 01:00:00
+ - Total repetitions: 3
+
+Summary:
+ - 2020/04/04
+   * [06:00:40-06:20:40][20m]: Tag 1 description
+
+# Statistics: 
+
+

--- a/src/kw_remote.sh
+++ b/src/kw_remote.sh
@@ -36,6 +36,11 @@ function remote_main()
     rename_remote
     return "$?"
   fi
+
+  if [[ -n "${options_values['LIST']}" ]]; then
+    list_remotes
+    return "$?"
+  fi
 }
 
 function add_new_remote()
@@ -210,6 +215,18 @@ function rename_remote()
   fi
 }
 
+function list_remotes()
+{
+  # check if the remote config file exists
+  if [ -f "$local_remote_config_file" ]; then
+    cat $local_remote_config_file
+    exit 0
+  else
+    echo "There are no remotes"
+    return 22 # EINVAL
+  fi
+}
+
 function parse_remote_options()
 {
   local long_options='add,remove,rename,verbose,set-default::'
@@ -256,6 +273,10 @@ function parse_remote_options()
         options_values['RENAME']=1
         shift
         ;;
+      list)
+        options_values['LIST']=1
+        shift
+        ;;
       --set-default | -s)
         default_option="$(str_strip "$2")"
         # set-default can be used in combination with add
@@ -299,6 +320,7 @@ function remote_help()
     '  remote add <name> <USER@IP:PORT> [--set-default] - Add new remote' \
     '  remote remove <name> - Remove remote' \
     '  remote rename <old> <new> - Rename remote' \
+    '  remote list - List all the remotes' \
     '  remote --set-default=<remonte-name> - Set default remote' \
     '  remote (--verbose | -v) - be verbose'
 }

--- a/tests/kw_remote_test.sh
+++ b/tests/kw_remote_test.sh
@@ -423,6 +423,10 @@ function test_parse_remote_options()
   parse_remote_options rename origin xpto
   assert_equals_helper 'Request rename' "($LINENO)" "${options_values['RENAME']}" 1
   assert_equals_helper 'Remote options' "($LINENO)" "${options_values['PARAMETERS']}" 'origin xpto '
+
+  # List
+  parse_remote_options list
+  assert_equals_helper 'Request rename' "($LINENO)" "${options_values['LIST']}" 1
 }
 
 invoke_shunit


### PR DESCRIPTION
A command to list all the available remotes was added to the remote command
https://github.com/kworkflow/kworkflow/issues/729