### PR TITLE
src: build: standardize build.sh file.

### DIFF
--- a/kw
+++ b/kw
@@ -81,7 +81,7 @@ function kw()
       (
         include "$KW_LIB_DIR/build.sh"
 
-        kernel_build '' "$@"
+        build_kernel_main '' "$@"
         local ret="$?"
         alert_completion 'kw build' "$1"
         return "$ret"
@@ -102,7 +102,7 @@ function kw()
         include "$KW_LIB_DIR/deploy.sh"
         include "$KW_LIB_DIR/build.sh"
 
-        kernel_build && deploy_main 1 "$@"
+        build_kernel_main && deploy_main 1 "$@"
         local ret="$?"
         alert_completion 'kw bd' "$1"
         return "$ret"

--- a/src/build.sh
+++ b/src/build.sh
@@ -4,32 +4,6 @@ include "$KW_LIB_DIR/kw_config_loader.sh"
 
 declare -gA options_values
 
-# This function retrieves and prints information related to the kernel that
-# will be compiled.
-function build_info()
-{
-  local flag="$1"
-  local kernel_name
-  local kernel_version
-  local compiled_modules
-  local env_path="${options_values['ENV_PATH_KBUILD_OUTPUT_FLAG']}"
-  local config_path='.config'
-
-  kernel_name=$(get_kernel_release "$flag")
-  kernel_version=$(get_kernel_version "$flag")
-
-  say 'Kernel source information'
-  printf '%s\n' "  Name: $kernel_name" \
-    "  Version: $kernel_version"
-
-  [[ -f "${env_path}/.config" ]] && config_path="${env_path}/.config"
-
-  if [[ -f "$config_path" ]]; then
-    compiled_modules=$(grep -c '=m' "$config_path")
-    printf '%s\n' "  Total modules to be compiled: $compiled_modules"
-  fi
-}
-
 # This function is responsible for manipulating kernel build operations such as
 # compile/cross-compile and menuconfig.
 #
@@ -38,7 +12,7 @@ function build_info()
 #
 # Return:
 # In case of successful return 0, otherwise, return 22 or 125.
-function kernel_build()
+function build_kernel_main()
 {
   local flag="$1"
   shift 1
@@ -164,6 +138,32 @@ function kernel_build()
   fi
 
   return "$ret"
+}
+
+# This function retrieves and prints information related to the kernel that
+# will be compiled.
+function build_info()
+{
+  local flag="$1"
+  local kernel_name
+  local kernel_version
+  local compiled_modules
+  local env_path="${options_values['ENV_PATH_KBUILD_OUTPUT_FLAG']}"
+  local config_path='.config'
+
+  kernel_name=$(get_kernel_release "$flag")
+  kernel_version=$(get_kernel_version "$flag")
+
+  say 'Kernel source information'
+  printf '%s\n' "  Name: $kernel_name" \
+    "  Version: $kernel_version"
+
+  [[ -f "${env_path}/.config" ]] && config_path="${env_path}/.config"
+
+  if [[ -f "$config_path" ]]; then
+    compiled_modules=$(grep -c '=m' "$config_path")
+    printf '%s\n' "  Total modules to be compiled: $compiled_modules"
+  fi
 }
 
 # This function runs the make command under the hood, which in this

--- a/tests/build_test.sh
+++ b/tests/build_test.sh
@@ -218,7 +218,7 @@ function test_kernel_build_cross_compilation_flags()
   parse_configuration "$SAMPLES_DIR/build_no_llvm.config" build_config
 
   # For CI: The tail and head command remove statistics output
-  output=$(kernel_build 'TEST_MODE' | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' | tail -n +1 | head -2)
 
   declare -a expected_cmd=(
     'make -j ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- --silent olddefconfig'
@@ -233,7 +233,7 @@ function test_kernel_build_menu_cross_compilation_flags()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --menu)
+  output=$(build_kernel_main 'TEST_MODE' --menu)
   expected_result='make -j ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- nconfig'
   assertEquals "($LINENO)" "$expected_result" "$output"
 }
@@ -246,7 +246,7 @@ function test_kernel_build_clean()
   build_config=()
   parse_configuration "${SAMPLES_DIR}/build_no_log.config" build_config
 
-  output=$(kernel_build 'TEST_MODE' --clean 2> /dev/null)
+  output=$(build_kernel_main 'TEST_MODE' --clean 2> /dev/null)
   expected_result='make clean'
   assertEquals "($LINENO)" "$expected_result" "$output"
 }
