### PR TITLE
Revise `kw remote` man page

### DIFF
--- a/documentation/man/features/remote.rst
+++ b/documentation/man/features/remote.rst
@@ -6,16 +6,16 @@ kw-remote
 
 SYNOPSIS
 ========
-| *kw remote* [-v | \--verbose ]
-| *kw remote add* <name> <user@remote:port>
-| *kw remote remove* <name>
-| *kw remote rename* <old-name> <new-name>
-| *kw remote --list*
+| *kw remote* [-v | \--verbose]
+| *kw remote* add <name> <user>@<remote>[:<port>]
+| *kw remote* remove <name>
+| *kw remote* rename <old-name> <new-name>
+| *kw remote* \--list
 | *kw remote* (-s | \--set-default)=<name>
 
 DESCRIPTION
 ===========
-Manage the set of test machines ("remotes") you want that kw to have easy
+Manage the set of test machines ("remotes") you want kw to have easy
 access.  This feature directly interacts with kw configuration for remote
 available at `.kw/remote.config`.
 
@@ -23,18 +23,19 @@ OPTIONS
 =======
 add <name> <remote-address>:
   Adds a remote named <name> for the test machine at <remote-address>. Notice
-  that <remote_address> must follow this pattern `user@remote:port` where
-  remote can be an IP or a name server.
+  that <remote_address> must follow the pattern `<user>@<remote>[:<port>]` where
+  `remote` can be an IP or a name server and `:<port>` is optional (default port
+  is 22).
 
 remove <name>:
   Remove the remote named <name>.
 
 rename <old-name> <new-name>:
-  Rename the remote named <old> to <new>. If you try a name already in use, kw
-  will fail with a message.
+  Rename the remote named <old-name> to <new-name>. If you try a name already
+  in use, kw will fail with a message.
 
 \--list:
-  Lest all available remotes.
+  List all available remotes.
 
 \-s=<name>, \--set-default=<name>:
   Set default remote to remote named <name>.

--- a/documentation/man/features/remote.rst
+++ b/documentation/man/features/remote.rst
@@ -11,6 +11,7 @@ SYNOPSIS
 | *kw remote remove* <name>
 | *kw remote rename* <old-name> <new-name>
 | *kw remote --list*
+| *kw remote* (-s | \--set-default)=<name>
 
 DESCRIPTION
 ===========
@@ -34,6 +35,9 @@ rename <old-name> <new-name>:
 
 \--list:
   Lest all available remotes.
+
+\-s=<name>, \--set-default=<name>:
+  Set default remote to remote named <name>.
 
 \-v, \--verbose:
   Be a little more verbose and show remote url after name.
@@ -61,3 +65,7 @@ If you want to rename::
 You can also list all your available remotes via::
 
  kw remote --list
+
+If you want to set the default remote::
+
+  kw remote --set-default=new-default-remote


### PR DESCRIPTION
This PR has two commits referent to the `kw remote` man page:

1. Adds documentation to the `--set-default` option.
2. Revises the man page as a whole.

The revisions where made using `kw mail` man page as reference, as this features is one of the newest of kw and its man page is a great example of documentation.