### PR TITLE
src: kw_remote: Fix not failing when missing valid options

### DIFF
--- a/src/kw_remote.sh
+++ b/src/kw_remote.sh
@@ -332,6 +332,12 @@ function parse_remote_options()
   elif [[ "${options_values['DEFAULT_REMOTE']}" == 1 ]]; then
     options_values['ERROR']='Expected a string values after --set-default='
     return 22
+  elif [[ -z "${options_values['ADD']}" && -z "${options_values['REMOVE']}" &&
+    -z "${options_values['RENAME']}" && -z "${options_values['LIST']}" &&
+    -z "${options_values['DEFAULT_REMOTE']}" ]]; then
+    options_values['ERROR']='"kw remote" should be proceeded by valid option'$'\n'
+    options_values['ERROR']+='Usage: kw remote (add | remove | rename | --list | --set-default) <params>[...]'
+    return 22 # EINVAL
   fi
 }
 

--- a/tests/kw_remote_test.sh
+++ b/tests/kw_remote_test.sh
@@ -459,4 +459,15 @@ function test_list_remotes_invalid()
   assertEquals "($LINENO)" "$?" 22
 }
 
+function test_kw_remote_without_valid_option()
+{
+  # kw remote (no option nor parameter)
+  parse_remote_options
+  assertEquals "($LINENO)" "$?" 22
+
+  # kw remote <params>[...] (no options)
+  parse_remote_options
+  assertEquals "($LINENO)" "$?" 22
+}
+
 invoke_shunit


### PR DESCRIPTION
Before this commit, kw remote did not validate if the command had valid option, i.e., calling kw remote (without option/parameters) or calling kw remote <name> <remote> (without valid option) did not fail, although it did not seems to have any side effect.

Now we validate if any of the options add, remove, rename, list or set default remote were passed at the end of parse_remote_options(). If not, the command fails.

Chose to validate at the end of parse_remote_options() as 1) it seems the responsability of this function and 2) it enables to make a simple unit test for this case.

Closes #728

Signed-off-by: David Tadokoro <davidbtadokoro@usp.br>