### PR TITLE
src: kw_env: Adding support to `kw env --no-env`

### DIFF
--- a/documentation/man/features/env.rst
+++ b/documentation/man/features/env.rst
@@ -9,7 +9,7 @@ SYNOPSIS
 | *kw* (*env*) [(-c | \--create) <NAME>]
 | *kw* (*env*) [(-u | \--use) <NAME>]
 | *kw* (*env*) [(-l | \--list)]
-
+| *kw* (*env*) [(-e | \--exit-env)]
 
 DESCRIPTION
 ===========
@@ -48,6 +48,11 @@ OPTIONS
 -l, \--list:
   It shows all envs created via `\--create` option.
 
+-n, \--exit-env:
+  Allow users to "exit" the env feature. If the user is using a specific env
+  and doesn't want to use it anymore, the `--exit-env` option will remove all
+  symbolic links and copy the current env's configuration files to the .kw.
+
 EXAMPLES
 ========
 If you want to create a new env, you can use::
@@ -63,3 +68,7 @@ If you want to create a new env, you can use::
 If you want to list the available envs::
 
   kw env --list
+
+If you want to exit the env feature::
+
+  kw env --exit-env

--- a/tests/kw_env_test.sh
+++ b/tests/kw_env_test.sh
@@ -219,4 +219,23 @@ function test_parse_env_options()
   assertEquals "($LINENO) Invalid option" "$?" 22
 }
 
+function test_exit_env_checking_files()
+{
+  local output
+
+  # Creating an env
+  options_values['CREATE']='MACHINE_A'
+  create_new_env
+
+  # Switch env
+  options_values['USE']='MACHINE_A'
+  use_target_env
+
+  # Exiting the env
+  options_values['EXIT_ENV']=1
+  output="$(printf '%s\n' 'y' | exit_env)"
+
+  assertFalse "$LINENO: We didn't expect a symbolic link in (${PWD}/.kw/build.config)" '[[ -L "${PWD}/.kw/build.config" ]]'
+}
+
 invoke_shunit


### PR DESCRIPTION
This commit creates a mechanism allowing the user to "exit" the env resource using the `--no-env` parameter.

Closes: #746

Signed-off-by: Aquila Macedo <aquilamacedo@riseup.net>