### PR TITLE
src: kw_env: fixing the "env.current does not exist" bug.

### DIFF
--- a/src/kw_env.sh
+++ b/src/kw_env.sh
@@ -216,11 +216,12 @@ function destroy_env()
   if [[ $(ask_yN 'Are you sure you want to delete this environment?') =~ 0 ]]; then
     return 22 # EINVAL
   fi
-  # Here it is checked if the current env is equal to the env we want to
-  # destroy, if so, we call the exit_env function to exit the environment mode.
-  current_env=$(< "${local_kw_configs}/${ENV_CURRENT_FILE}")
-  if [[ "$current_env" == "$env_name" ]]; then
-    exit_env
+
+  if [[ -f "${local_kw_configs}/${ENV_CURRENT_FILE}" ]]; then
+    current_env=$(< "${local_kw_configs}/${ENV_CURRENT_FILE}")
+    if [[ "$current_env" == "$env_name" ]]; then
+      exit_env
+    fi
   fi
 
   rm -rf "${local_kw_configs:?}/${ENV_DIR}/${env_name}" && rm -rf "${cache_build_path:?}/${ENV_DIR}/${env_name}"

--- a/tests/kw_env_test.sh
+++ b/tests/kw_env_test.sh
@@ -290,4 +290,19 @@ function test_destroy_env_checking_the_existence_of_a_directory()
   assertFalse "($LINENO) We didn't expect to find this folder in .cache (${KW_CACHE_DIR}/envs/MACHINE_C) since the env was destroyed." '[[ -d "${KW_CACHE_DIR}/envs/MACHINE_C" ]]'
 }
 
+function test_create_and_destroy_env()
+{
+  local output
+  options_values['CREATE']='MACHINE_E'
+  create_new_env
+
+  # Destroying the MACHINE_E env
+  options_values['DESTROY']='MACHINE_E'
+  output="$(printf '%s\n' 'y' | destroy_env)"
+
+  # MACHINE_E
+  assertFalse "($LINENO) We didn't expect to find this folder (${PWD}/.kw/MACHINE_E) since the env was destroyed." '[[ -d "${PWD}/.kw/MACHINE_E" ]]'
+  assertFalse "($LINENO) We didn't expect to find this folder in .cache (${KW_CACHE_DIR}/MACHINE_E) since the env was destroyed." '[[ -d "${KW_CACHE_DIR}/MACHINE_E" ]]'
+}
+
 invoke_shunit


### PR DESCRIPTION
The destroy_env() function had a bug where it looked for the env.current file, and that file didn't exist. This bug occurred when the user created an env and then destroyed that same env.

This commit checks if the env.current file exists to see if the user is using the environment they want to be destroyed.

Closes: #774