### PR TITLE
src: plugins: kernel_install: utils: Copy config file

### DIFF
--- a/src/plugins/kernel_install/utils.sh
+++ b/src/plugins/kernel_install/utils.sh
@@ -637,6 +637,10 @@ function install_kernel()
     cmd_manager "$flag" "$cmd"
   fi
 
+  # Copy kernel config
+  cmd="${sudo_cmd}cp ${KW_DEPLOY_TMP_FILE}/kw_pkg/config-${name} /boot/"
+  cmd_manager "$flag" "$cmd"
+
   # Update kernel image in the /boot
   cmd="${sudo_cmd}cp ${KW_DEPLOY_TMP_FILE}/kw_pkg/${kernel_image_name} /boot/"
   cmd_manager "$flag" "$cmd"

--- a/tests/plugins/kernel_install/utils_test.sh
+++ b/tests/plugins/kernel_install/utils_test.sh
@@ -506,6 +506,7 @@ function test_install_kernel_remote()
     "tar --touch --auto-compress --extract --file='${KW_DEPLOY_TMP_FILE}/${name}.kw.tar' --directory='${SHUNIT_TMPDIR}/tmp/kw' --no-same-owner"
     "rsync --archive ${SHUNIT_TMPDIR}/tmp/kw/kw_pkg/modules/lib/modules/* /lib/modules"
     "cp ${PWD}/boot/vmlinuz-${name} ${PWD}/boot/vmlinuz-${name}.old"
+    "cp ${SHUNIT_TMPDIR}/tmp/kw/kw_pkg/config-test /boot/"
     "cp ${SHUNIT_TMPDIR}/tmp/kw/kw_pkg/bzImage /boot/"
     'generate_debian_temporary_root_file_system TEST_MODE test remote GRUB'
     'run_bootloader_update_mock'
@@ -518,6 +519,7 @@ function test_install_kernel_remote()
     "rm -rf ${KW_DEPLOY_TMP_FILE}/kw_pkg"
     "tar --touch --auto-compress --extract --file='${KW_DEPLOY_TMP_FILE}/${name}.kw.tar' --directory='${SHUNIT_TMPDIR}/tmp/kw' --no-same-owner"
     "rsync --archive ${SHUNIT_TMPDIR}/tmp/kw/kw_pkg/modules/lib/modules/* /lib/modules"
+    "cp ${SHUNIT_TMPDIR}/tmp/kw/kw_pkg/config-test /boot/"
     "cp ${SHUNIT_TMPDIR}/tmp/kw/kw_pkg/bzImage /boot/"
     "cp ${SHUNIT_TMPDIR}/tmp/kw/kw_pkg/*.dtb /boot/"
     'generate_debian_temporary_root_file_system TEST_MODE test remote GRUB'
@@ -582,6 +584,7 @@ function test_install_kernel_local()
     "rm -rf ${KW_DEPLOY_TMP_FILE}/kw_pkg"
     "tar --touch --auto-compress --extract --file='${KW_DEPLOY_TMP_FILE}/${name}.kw.tar' --directory='${SHUNIT_TMPDIR}/tmp/kw' --no-same-owner"
     "sudo -E rsync --archive ${SHUNIT_TMPDIR}/tmp/kw/kw_pkg/modules/lib/modules/* /lib/modules"
+    "sudo -E cp ${KW_DEPLOY_TMP_FILE}/kw_pkg/config-test /boot/"
     "sudo -E cp ${KW_DEPLOY_TMP_FILE}/kw_pkg/${kernel_image_name} /boot/"
     'generate_debian_temporary_root_file_system TEST_MODE test local GRUB'
     'run_bootloader_update_mock'


### PR DESCRIPTION
Recently we updated kw to use a package system, but we forgot to copy the .config file to the /boot folder. This was a perfect storm to hit the below error:

root@debian:~# update-initramfs -c -k [KERNEL-NAME] update-initramfs: Generating /boot/initrd.img-[KERNEL-NAME] grep: /boot/config-vmlinuz-[KERNEL-NAME]: No such file or directory W: zstd compression (CONFIG_RD_ZSTD) not supported by kernel, using gzip grep: /boot/config-vmlinuz-[KERNEL-NAME]: No such file or directory E: gzip compression (CONFIG_RD_GZIP) not supported by kernel update-initramfs: failed for /boot/initrd.img-[KERNEL-NAME] with 1.

Notice that we can only see it in a Debian-based distro that uses the latest initramfs-tool. This is a recent change, as you can see here:

https://salsa.debian.org/kernel-team/initramfs-tools/-/merge_requests/37/diffs#e3b45015ecbf200e358bd3915bb51b4b9d044d5e_188_190

This commit address this issue by ensuring the copy of the .config file.

Signed-off-by: Rodrigo Siqueira <siqueirajordao@riseup.net>