### PR TITLE
src: plugins: kernel_install: Remove shebang

### DIFF
--- a/src/plugins/kernel_install/remote_deploy.sh
+++ b/src/plugins/kernel_install/remote_deploy.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # This script will be executed via ssh, because of this, I can't see any good
 # reason (until now) for making things complicated here.
 #


### PR DESCRIPTION
Debian Lintian highlighted the following issue:

  W: kworkflow: script-not-executable [usr/share/kw/plugins/kernel_install/remote_deploy.sh]

Since remote_deploy is always invoked with `bash`, we can safely remove this shebang.