@@ -259,7 +259,7 @@ function test_kernel_build_full_cleanup()
   build_config=()
   parse_configuration "${SAMPLES_DIR}/build_no_log.config" build_config
 
-  output=$(kernel_build 'TEST_MODE' --full-cleanup 2> /dev/null)
+  output=$(build_kernel_main 'TEST_MODE' --full-cleanup 2> /dev/null)
   expected_result='make distclean'
   assertEquals "($LINENO)" "$expected_result" "$output"
 }
@@ -272,7 +272,7 @@ function test_kernel_build_html_doc()
   build_config=()
   parse_configuration "$SAMPLES_DIR/build_no_log.config" build_config
 
-  output=$(kernel_build 'TEST_MODE' --doc)
+  output=$(build_kernel_main 'TEST_MODE' --doc)
   expected_result="make -j${PARALLEL_CORES} htmldocs"
   assertEquals "($LINENO)" "$expected_result" "$output"
 }
@@ -285,7 +285,7 @@ function test_kernel_build_html_doc_with_ccache()
   build_config=()
   parse_configuration "$SAMPLES_DIR/build_no_log.config" build_config
 
-  output=$(kernel_build 'TEST_MODE' --doc --ccache)
+  output=$(build_kernel_main 'TEST_MODE' --doc --ccache)
   expected_result="make CC=\"ccache gcc -fdiagnostics-color\" -j${PARALLEL_CORES} htmldocs"
   assertEquals "($LINENO)" "$expected_result" "$output"
 }
@@ -295,7 +295,7 @@ function test_kernel_build_html_doc_with_save_log_option()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --doc --save-log-to docs.out)
+  output=$(build_kernel_main 'TEST_MODE' --doc --save-log-to docs.out)
   expected_result="make -j${PARALLEL_CORES} htmldocs 2>&1 | tee docs.out"
   assertEquals "($LINENO)" "$expected_result" "$output"
 }
@@ -305,7 +305,7 @@ function test_kernel_build_invalid_flag()
   local output
   local ret
 
-  output=$(kernel_build 'TEST_MODE' --notvalid 2> /dev/null)
+  output=$(build_kernel_main 'TEST_MODE' --notvalid 2> /dev/null)
   ret="$?"
   assertEquals "($LINENO)" "$ret" 22
 }
@@ -320,7 +320,7 @@ function test_kernel_build_outside_kernel_repository()
     return
   }
 
-  output=$(kernel_build 'TEST_MODE')
+  output=$(build_kernel_main 'TEST_MODE')
   ret="$?"
   assert_equals_helper 'We expected an error' "($LINENO)" "$ret" 125
 
@@ -352,7 +352,7 @@ function test_kernel_build_x86()
   }
 
   # For CI: The tail and head command remove statistics output
-  output=$(kernel_build 'TEST_MODE' | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' | tail -n +1 | head -2)
   declare -a expected_cmd=(
     'make -j ARCH=x86_64 --silent olddefconfig'
     "make -j$PARALLEL_CORES ARCH=x86_64"
@@ -526,14 +526,14 @@ function test_build_info()
     "$version_output"
   )
 
-  output=$(kernel_build 'TEST_MODE' '--info')
+  output=$(build_kernel_main 'TEST_MODE' '--info')
   compare_command_sequence '' "$LINENO" 'expected_cmd' "$output"
 
   # Change modules
   modules='Total modules to be compiled: 5'
   cp "${original_dir}/tests/samples/.config" '.config'
   expected_cmd[3]="$modules"
-  output=$(kernel_build 'TEST_MODE' '--info')
+  output=$(build_kernel_main 'TEST_MODE' '--info')
   compare_command_sequence '' "$LINENO" 'expected_cmd' "$output"
 }
 
@@ -542,7 +542,7 @@ function test_kernel_build_only_cpu_scaling_option()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --cpu-scaling 50 | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --cpu-scaling 50 | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j ARCH=x86_64 --silent olddefconfig'
     "make -j${SCALING} ARCH=x86_64"
@@ -555,7 +555,7 @@ function test_kernel_build_cpu_scaling_and_warning()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --cpu-scaling 50 --warnings 123 | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --cpu-scaling 50 --warnings 123 | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j ARCH=x86_64 --silent olddefconfig'
     "make -j${SCALING} ARCH=x86_64 W=123"
@@ -568,7 +568,7 @@ function test_kernel_build_cpu_scaling_with_save_log_to()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --cpu-scaling 50 --save-log-to log.out | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --cpu-scaling 50 --save-log-to log.out | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j ARCH=x86_64 --silent olddefconfig'
     "make -j${SCALING} ARCH=x86_64 2>&1 | tee log.out"
