### PR TITLE
src: upstream_patches_ui: Fix list_patches menu title

### DIFF
--- a/src/upstream_patches_ui.sh
+++ b/src/upstream_patches_ui.sh
@@ -230,12 +230,12 @@ function show_series_details()
 # @_target_array_list: List of patches to be displayed
 function list_patches()
 {
-  local message_box="$1"
+  local menu_title="$1"
   local -n _target_array_list="$2"
   local selected_patch
   local ret
 
-  create_menu_options 'Bookmarked patches' "$message_box" '_target_array_list' 1
+  create_menu_options "${menu_title}" '' '_target_array_list' 1
   ret="$?"
 
   selected_patch=$((menu_return_string - 1))


### PR DESCRIPTION
The list_patches function is used whenever we need to display an array of patches. Under the hood, it calls a function to create the menu for the user and this function accepts a menu title parameter. list_patches had this parameter hardcoded to "Bookmarked patches", which in turn resulted in wrong menu titles (e.g. when listing patches from a specific mailing list).

As list_patches accepts a parameter to display a custom message box, this commit fixes the problem by hardcoding an empty message box and substituting the parameter mentioned to represent the menu title.

list_patches could also accept both a custom menu title and message box, but, at the moment, just an indicative menu title seems enough. The fix could also be done by just hardcoding an empty menu title and leaving the custom message box as it is, but this seems to waste the highligthing of a menu title (this is a style choice).

Closes: #798