### PR TITLE
run_tests.sh: Fix name collision when specifying test name

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -103,7 +103,7 @@ function strip_path()
 check_files="$?"
 #shellcheck disable=SC2086
 if [[ "$#" -eq 0 ]]; then
-  files_list=$(find ./tests -name '*_test.sh' | grep -Ev 'samples/.*|/shunit2/')
+  files_list=$(find ./tests -name '*_test.sh' | grep --extended-regexp --invert-match 'samples/.*|/shunit2/')
   # Note: Usually we want to use double-quotes on bash variables, however,
   # in this case we want a set of parameters instead of a single one.
   strip_path $files_list

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -63,7 +63,7 @@ function run_tests()
   local test_failure_list=''
 
   for current_test in "${TESTS[@]}"; do
-    target=$(find ./tests -name "$current_test*.sh")
+    target=$(find ./tests -name "${current_test}*.sh" | grep --extended-regexp --invert-match 'samples/.*|/shunit2/')
     if [[ -f "$target" ]]; then
       say "Running test [${current_test}]"
       say "$SEPARATOR"


### PR DESCRIPTION
When specifying the test (`run_tests.sh test <test>`) if the shunit2 repo where cloned inside the kworkflow repo `tests` folder and there is a file which start with the same name inside `tests/shunit2` the test might fail. As an example `run_tests.sh test init` fails because it finds `tests/shunit2/init_githooks.sh` and tries to run `tests/init_githooks.sh`, instead of `tests/init_test.sh`, which doesn't exists.

This commit fix this issue.