### PR TITLE
src: kw: Check if kw has a package version

### DIFF
--- a/kw
+++ b/kw
@@ -5,7 +5,12 @@ KWORKFLOW=${KWORKFLOW:-'kw'}
 # Global paths
 
 # Kw shell files
-KW_LIB_DIR="${KW_LIB_DIR:-"$HOME/.local/lib"}/$KWORKFLOW"
+if [[ -f '/usr/bin/kw' ]]; then
+  KW_LIB_DIR='/usr/share/kw'
+else
+  KW_LIB_DIR="${KW_LIB_DIR:-"${HOME}/.local/lib"}/${KWORKFLOW}"
+fi
+
 KW_PLUGINS_DIR="${KW_PLUGINS_DIR:-"$KW_LIB_DIR/plugins"}"
 
 # Share files


### PR DESCRIPTION
In the Debian package version of kw, a patch makes the variable KW_LIB_DIR point to /usr/share/kw. The Debian patch exposes a problem with how kw deals with default paths. To address this issue, this commit adds a verification path in the kw file; if kw is installed in the system kw will prefer to use the system-wide version.