### PR TITLE
src: kw_remote: Add support for global remote.config

### DIFF
--- a/documentation/man/features/remote.rst
+++ b/documentation/man/features/remote.rst
@@ -7,17 +7,17 @@ kw-remote
 SYNOPSIS
 ========
 | *kw remote* [-v | \--verbose]
-| *kw remote* add <name> <user>@<remote>[:<port>]
-| *kw remote* remove <name>
-| *kw remote* rename <old-name> <new-name>
-| *kw remote* \--list
-| *kw remote* (-s | \--set-default)=<name>
+| *kw remote* [--global] add <name> <user>@<remote>[:<port>]
+| *kw remote* [--global] remove <name>
+| *kw remote* [--global] rename <old-name> <new-name>
+| *kw remote* [--global] \--list
+| *kw remote* [--global] (-s | \--set-default)=<name>
 
 DESCRIPTION
 ===========
 Manage the set of test machines ("remotes") you want kw to have easy
 access.  This feature directly interacts with kw configuration for remote
-available at `.kw/remote.config`.
+available locally at `.kw/remote.config` or globally at `~/.config/kw/remote.config`.
 
 OPTIONS
 =======
@@ -36,6 +36,9 @@ rename <old-name> <new-name>:
 
 \--list:
   List all available remotes.
+
+\--global:
+  Force use global config file instead of the local one.
 
 \-s=<name>, \--set-default=<name>:
   Set default remote to remote named <name>.

--- a/src/kw_remote.sh
+++ b/src/kw_remote.sh
@@ -127,11 +127,11 @@ function add_new_remote()
   fi
 
   # Check if remote name already exists
-  grep -xq "^Host ${name}$" "$local_remote_config_file"
+  grep --line-regexp --quiet "^Host ${name}$" "$local_remote_config_file"
   if [[ "$?" == 0 ]]; then
-    sed -i -r "/^Host ${name}$/{n;s/Hostname.*/Hostname ${remote_parameters['REMOTE_IP']}/}" "$local_remote_config_file"
-    sed -i -r "/^Host ${name}$/{n;n;s/Port.*/Port ${remote_parameters['REMOTE_PORT']}/}" "$local_remote_config_file"
-    sed -i -r "/^Host ${name}$/{n;n;n;s/User.*/User ${remote_parameters['REMOTE_USER']}/}" "$local_remote_config_file"
+    sed --in-place --regexp-extended "/^Host ${name}$/{n;s/Hostname.*/Hostname ${remote_parameters['REMOTE_IP']}/}" "$local_remote_config_file"
+    sed --in-place --regexp-extended "/^Host ${name}$/{n;n;s/Port.*/Port ${remote_parameters['REMOTE_PORT']}/}" "$local_remote_config_file"
+    sed --in-place --regexp-extended "/^Host ${name}$/{n;n;n;s/User.*/User ${remote_parameters['REMOTE_USER']}/}" "$local_remote_config_file"
     return
   fi
 
@@ -149,14 +149,14 @@ function set_default_remote()
 {
   local default_remote="${options_values['DEFAULT_REMOTE']}"
 
-  grep -xq "^#kw-default=.*" "$local_remote_config_file"
+  grep --line-regexp --quiet "^#kw-default=.*" "$local_remote_config_file"
   # We don't have the default header yet, let's add it
   if [[ "$?" != 0 ]]; then
-    sed -i "1s/^/#kw-default=${default_remote}\n/" "$local_remote_config_file"
+    sed --in-place "1s/^/#kw-default=${default_remote}\n/" "$local_remote_config_file"
     return "$?"
   fi
 
-  grep -xq "^Host ${default_remote}$" "$local_remote_config_file"
+  grep --line-regexp --quiet "^Host ${default_remote}$" "$local_remote_config_file"
   # We don't have the default header yet, let's add it
   if [[ "$?" != 0 ]]; then
     complain "We could not find '${default_remote}'. Is this a valid remote?"
@@ -164,7 +164,7 @@ function set_default_remote()
   fi
 
   # We already have the default remote
-  sed -i -r "s/^#kw-default=.*/#kw-default=${default_remote}/" "$local_remote_config_file"
+  sed --in-place --regexp-extended "s/^#kw-default=.*/#kw-default=${default_remote}/" "$local_remote_config_file"
 }
 
 function remove_remote()
@@ -182,20 +182,20 @@ function remove_remote()
   target_remote="${remove_parameters[0]}"
 
   # Check if remote name exists
-  grep -xq "^Host ${target_remote}$" "$local_remote_config_file"
+  grep --line-regexp --quiet "^Host ${target_remote}$" "$local_remote_config_file"
   if [[ "$?" == 0 ]]; then