@@ -582,7 +582,7 @@ function test_kernel_build_cpu_scaling_llvm()
   local output
 
   build_config['USE_LLVM_TOOLCHAIN']='yes'
-  output=$(kernel_build 'TEST_MODE' --cpu-scaling 50 --llvm | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --cpu-scaling 50 --llvm | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j LLVM=1 ARCH=x86_64 --silent olddefconfig'
     "make -j$SCALING LLVM=1 ARCH=x86_64"
@@ -595,7 +595,7 @@ function test_kernel_build_warning_and_save_log_to()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --warnings 123 --save-log-to log.out | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --warnings 123 --save-log-to log.out | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j ARCH=x86_64 --silent olddefconfig'
     "make -j${PARALLEL_CORES} ARCH=x86_64 W=123 2>&1 | tee log.out"
@@ -609,21 +609,21 @@ function test_kernel_build_kernel_ccache_cpu_scaling_warning()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --ccache --cpu-scaling 50 --warnings 123 | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --ccache --cpu-scaling 50 --warnings 123 | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j ARCH=x86_64 --silent olddefconfig'
     "make CC=\"ccache gcc -fdiagnostics-color\" -j${SCALING} ARCH=x86_64 W=123"
   )
   compare_command_sequence '' "($LINENO)" 'expected_result' "$output"
 
-  output=$(kernel_build 'TEST_MODE' --ccache --cpu-scaling 50 --save-log-to log.out | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --ccache --cpu-scaling 50 --save-log-to log.out | tail -n +1 | head -2)
   declare -a expected_cmd=(
     'make -j ARCH=x86_64 --silent olddefconfig'
     "make CC=\"ccache gcc -fdiagnostics-color\" -j${SCALING} ARCH=x86_64 2>&1 | tee log.out"
   )
   compare_command_sequence '' "($LINENO)" 'expected_cmd' "$output"
 
