### PR TITLE
doc: conf: silence a warning caused by language=None

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -67,7 +67,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
Since Sphinx version 5.0.0, sphinx-build returns a non zero value and outputs the following warning [sic]:

	WARNING: Invalid configuration value found: 'language = None'.
	Update your configuration to a valid language code. Falling back
	to 'en' (English).

Which causes setup to fail. So, silence this warning by using 'en'.

Signed-off-by: Hamza Mahfooz <someguy@effective-light.com>