### PR TITLE
src: plugins: kernel_install: Make .old kernel optional

### DIFF
--- a/etc/deploy.config
+++ b/etc/deploy.config
@@ -34,6 +34,13 @@ dtb_copy_pattern=
 # you can also use `local` and `remote`.
 default_deploy_target=remote
 
+# If you set this option to 'yes', kw will make a copy of the kernel you are
+# replacing with the .old extension (you can see it in the GRUB menu). This can
+# be useful if you only have one kernel and you need to roll back to the
+# previous kernel; however, keep in mind that if you run multiple updates, your
+# .old kernel may not be a good backup.
+previous_kernel_backup=no
+
 # If you want to reboot your target machine after the deploy gets done, you can
 # change the option `reboot_after_deploy` from "no" to "yes".
 reboot_after_deploy=no

--- a/etc/init_templates/rpi4-raspbian-32-cross-x86-arm/deploy.config
+++ b/etc/init_templates/rpi4-raspbian-32-cross-x86-arm/deploy.config
@@ -34,6 +34,13 @@ dtb_copy_pattern=broadcom/*.dtb
 # you can also use `local` and `remote`.
 default_deploy_target=remote
 
+# If you set this option to 'yes', kw will make a copy of the kernel you are
+# replacing with the .old extension (you can see it in the GRUB menu). This can
+# be useful if you only have one kernel and you need to roll back to the
+# previous kernel; however, keep in mind that if you run multiple updates, your
+# .old kernel may not be a good backup.
+previous_kernel_backup=no
+
 # If you want to reboot your target machine after the deploy gets done, you can
 # change the option `reboot_after_deploy` from "no" to "yes".
 reboot_after_deploy=no

--- a/etc/init_templates/rpi4-raspbian-64-cross-x86-arm/deploy.config
+++ b/etc/init_templates/rpi4-raspbian-64-cross-x86-arm/deploy.config
@@ -34,6 +34,13 @@ dtb_copy_pattern=broadcom/*.dtb
 # you can also use `local` and `remote`.
 default_deploy_target=remote
 
+# If you set this option to 'yes', kw will make a copy of the kernel you are
+# replacing with the .old extension (you can see it in the GRUB menu). This can
+# be useful if you only have one kernel and you need to roll back to the
+# previous kernel; however, keep in mind that if you run multiple updates, your
+# .old kernel may not be a good backup.
+previous_kernel_backup=no
+
 # If you want to reboot your target machine after the deploy gets done, you can
 # change the option `reboot_after_deploy` from "no" to "yes".
 reboot_after_deploy=no

--- a/etc/init_templates/x86-64/deploy.config
+++ b/etc/init_templates/x86-64/deploy.config
@@ -34,6 +34,13 @@ dtb_copy_pattern=
 # you can also use `local` and `remote`.
 default_deploy_target=remote
 
+# If you set this option to 'yes', kw will make a copy of the kernel you are
+# replacing with the .old extension (you can see it in the GRUB menu). This can
+# be useful if you only have one kernel and you need to roll back to the
+# previous kernel; however, keep in mind that if you run multiple updates, your
+# .old kernel may not be a good backup.
+previous_kernel_backup=no
+
 # If you want to reboot your target machine after the deploy gets done, you can
 # change the option `reboot_after_deploy` from "no" to "yes".
 reboot_after_deploy=no

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -1089,6 +1089,7 @@ function create_pkg_metadata_file_for_deploy()
   printf 'kernel_name=%s\n' "$kernel_name" > "${cache_pkg_metadata_file_path}"
   printf 'kernel_binary_image_file=%s\n' "$kernel_binary_file_name" >> "${cache_pkg_metadata_file_path}"
   printf 'architecture=%s\n' "$arch" >> "${cache_pkg_metadata_file_path}"
+  printf 'previous_kernel_backup=%s\n' "${deploy_config[previous_kernel_backup]}" >> "${cache_pkg_metadata_file_path}"
 }
 
 # This function is responsible for putting all the required boot files in a

--- a/src/kw_config_loader.sh
+++ b/src/kw_config_loader.sh
@@ -197,6 +197,7 @@ function show_deploy_variables()
     [deploy_temporary_files_path]='Temporary files path used in the remote machine'
     [deploy_default_compression]='Default compression option used in the deploy'
     [dtb_copy_pattern]='How kw should copy dtb files to the boot folder'
+    [old_kernel_backup]='Backup the previous kernel if the current kernel to be deployed has the same name'
     [strip_modules_debug_option]='Modules will be stripped after they are installed which will reduce the initramfs size'
   )
 

--- a/src/plugins/kernel_install/utils.sh
+++ b/src/plugins/kernel_install/utils.sh
@@ -596,7 +596,7 @@ function install_kernel()
   local flag="$4"
   local sudo_cmd=''
   local cmd=''
-  local path_prefix=''
+  local path_test=''
   local verbose_cp
   local ret
 
@@ -604,6 +604,7 @@ function install_kernel()
   target=${target:-'remote'}
 
   [[ "$flag" == 'VERBOSE' ]] && verbose_cp='-v'
+  [[ "$flag" == 'TEST_MODE' ]] && path_test="$PWD"
 
   if [[ "$target" == 'local' ]]; then
     sudo_cmd='sudo -E '
@@ -631,8 +632,8 @@ function install_kernel()
   install_modules "$target" "$flag"
 
   # Copy kernel image
-  if [[ -f "${path_prefix}/boot/vmlinuz-${name}" ]]; then
-    cmd="$sudo_cmd cp $path_prefix/boot/vmlinuz-$name $path_prefix/boot/vmlinuz-$name.old"
+  if [[ -f "${path_test}/boot/vmlinuz-${name}" && "${kw_package_metadata['previous_kernel_backup']}" == 'yes' ]]; then
+    cmd="${sudo_cmd} cp ${path_test}/boot/vmlinuz-${name} ${path_test}/boot/vmlinuz-${name}.old"
     cmd_manager "$flag" "$cmd"
   fi
 
@@ -641,7 +642,7 @@ function install_kernel()
   cmd_manager "$flag" "$cmd"
 
   # Each distro has their own way to update their bootloader
-  update_bootloader "$flag" "$name" "$target" "$kernel_image_name" "$distro" "$path_prefix"
+  update_bootloader "$flag" "$name" "$target" "$kernel_image_name" "$distro" "$path_test"
   ret="$?"
 
   if [[ "$ret" != 0 ]]; then

--- a/tests/plugins/kernel_install/utils_test.sh
+++ b/tests/plugins/kernel_install/utils_test.sh
@@ -505,6 +505,7 @@ function test_install_kernel_remote()
     "rm -rf ${KW_DEPLOY_TMP_FILE}/kw_pkg"
     "tar --touch --auto-compress --extract --file='${KW_DEPLOY_TMP_FILE}/${name}.kw.tar' --directory='${SHUNIT_TMPDIR}/tmp/kw' --no-same-owner"
     "rsync --archive ${SHUNIT_TMPDIR}/tmp/kw/kw_pkg/modules/lib/modules/* /lib/modules"
+    "cp ${PWD}/boot/vmlinuz-${name} ${PWD}/boot/vmlinuz-${name}.old"
     "cp ${SHUNIT_TMPDIR}/tmp/kw/kw_pkg/bzImage /boot/"
     'generate_debian_temporary_root_file_system TEST_MODE test remote GRUB'
     'run_bootloader_update_mock'
@@ -513,12 +514,14 @@ function test_install_kernel_remote()
   )
 
   # Test preparation
-  mk_fake_tar_file_to_deploy "$PWD" "$KW_DEPLOY_TMP_FILE"
+  mk_fake_tar_file_to_deploy "$PWD" "$KW_DEPLOY_TMP_FILE" "$name"
   mkdir -p "${KW_DEPLOY_TMP_FILE}/kw_pkg"
   touch "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
   printf 'kernel_name=%s\n' "$name" > "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
   printf 'kernel_binary_image_file=%s\n' "$kernel_image_name" >> "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
   printf 'architecture=%s\n' "$architecture" >> "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
+  printf 'previous_kernel_backup=yes\n' >> "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
+  touch "${PWD}/boot/vmlinuz-${name}"
 
   output=$(install_kernel 'debian' "$reboot" "$target" 'TEST_MODE')
   compare_command_sequence '' "$LINENO" 'cmd_sequence' "$output"


### PR DESCRIPTION
This commit removes the '.old' kernel as a default option and moves it to the deploy.config file. Users can still have this option by updating their config file.

Closes: #706

Signed-off-by: Rodrigo Siqueira <siqueirajordao@riseup.net>