### PR TITLE
src: kw_remote: Fix remove remote that is prefix of other remote

### DIFF
--- a/src/kw_remote.sh
+++ b/src/kw_remote.sh
@@ -194,7 +194,7 @@ function remove_remote()
     sed -i -r "/^Host ${target_remote}$/{n;/Hostname.*/d}" "$local_remote_config_file"
     sed -i -r "/^Host ${target_remote}$/{n;/Port.*/d}" "$local_remote_config_file"
     sed -i -r "/^Host ${target_remote}$/{n;/User.*/d}" "$local_remote_config_file"
-    sed -i -r "/^Host ${target_remote}/d" "$local_remote_config_file"
+    sed -i -r "/^Host ${target_remote}$/d" "$local_remote_config_file"
     sed -i -r '/^$/d' "$local_remote_config_file"
   else
     complain "We could not find ${target_remote}"

--- a/tests/kw_remote_test.sh
+++ b/tests/kw_remote_test.sh
@@ -459,4 +459,23 @@ function test_list_remotes_invalid()
   assertEquals "($LINENO)" "$?" 22
 }
 
+function test_remove_remote_that_is_prefix_of_other_remote()
+{
+  local output
+
+  declare -a expected_result=(
+    'kworkflow'
+    '- Hostname kworkflow-tm'
+    '- Port 4321'
+    '- User kworkflow'
+  )
+
+  cp "${SAMPLES_DIR}/remote_samples/remote_prefix.config" "${BASE_PATH_KW}/remote.config"
+
+  options_values['PARAMETERS']='kw'
+  remove_remote
+  output=$(list_remotes)
+  compare_command_sequence 'Should only remove the prefix remote' "$LINENO" 'expected_result' "$output"
+}
+
 invoke_shunit

--- a/tests/samples/remote_samples/remote_prefix.config
+++ b/tests/samples/remote_samples/remote_prefix.config
@@ -1,0 +1,8 @@
+Host kw
+  Hostname kw-tm
+  Port 1234
+  User kw
+Host kworkflow
+  Hostname kworkflow-tm
+  Port 4321
+  User kworkflow


### PR DESCRIPTION
If there were two remotes, one with a name that is a prefix of the other (like "kw" and "kworkflow"), and we tried to remove the first one, the second one would have its first line removed from the remote.config. This resulted in this second remote being virtually also removed, although that was not the intention and the user was not warned.

The cause of the bug was a missing $ at the end of the pattern used by sed to remove the first line of the target remote in the remote.config (the 'Host <name>' line). This caused sed to not get only the exact match of the line and remove lines prefixed by the target one as well. As expected, the fix was just the inclusion of this missing $.

Signed-off-by: David Tadokoro <davidbtadokoro@usp.br>