-    grep -xq "^#kw-default=${target_remote}" "$local_remote_config_file"
+    grep --line-regexp --quiet "^#kw-default=${target_remote}" "$local_remote_config_file"
     # Check if the target remote is the default
     if [[ "$?" == 0 ]]; then
       warning "'${target_remote}' was the default remote, please, set a new default"
-      sed -i "/^#kw-default=${target_remote}/d" "$local_remote_config_file"
+      sed --in-place "/^#kw-default=${target_remote}/d" "$local_remote_config_file"
     fi
 
-    sed -i -r "/^Host ${target_remote}$/{n;/Hostname.*/d}" "$local_remote_config_file"
-    sed -i -r "/^Host ${target_remote}$/{n;/Port.*/d}" "$local_remote_config_file"
-    sed -i -r "/^Host ${target_remote}$/{n;/User.*/d}" "$local_remote_config_file"
-    sed -i -r "/^Host ${target_remote}$/d" "$local_remote_config_file"
-    sed -i -r '/^$/d' "$local_remote_config_file"
+    sed --in-place --regexp-extended "/^Host ${target_remote}$/{n;/Hostname.*/d}" "$local_remote_config_file"
+    sed --in-place --regexp-extended "/^Host ${target_remote}$/{n;/Port.*/d}" "$local_remote_config_file"
+    sed --in-place --regexp-extended "/^Host ${target_remote}$/{n;/User.*/d}" "$local_remote_config_file"
+    sed --in-place --regexp-extended "/^Host ${target_remote}$/d" "$local_remote_config_file"
+    sed --in-place --regexp-extended '/^$/d' "$local_remote_config_file"
   else
     complain "We could not find ${target_remote}"
     return 22 # EINVAL
@@ -227,7 +227,7 @@ function rename_remote()
   fi
 
   # Check if new name already exists
-  grep -xq "^Host ${new_name}$" "$local_remote_config_file"
+  grep --line-regexp --quiet "^Host ${new_name}$" "$local_remote_config_file"
   if [[ "$?" == 0 ]]; then
     complain "It looks like that '${new_name}' already exists"
     complain "Please, choose another name or remove '${old_name}' first"
@@ -235,12 +235,12 @@ function rename_remote()
   fi
 
   # Check if remote name already exists
-  grep -xq "^Host ${old_name}$" "$local_remote_config_file"
+  grep --line-regexp --quiet "^Host ${old_name}$" "$local_remote_config_file"
   if [[ "$?" == 0 ]]; then
-    sed -i -r "s/^Host $old_name/Host $new_name/" "$local_remote_config_file"
+    sed --in-place --regexp-extended "s/^Host $old_name/Host $new_name/" "$local_remote_config_file"
 
     # Check if the target remote was marked as a default
-    grep -xq "^#kw-default=${old_name}$" "$local_remote_config_file"
+    grep --line-regexp --quiet "^#kw-default=${old_name}$" "$local_remote_config_file"
     if [[ "$?" == 0 ]]; then
       options_values['DEFAULT_REMOTE']="$new_name"
       set_default_remote

--- a/tests/kw_remote_test.sh
+++ b/tests/kw_remote_test.sh
@@ -9,13 +9,19 @@ function setUp()
 
   export BASE_PATH_KW="${SHUNIT_TMPDIR}/.kw"
   export local_remote_config_file="${BASE_PATH_KW}/remote.config"
+  export KW_ETC_DIR="${SHUNIT_TMPDIR}/.config/kw"
+  export global_remote_config_file="${KW_ETC_DIR}/remote.config"
 
-  # Create basic env
+  # Create basic local env
   mkdir -p "$BASE_PATH_KW"
-  touch "${BASE_PATH_KW}/remote"
+  touch "${BASE_PATH_KW}/remote.config"
+
+  # Create basic global env
+  mkdir -p "$KW_ETC_DIR"
+  touch "${KW_ETC_DIR}/remote.config"
 
   cd "${SHUNIT_TMPDIR}" || {
-    fail "($LINENO): setIp(): It was not possible to move into ${SHUNIT_TMPDIR}"
+    fail "($LINENO): setUp(): It was not possible to move into ${SHUNIT_TMPDIR}"
     return
   }
 }
@@ -52,6 +58,7 @@ function test_add_new_remote_no_kw_folder()
   local output
 
   rm -rf ".kw"
+  rm -rf ".config/kw"
 
   options_values['PARAMETERS']='origin u'
   output=$(add_new_remote)
