### PR TITLE
documentation: dependencies: Add curl and xpath dependencies

### DIFF
--- a/documentation/dependencies/arch.dependencies
+++ b/documentation/dependencies/arch.dependencies
@@ -26,3 +26,5 @@ rsync
 ccache
 python-setuptools
 dialog
+curl
+perl-xml-xpath

--- a/documentation/dependencies/debian.dependencies
+++ b/documentation/dependencies/debian.dependencies
@@ -26,3 +26,5 @@ pv
 rsync
 ccache
 dialog
+curl
+libxml-xpath-perl

--- a/documentation/dependencies/fedora.dependencies
+++ b/documentation/dependencies/fedora.dependencies
@@ -23,3 +23,5 @@ ccache
 patch
 sqlite
 dialog
+curl
+perl-XML-XPath


### PR DESCRIPTION
The commands curl and xpath are used by the kw upstream-patches-ui command, but those dependencies are not checked when kw is installed. Although they are really common commands in almost every linux installation, if the setup doesn't have these dependencies installed, a command not found error occurs.

This commit fix this problem by adding both dependencies to the dependencies files of Arch, Debian and Fedora distros.

Closes: #792