### PR TITLE
src: remote: List remotes

### DIFF
--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -65,7 +65,7 @@ function _kw_autocomplete()
   kw_options['s']="${kw_options['ssh']}"
 
   kw_options['config']='--local --global'
-  kw_options['remote']='add remove rename --set-default --verbose'
+  kw_options['remote']='add remove rename --set-default --verbose --list'
 
   kw_options['drm']='--remote --local --gui-on --gui-off --load-module
                      --unload-module --conn-available --modes --help'

--- a/tests/kw_remote_test.sh
+++ b/tests/kw_remote_test.sh
@@ -425,4 +425,38 @@ function test_parse_remote_options()
   assert_equals_helper 'Remote options' "($LINENO)" "${options_values['PARAMETERS']}" 'origin xpto '
 }
 
+function test_list_remotes()
+{
+  local output
+
+  declare -a expected_result=(
+    'Default Remote: arch-test'
+    'steamos'
+    '- Hostname steamdeck'
+    '- Port 8888'
+    '- User jozzi'
+    'arch-test'
+    '- Hostname arch-tm'
+    '- Port 22'
+    '- User abc'
+  )
+
+  cp "${SAMPLES_DIR}/remote_samples/remote_simple.config" "${BASE_PATH_KW}/remote.config"
+
+  output=$(list_remotes)
+  compare_command_sequence '' "$LINENO" 'expected_result' "$output"
+}
+
+function test_list_remotes_invalid()
+{
+  output=$(list_remotes)
+
+  assertEquals "($LINENO)" "$?" 22
+
+  rm -rf .kw
+
+  output=$(list_remotes)
+  assertEquals "($LINENO)" "$?" 22
+}
+
 invoke_shunit

--- a/tests/samples/remote_samples/remote_simple.config
+++ b/tests/samples/remote_samples/remote_simple.config
@@ -1,0 +1,9 @@
+#kw-default=arch-test
+Host steamos
+  Hostname steamdeck
+  Port 8888
+  User jozzi
+Host arch-test
+  Hostname arch-tm
+  Port 22
+  User abc


### PR DESCRIPTION
Kw provides a feature for dealing with multiple remotes but does not have a simple mechanism for the already available remotes. This commit introduces a list option that easily shows all remotes under kw management.

Closes #729

Signed-off-by: Rodrigo Siqueira <siqueirajordao@riseup.net>