@@ -59,25 +66,36 @@ function test_add_new_remote_no_kw_folder()
   assertEquals "($LINENO)" "$?" 22
 }
 
-function test_add_new_remote_new_remote_to_empty_file()
+function test_add_new_remote_with_no_config_file()
 {
   local output
-  local new_config_file
   local expected_result
+
+  rm "$local_remote_config_file"
+
+  declare -a expected_result=(
+    '#kw-default=origin'
+    'Host origin'
+    '  Hostname test-debian'
+    '  Port 3333'
+    '  User root'
+  )
 
   options_values['PARAMETERS']='origin root@test-debian:3333'
   output=$(add_new_remote)
-  new_config_file=$(< "${BASE_PATH_KW}/remote.config")
+
+  mapfile -t final_result_array < "${BASE_PATH_KW}/remote.config"
+
+  compare_array_values expected_result final_result_array "$LINENO"
+
 }
 
 function test_add_new_remote_multiple_different_instances()
 {
   local output
-  local new_config_file
   local final_result_array
 
   declare -a expected_result=(
-    '#kw-default=origin'
     'Host origin'
     '  Hostname test-debian'
     '  Port 3333'
@@ -109,11 +127,9 @@ function test_add_new_remote_multiple_different_instances()
 function test_add_new_remote_multiple_entry_with_duplication()
 {
   local output
-  local new_config_file
   local final_result_array
 
   declare -a expected_result=(
-    '#kw-default=origin'
     'Host origin'
     '  Hostname test-debian'
     '  Port 3333'
@@ -449,12 +465,12 @@ function test_list_remotes()
 
 function test_list_remotes_invalid()
 {
+  rm "${local_remote_config_file}"
   output=$(list_remotes)
-
   assertEquals "($LINENO)" "$?" 22
 
-  rm -rf .kw
-
+  rm -rf "${BASE_PATH_KW}"
+  rm "${global_remote_config_file}"
   output=$(list_remotes)
   assertEquals "($LINENO)" "$?" 22
 }
@@ -487,6 +503,219 @@ function test_remove_remote_that_is_prefix_of_other_remote()
   remove_remote
   output=$(list_remotes)
   compare_command_sequence 'Should only remove the prefix remote' "$LINENO" 'expected_result' "$output"
+}
+
+function test_add_new_global_remote()
+{
+  local final_result_array
+  local output
+
+  declare -a expected_result=(
+    '#kw-default=global'
+    'Host galactical'
+    '  Hostname milky-way'
+    '  Port 1234'
+    '  User hubble'
+    'Host global'
+    '  Hostname planet-earth'
+    '  Port 5678'
+    '  User newton'
+    'Host universal'
+    '  Hostname universe'
+    '  Port 9999'
+    '  User einstein'
+  )
+
+  cp "${SAMPLES_DIR}/remote_samples/remote_global.config" "${global_remote_config_file}"
+
+  rm -rf "$BASE_PATH_KW"
+
+  options_values['PARAMETERS']='universal einstein@universe:9999'
+  output=$(add_new_remote)
+  mapfile -t final_result_array < "${global_remote_config_file}"
+  compare_array_values expected_result final_result_array "$LINENO"
+}
+
+function test_remove_global_remote()
+{
+  local final_result_array
+  local output
+
+  declare -a expected_result=(
+    'Host galactical'
+    '  Hostname milky-way'
+    '  Port 1234'
+    '  User hubble'
+  )
+
+  cp "${SAMPLES_DIR}/remote_samples/remote_global.config" "${global_remote_config_file}"
+
+  rm -rf "$BASE_PATH_KW"
+
+  options_values['PARAMETERS']='global'
+  output=$(remove_remote)
+  mapfile -t final_result_array < "${global_remote_config_file}"
+  compare_array_values expected_result final_result_array "$LINENO"
+}
+
+function test_rename_global_remote()
+{
+  local final_result_array
+  local output
+
+  declare -a expected_result=(
+    '#kw-default=existential'
+    'Host galactical'
+    '  Hostname milky-way'
+    '  Port 1234'
+    '  User hubble'
+    'Host existential'
+    '  Hostname planet-earth'
+    '  Port 5678'
+    '  User newton'
+  )
+
+  cp "${SAMPLES_DIR}/remote_samples/remote_global.config" "${global_remote_config_file}"
+
+  rm -rf "$BASE_PATH_KW"
+
+  options_values['PARAMETERS']='global existential'
+  output=$(rename_remote)
+  mapfile -t final_result_array < "${global_remote_config_file}"
+  compare_array_values expected_result final_result_array "$LINENO"
+}
+
+function test_set_default_global_remote()
+{
+  local final_result_array
+  local output
+
+  declare -a expected_result=(
+    '#kw-default=galactical'
+    'Host galactical'
+    '  Hostname milky-way'
+    '  Port 1234'
+    '  User hubble'
+    'Host global'
+    '  Hostname planet-earth'
+    '  Port 5678'
+    '  User newton'
+  )
+
+  cp "${SAMPLES_DIR}/remote_samples/remote_global.config" "${global_remote_config_file}"
+
+  rm -rf "$BASE_PATH_KW"
+
+  options_values['DEFAULT_REMOTE']='galactical'
+  output=$(set_default_remote)
+  mapfile -t final_result_array < "${global_remote_config_file}"
+  compare_array_values expected_result final_result_array "$LINENO"
+}
+
+function test_list_global_remotes()
+{
+  local output
+
+  declare -a expected_result=(
+    'Default Remote: global'
+    'galactical'
+    '- Hostname milky-way'
+    '- Port 1234'
+    '- User hubble'
+    'global'
+    '- Hostname planet-earth'
+    '- Port 5678'
+    '- User newton'
+  )
+
+  cp "${SAMPLES_DIR}/remote_samples/remote_global.config" "${global_remote_config_file}"
+
+  rm -rf "$BASE_PATH_KW"
+
+  output=$(list_remotes)
+  compare_command_sequence 'Should list the global remote.config if there is no local one' "$LINENO" 'expected_result' "$output"
+}
+function test_global_option_rename_remote()
+{
+  local final_result_array
+  local output
+
+  declare -a expected_result=(
+    '#kw-default=existential'
+    'Host galactical'
+    '  Hostname milky-way'
+    '  Port 1234'
+    '  User hubble'
+    'Host existential'
+    '  Hostname planet-earth'
+    '  Port 5678'
+    '  User newton'
+  )
+
+  cp "${SAMPLES_DIR}/remote_samples/remote_global.config" "${global_remote_config_file}"
+
+  options_values['PARAMETERS']='global existential'
+  options_values['GLOBAL']='1'
+  output=$(rename_remote)
+  mapfile -t final_result_array < "${global_remote_config_file}"
+  compare_array_values expected_result final_result_array "$LINENO"
+}
+function test_global_options_set_default_remote()
+{
+  local final_result_array
+  local output
+
+  declare -a expected_result=(
+    '#kw-default=galactical'
+    'Host galactical'
+    '  Hostname milky-way'
+    '  Port 1234'
+    '  User hubble'
+    'Host global'
+    '  Hostname planet-earth'
+    '  Port 5678'
+    '  User newton'
+  )
+
+  cp "${SAMPLES_DIR}/remote_samples/remote_global.config" "${global_remote_config_file}"
+
+  options_values['DEFAULT_REMOTE']='galactical'
+  options_values['GLOBAL']='1'
+  output=$(set_default_remote)
+  mapfile -t final_result_array < "${global_remote_config_file}"
+  compare_array_values expected_result final_result_array "$LINENO"
+}
+function test_global_option_list_remotes()
+{
+  local final_result_array
+  local output
+
+  declare -a expected_result=(
+    '#kw-default=galactical'
+    'Host galactical'
+    '  Hostname milky-way'
+    '  Port 1234'
+    '  User hubble'
+    'Host global'
+    '  Hostname planet-earth'
+    '  Port 5678'
+    '  User newton'
+  )
+
+  cp "${SAMPLES_DIR}/remote_samples/remote_global.config" "${global_remote_config_file}"
+
+  options_values['DEFAULT_REMOTE']='galactical'
+  options_values['GLOBAL']='1'
+  output=$(set_default_remote)
+  mapfile -t final_result_array < "${global_remote_config_file}"
+  compare_array_values expected_result final_result_array "$LINENO"
+}
+function test_global_option_list_remote_invalid()
+{
+  rm "${global_remote_config_file}"
+  options_values['GLOBAL']='1'
+  output=$(list_remotes)
+  assertEquals "($LINENO)" "$?" 22
 }
 
 invoke_shunit

--- a/tests/samples/remote_samples/remote_global.config
+++ b/tests/samples/remote_samples/remote_global.config
@@ -1,0 +1,9 @@
+#kw-default=global
+Host galactical
+  Hostname milky-way
+  Port 1234
+  User hubble
+Host global
+  Hostname planet-earth
+  Port 5678
+  User newton


### PR DESCRIPTION
`kw remote` checks for the presence of `$PWD/.config/kw/remote.conf` and use it if a local one is not found.

Fixes #775.