-  output=$(kernel_build 'TEST_MODE' --ccache --warnings 123 --save-log-to log.out | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --ccache --warnings 123 --save-log-to log.out | tail -n +1 | head -2)
   declare -a expected_cmd=(
     'make -j ARCH=x86_64 --silent olddefconfig'
     "make CC=\"ccache gcc -fdiagnostics-color\" -j${PARALLEL_CORES} ARCH=x86_64 W=123 2>&1 | tee log.out"
@@ -636,7 +636,7 @@ function test_kernel_build_kernel_ccache_cpu_scaling_save_log_to()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --ccache --cpu-scaling 50 --save-log-to log.out | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --ccache --cpu-scaling 50 --save-log-to log.out | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j ARCH=x86_64 --silent olddefconfig'
     "make CC=\"ccache gcc -fdiagnostics-color\" -j${SCALING} ARCH=x86_64 2>&1 | tee log.out"
@@ -649,7 +649,7 @@ function test_kernel_build_ccache_warning_save_log_to()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --ccache --warnings 123 --save-log-to log.out | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --ccache --warnings 123 --save-log-to log.out | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j ARCH=x86_64 --silent olddefconfig'
     "make CC=\"ccache gcc -fdiagnostics-color\" -j${PARALLEL_CORES} ARCH=x86_64 W=123 2>&1 | tee log.out"
@@ -662,7 +662,7 @@ function test_kernel_build_with_llvm_warning()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --llvm --warnings 123 | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --llvm --warnings 123 | tail -n +1 | head -2)
   declare -a expected_cmd=(
     'make -j LLVM=1 ARCH=x86_64 --silent olddefconfig'
     "make -j${PARALLEL_CORES} LLVM=1 ARCH=x86_64 W=123"
@@ -675,7 +675,7 @@ function test_kernel_build_with_llvm_save_log_to()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --llvm --save-log-to log.out | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --llvm --save-log-to log.out | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j LLVM=1 ARCH=x86_64 --silent olddefconfig'
     "make -j${PARALLEL_CORES} LLVM=1 ARCH=x86_64 2>&1 | tee log.out"
@@ -688,7 +688,7 @@ function test_kernel_build_ccache_cpu_scaling_llvm()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --ccache --cpu-scaling 50 --llvm | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --ccache --cpu-scaling 50 --llvm | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j LLVM=1 ARCH=x86_64 --silent olddefconfig'
     "make CC=\"ccache clang -fdiagnostics-color\" -j${SCALING} LLVM=1 ARCH=x86_64"
@@ -701,7 +701,7 @@ function test_kernel_build_ccache_cpu_scaling_warning()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --ccache --cpu-scaling 50 --warnings 123 | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --ccache --cpu-scaling 50 --warnings 123 | tail -n +1 | head -2)
   declare -a expected_cmd=(
     'make -j ARCH=x86_64 --silent olddefconfig'
     "make CC=\"ccache gcc -fdiagnostics-color\" -j${SCALING} ARCH=x86_64 W=123"
@@ -714,7 +714,7 @@ function test_kernel_build_ccache_cpu_scaling_save_log_to()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --ccache --cpu-scaling 50 --save-log-to log.out | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --ccache --cpu-scaling 50 --save-log-to log.out | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j ARCH=x86_64 --silent olddefconfig'
     "make CC=\"ccache gcc -fdiagnostics-color\" -j${SCALING} ARCH=x86_64 2>&1 | tee log.out"
@@ -727,7 +727,7 @@ function test_kernel_build_ccache_llvm_warning()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --ccache --llvm --warnings 123 | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --ccache --llvm --warnings 123 | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j LLVM=1 ARCH=x86_64 --silent olddefconfig'
     "make CC=\"ccache clang -fdiagnostics-color\" -j${PARALLEL_CORES} LLVM=1 ARCH=x86_64 W=123"
@@ -740,23 +740,10 @@ function test_kernel_build_ccache_llvm_save_log_to()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --ccache --llvm --save-log-to log.out | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --ccache --llvm --save-log-to log.out | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j LLVM=1 ARCH=x86_64 --silent olddefconfig'
     "make CC=\"ccache clang -fdiagnostics-color\" -j${PARALLEL_CORES} LLVM=1 ARCH=x86_64 2>&1 | tee log.out"
-  )
-  compare_command_sequence '' "($LINENO)" 'expected_cmd' "$output"
-}
-
-function test_kernel_build_ccache_llvm_save_log_to()
-{
-  local expected_result
-  local output
-
-  output=$(kernel_build 'TEST_MODE' --ccache --warnings 123 --save-log-to log.out | tail -n +1 | head -2)
-  declare -a expected_result=(
-    'make -j ARCH=x86_64 --silent olddefconfig'
-    "make CC=\"ccache gcc -fdiagnostics-color\" -j${PARALLEL_CORES} ARCH=x86_64 W=123 2>&1 | tee log.out"
   )
   compare_command_sequence '' "($LINENO)" 'expected_result' "$output"
 }
@@ -766,7 +753,7 @@ function test_kernel_cpu_scaling_llvm_warning()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --cpu-scaling 50 --llvm --warnings 123 | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --cpu-scaling 50 --llvm --warnings 123 | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j LLVM=1 ARCH=x86_64 --silent olddefconfig'
     "make -j${SCALING} LLVM=1 ARCH=x86_64 W=123"
@@ -779,7 +766,7 @@ function test_kernel_cpu_scaling_llvm_save_log_to()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --cpu-scaling 50 --llvm --save-log-to log.out | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --cpu-scaling 50 --llvm --save-log-to log.out | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j LLVM=1 ARCH=x86_64 --silent olddefconfig'
     "make -j${SCALING} LLVM=1 ARCH=x86_64 2>&1 | tee log.out"
