### PR TITLE
plugins/utils: copy dtb files if in the remote package

### DIFF
--- a/src/plugins/kernel_install/utils.sh
+++ b/src/plugins/kernel_install/utils.sh
@@ -641,6 +641,13 @@ function install_kernel()
   cmd="${sudo_cmd}cp ${KW_DEPLOY_TMP_FILE}/kw_pkg/${kernel_image_name} /boot/"
   cmd_manager "$flag" "$cmd"
 
+  # Copy dtbs to /boot if exist
+  dtb_files=$(find "${KW_DEPLOY_TMP_FILE}"/kw_pkg -type f -name "*.dtb")
+  if [[ -n "$dtb_files" ]]; then
+    cmd="${sudo_cmd} cp ${KW_DEPLOY_TMP_FILE}/kw_pkg/*.dtb /boot/"
+    cmd_manager "$flag" "$cmd"
+  fi
+
   # Each distro has their own way to update their bootloader
   update_bootloader "$flag" "$name" "$target" "$kernel_image_name" "$distro" "$path_test"
   ret="$?"


### PR DESCRIPTION
Check if there are dtb files in the remote package and copy them to boot, accordingly.

Suggested-by: Rodrigo Siqueira <siqueirajordao@riseup.net>
Signed-off-by: Melissa Wen <mwen@igalia.com>