### PR TITLE
tests: report_test: Fix terminal and file outputs from test_save_data_to()

### DIFF
--- a/tests/report_test.sh
+++ b/tests/report_test.sh
@@ -370,7 +370,7 @@ function test_save_data_to()
   local expected
 
   grouping_day_data '2020/04/04'
-  save_data_to "$SHUNIT_TMPDIR/test"
+  save_data_to "$SHUNIT_TMPDIR/test" > /dev/null 2>&1
   [[ ! -f "$SHUNIT_TMPDIR/test" ]] && fail "$LINENO: We expect to find a test file"
 
   output=$(cat "$SHUNIT_TMPDIR/test")
@@ -381,19 +381,18 @@ function test_save_data_to()
   ret="$?"
   assert_equals_helper "We expect an invalid path error" "$LINENO" "$ret" 1
 
-  # Try to use a valid directory path.
-  output=$(save_data_to './')
+  # Try to use a valid path to directory.
+  output=$(save_data_to "${SHUNIT_TMPDIR}")
   ret="$?"
   assert_equals_helper "We expect a valid path" "$LINENO" "$ret" 0
 
   # Verifying that the correct message is displayed.
-  expected='The report output was saved in:'
-  message=${output::-16}
+  expected="The report output was saved in: ${SHUNIT_TMPDIR}/report_output"
+  message="$output"
   assert_equals_helper "We expect a valid message" "$LINENO" "$message" "$expected"
 
   # Verifying that the correct filename is displayed.
-  filename=${output:(-13)}
-  [[ ! -f "./$filename" ]] && fail "$LINENO: We expect to find a test file"
+  [[ ! -f "${SHUNIT_TMPDIR}/report_output" ]] && fail "$LINENO: We expect to find a test file"
 
   # Try to use an invalid root directory path.
   output=$(save_data_to '/root/')


### PR DESCRIPTION
The test_save_data_to() test function generated a terminal output during its execution and a file outside the Shunit temporary dir, which resulted in a hanging file named 'report_output' inside the repository. The former issue was due to a call to the save_data_to() function without handling its output and the latter was because the same function was being called passing the current directory as an argument (as this test suite does not have a set up to change to the Shunit tmp dir this resulted in the file being generated in the repository root).

The solution for the first was to redirect all function output to /dev/null and for the second was to pass the Shunit tmp dir as argument (although, as mentioned above, the best approach would've been to cd in and out of this dir with set up and teardown functions).

Considered making set up and teardown functions, but, as this commit aims only to fix the improper terminal and file outputs, those changes are beyond the scope.

Signed-off-by: David Tadokoro <davidbtadokoro@usp.br>