### PR TITLE
Allow some `kw deploy` commands to be run outside kernel tree

### DIFF
--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -1437,8 +1437,8 @@ function parse_deploy_options()
         ;;
       *)
         options_values['ERROR']="Unrecognized argument: $1"
-        return 22 # EINVAL
         shift
+        return 22 # EINVAL
         ;;
     esac
   done

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -96,7 +96,7 @@ function deploy_main()
     exit 22 # EINVAL
   fi
 
-  if [[ -z "${options_values['FROM_PACKAGE']}" ]]; then
+  if [[ -z "${options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']}" ]]; then
     if ! is_kernel_root "$PWD"; then
       complain 'Execute this command in a kernel tree.'
       exit 125 # ECANCELED
@@ -1336,6 +1336,7 @@ function parse_deploy_options()
   options_values['VERBOSE']=''
   options_values['CREATE_PACKAGE']=''
   options_values['FROM_PACKAGE']=''
+  options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=''
 
   remote_parameters['REMOTE_IP']=''
   remote_parameters['REMOTE_PORT']=''
@@ -1390,14 +1391,17 @@ function parse_deploy_options()
         ;;
       --list | -l)
         options_values['LS']=1
+        options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=1
         shift
         ;;
       --list-all | -a)
         options_values['LS_ALL']=1
+        options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=1
         shift
         ;;
       --ls-line | -s)
         options_values['LS_LINE']=1
+        options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=1
         shift
         ;;
       --setup)
@@ -1410,6 +1414,7 @@ function parse_deploy_options()
           return 22 # EINVAL
         fi
         options_values['UNINSTALL']+="$2"
+        options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=1
         shift 2
         ;;
       --verbose | -v)
@@ -1426,6 +1431,7 @@ function parse_deploy_options()
         ;;
       --from-package | -F)
         options_values['FROM_PACKAGE']+="$2"
+        options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=1
         shift 2
         ;;
       --) # End of options, beginning of arguments

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -1086,10 +1086,12 @@ function create_pkg_metadata_file_for_deploy()
 
   cache_pkg_metadata_file_path="${base_kw_deploy_store_path}/kw.pkg.info"
 
-  printf 'kernel_name=%s\n' "$kernel_name" > "${cache_pkg_metadata_file_path}"
-  printf 'kernel_binary_image_file=%s\n' "$kernel_binary_file_name" >> "${cache_pkg_metadata_file_path}"
-  printf 'architecture=%s\n' "$arch" >> "${cache_pkg_metadata_file_path}"
-  printf 'previous_kernel_backup=%s\n' "${deploy_config[previous_kernel_backup]}" >> "${cache_pkg_metadata_file_path}"
+  {
+    printf 'kernel_name=%s\n' "$kernel_name"
+    printf 'kernel_binary_image_file=%s\n' "$kernel_binary_file_name"
+    printf 'architecture=%s\n' "$arch"
+    printf 'previous_kernel_backup=%s\n' "${deploy_config[previous_kernel_backup]}"
+  } > "${cache_pkg_metadata_file_path}"
 }
 
 # This function is responsible for putting all the required boot files in a

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -119,6 +119,11 @@ function setUp()
     "$GENERATE_BOOT_TAR_FILE"
     "$SEND_BOOT_FILES_HOST2REMOTE"
   )
+
+  # Create non kernel tree directory to test commands that can be run
+  # outside kernel tree (--list, --list-all, --ls-line, --uninstall)
+  NON_KERNEL_TREE="${SHUNIT_TMPDIR}/non_kernel_tree"
+  mkdir -p "${NON_KERNEL_TREE}"
 }
 
 function get_deploy_cmd_helper()
@@ -1184,6 +1189,38 @@ function test_create_pkg_metadata_file_for_deploy()
 
   output=$(grep 'architecture' './TEST/kw.pkg.info')
   assertEquals "($LINENO)" 'architecture=x86_64' "$output"
+
+  cd "$original" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
+}
+
+function test_run_commands_outside_kernel_tree()
+{
+  local output
+  local original="$PWD"
+
+  cd "${NON_KERNEL_TREE}" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
+
+  options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=''
+  parse_deploy_options --list
+  assertTrue "($LINENO) - Should list outside kernel tree" "[[ -n ${options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']} ]]"
+
+  options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=''
+  parse_deploy_options --list-all
+  assertTrue "($LINENO) - Should list all outside kernel tree" "[[ -n ${options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']} ]]"
+
+  options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=''
+  parse_deploy_options --ls-line
+  assertTrue "($LINENO) - Should line list outside kernel tree" "[[ -n ${options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']} ]]"
+
+  options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=''
+  parse_deploy_options --uninstall 'some_kernel'
+  assertTrue "($LINENO) - Should uninstall outside kernel tree" "[[ -n ${options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']} ]]"
 
   cd "$original" || {
     fail "($LINENO) It was not possible to move back from temp directory"

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -869,6 +869,7 @@ function test_collect_target_info_for_deploy()
   # REMOTE
   function cmd_remotely()
   {
+    # shellcheck disable=SC2317
     printf '[bootloader]=syslinux [distro]=chrome'
   }
   collect_target_info_for_deploy 3 'TEST_MODE'


### PR DESCRIPTION
As pointed in #734, some `kw deploy` commands like `--list` and `--uninstall` can't be run outside a kernel tree when they should. This PR implements this.

Also, this PR contains commits fixing issues related with ShellCheck failures that I came across when implementing the above. The issues where:
- An unreachable command in  `deploy.sh`  ([SC2317)](https://www.shellcheck.net/wiki/SC2317))
- Multiple individual redirects in `deploy.sh`  ([SC2129](https://www.shellcheck.net/wiki/SC2129))
- An unreachable command incorrectly pointed out by ShellCheck in `deploy_test.sh`  ([SC2129](https://www.shellcheck.net/wiki/SC2129))