### PR TITLE
etc/init_templates: change default deploy target to remote for x86

### DIFF
--- a/etc/init_templates/x86-64/deploy.config
+++ b/etc/init_templates/x86-64/deploy.config
@@ -32,7 +32,7 @@ dtb_copy_pattern=
 # Sometimes it could be bothersome to pass the same parameter for kw deploy;
 # here, you can set the default target. We define `vm` as the default, but
 # you can also use `local` and `remote`.
-default_deploy_target=vm
+default_deploy_target=remote
 
 # If you want to reboot your target machine after the deploy gets done, you can
 # change the option `reboot_after_deploy` from "no" to "yes".


### PR DESCRIPTION
vm deployment support was removed. change default deploy target on x86 template to match deployment options.

Signed-off-by: Melissa Wen <mwen@igalia.com>