### PR TITLE
src: build: changing the short option of the --cpu-scaling parameter.

### DIFF
--- a/documentation/man/features/build.rst
+++ b/documentation/man/features/build.rst
@@ -10,7 +10,7 @@ SYNOPSIS
 | *kw* (*b* | *build*) [(-n | \--menu)] [\--alert=(s | v | (sv | vs) | n)]
 | *kw* (*b* | *build*) [(-d | \--doc)] [\--alert=(s | v | (sv | vs) | n)]
 | *kw* (*b* | *build*) [\--ccache] [\--alert=(s | v | (sv | vs) | n)]
-| *kw* (*b* | *build*) [(-c | \--cpu-scaling)] <percentage> [\--alert=(s | v | (sv | vs) | n)]
+| *kw* (*b* | *build*) [(-S | \--cpu-scaling)] <percentage> [\--alert=(s | v | (sv | vs) | n)]
 | *kw* (*b* | *build*) [(-w | \--warnings)] [warning-levels] [\--alert=(s | v | (sv | vs) | n)]
 | *kw* (*b* | *build*) [(-s | \--save-log-to)] <path> [\--alert=(s | v | (sv | vs) | n)]
 | *kw* (*b* | *build*) [\--llvm] [\--alert=(s | v | (sv | vs) | n)]
@@ -46,7 +46,7 @@ OPTIONS
   it will build htmldocs. Users can change the default documentation output by
   changing the parameter *doc_type* in the **kworkflow.config** file.
 
--c, \--cpu-scaling:
+-S, \--cpu-scaling:
   The cpu-scaling option lets the user set whichever CPU usage they want from
   their CPU, basically setting the ``-j`` flag accordingly.
 

--- a/src/build.sh
+++ b/src/build.sh
@@ -201,7 +201,7 @@ function load_build_config()
 function parse_build_options()
 {
   local long_options='help,info,menu,doc,ccache,cpu-scaling:,warnings::,save-log-to:,llvm'
-  local short_options='h,i,n,d,c:,w::,s:'
+  local short_options='h,i,n,d,S:,w::,s:'
   local doc_type
   local file_name_size
 
@@ -249,7 +249,7 @@ function parse_build_options()
         options_values['MENU_CONFIG']="${build_config[menu_config]:-$menu_fallback}"
         shift
         ;;
-      --cpu-scaling | -c)
+      --cpu-scaling | -S)
         if [[ ! "$2" =~ [0-9]+ ]]; then
           options_values['ERROR']="$2"
           return 22 # EINVAL
@@ -317,7 +317,7 @@ function build_help()
     '  build (-n | --menu) - Open kernel menu config' \
     '  build (-i | --info) - Display build information' \
     '  build (-d | --doc) - Build kernel documentation' \
-    '  build (-c | --cpu-scaling) <percentage> - Scale CPU usage by factor' \
+    '  build (-S | --cpu-scaling) <percentage> - Scale CPU usage by factor' \
     '  build (--ccache) - Enable use of ccache' \
     '  build (-w | --warnings) [warning_levels] - Enable warnings' \
     '  build (-s | --save-log-to) <path> - Save compilation log to path' \

--- a/tests/build_test.sh
+++ b/tests/build_test.sh
@@ -438,7 +438,7 @@ function test_parse_build_options()
     "($LINENO)" 150 "${options_values['CPU_SCALING_FACTOR']}"
 
   options_values=()
-  parse_build_options -c 150 > /dev/null
+  parse_build_options -S 150 > /dev/null
   assert_equals_helper 'Could not set build option CPU_SCALING_FACTOR' \
     "($LINENO)" 150 "${options_values['CPU_SCALING_FACTOR']}"
 


### PR DESCRIPTION
This commit changes the short option of the `build --cpu-scaling` parameter 
from `c` to `S`, as `c` will be used in the future for the `build --clean` parameter.

Signed-off-by: Aquila Macedo <aquilamacedo@riseup.net>