@@ -792,7 +779,7 @@ function test_kernel_cpu_scaling_warning_save_log_to()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --cpu-scaling 50 --warnings 123 --save-log-to log.out | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --cpu-scaling 50 --warnings 123 --save-log-to log.out | tail -n +1 | head -2)
   declare -a expected_cmd=(
     'make -j ARCH=x86_64 --silent olddefconfig'
     "make -j${SCALING} ARCH=x86_64 W=123 2>&1 | tee log.out"
@@ -805,7 +792,7 @@ function test_kernel_build_ccache_cpu_scaling_llvm_warning()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --ccache --cpu-scaling 50 --llvm --warnings 123 | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --ccache --cpu-scaling 50 --llvm --warnings 123 | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j LLVM=1 ARCH=x86_64 --silent olddefconfig'
     "make CC=\"ccache clang -fdiagnostics-color\" -j${SCALING} LLVM=1 ARCH=x86_64 W=123"
@@ -818,7 +805,7 @@ function test_kernel_build_ccache_cpu_scaling_llvm_save_log_to()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --ccache --cpu-scaling 50 --llvm --save-log-to log.out | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --ccache --cpu-scaling 50 --llvm --save-log-to log.out | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j LLVM=1 ARCH=x86_64 --silent olddefconfig'
     "make CC=\"ccache clang -fdiagnostics-color\" -j${SCALING} LLVM=1 ARCH=x86_64 2>&1 | tee log.out"
@@ -831,7 +818,7 @@ function test_kernel_build_ccache_cpu_scaling_warning_save_log_to()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --ccache --cpu-scaling 50 --warnings 123 --save-log-to log.out | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --ccache --cpu-scaling 50 --warnings 123 --save-log-to log.out | tail -n +1 | head -2)
   declare -a expected_cmd=(
     'make -j ARCH=x86_64 --silent olddefconfig'
     "make CC=\"ccache gcc -fdiagnostics-color\" -j${SCALING} ARCH=x86_64 W=123 2>&1 | tee log.out"
@@ -844,7 +831,7 @@ function test_kernel_build_ccache_llvm_warning_save_log_to()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --ccache --llvm --warnings 123 --save-log-to log.out | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --ccache --llvm --warnings 123 --save-log-to log.out | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j LLVM=1 ARCH=x86_64 --silent olddefconfig'
     "make CC=\"ccache clang -fdiagnostics-color\" -j${PARALLEL_CORES} LLVM=1 ARCH=x86_64 W=123 2>&1 | tee log.out"
@@ -857,7 +844,7 @@ function test_kernel_build_cpu_scaling_llvm_warning_sava_log_to()
   local expected_result
   local output
 
-  output=$(kernel_build 'TEST_MODE' --cpu-scaling 50 --llvm --warnings 123 --save-log-to log.out | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' --cpu-scaling 50 --llvm --warnings 123 --save-log-to log.out | tail -n +1 | head -2)
   declare -a expected_result=(
     'make -j LLVM=1 ARCH=x86_64 --silent olddefconfig'
     "make -j$SCALING LLVM=1 ARCH=x86_64 W=123 2>&1 | tee log.out"
@@ -876,7 +863,7 @@ function test_kernel_build_inside_an_env()
 
   parse_configuration "$SAMPLES_DIR/build_no_llvm.config" build_config
 
-  output=$(kernel_build 'TEST_MODE' | tail -n +1 | head -2)
+  output=$(build_kernel_main 'TEST_MODE' | tail -n +1 | head -2)
 
   declare -a expected_cmd=(
     "make -j ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- --silent olddefconfig O=${env_output}"
@@ -897,7 +884,7 @@ function test_kernel_build_html_doc_inside_env()
 
   parse_configuration "$SAMPLES_DIR/build_no_log.config" build_config
 
-  output=$(kernel_build 'TEST_MODE' --doc)
+  output=$(build_kernel_main 'TEST_MODE' --doc)
   expected_result="make -j${PARALLEL_CORES} htmldocs O=${env_output}"
   assertEquals "($LINENO)" "$expected_result" "$output"
 }
@@ -913,7 +900,7 @@ function test_kernel_build_menu_inside_env()
 
   parse_configuration "$SAMPLES_DIR/build_no_log.config" build_config
 
-  output=$(kernel_build 'TEST_MODE' --menu)
+  output=$(build_kernel_main 'TEST_MODE' --menu)
   expected_result="make -j ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- nconfig O=${env_output}"
   assertEquals "($LINENO)" "$expected_result" "$output"
 }
@@ -929,7 +916,7 @@ function test_kernel_build_clean_inside_env()
 
   parse_configuration "${SAMPLES_DIR}/build_no_log.config" build_config
 
-  output=$(kernel_build 'TEST_MODE' --clean 2> /dev/null)
+  output=$(build_kernel_main 'TEST_MODE' --clean 2> /dev/null)
   expected_result="make clean O=${env_output}"
   assertEquals "($LINENO)" "$expected_result" "$output"
 }
@@ -945,7 +932,7 @@ function test_kernel_build_full_cleanup_inside_env()
 
   parse_configuration "${SAMPLES_DIR}/build_no_log.config" build_config
 
-  output=$(kernel_build 'TEST_MODE' --full-cleanup 2> /dev/null)
+  output=$(build_kernel_main 'TEST_MODE' --full-cleanup 2> /dev/null)
   expected_result="make distclean O=${env_output}"
   assertEquals "($LINENO)" "$expected_result" "$output"
 }


### PR DESCRIPTION
In order to follow the pattern of other kw files, this commit
organizes the order of functions in the `build.sh` file.

Closes: #787