### PR TITLE
src: upstream_patches_ui: Add loading screen for delayed actions

### DIFF
--- a/src/upstream_patches_ui.sh
+++ b/src/upstream_patches_ui.sh
@@ -154,6 +154,7 @@ function show_new_patches_in_the_mailing_list()
   # Query patches from mailing list, this info will be saved at
   # ${list_of_mailinglist_patches[@]}
   if [[ "${screen_sequence['SHOW_SCREEN_PARAMETER']}" != 'return' ]]; then
+    create_loading_screen_notification "Loading patches from ${list_name} list"
     get_patches_from_mailing_list "$list_name" patches_from_mailing_list
   fi
 
@@ -206,6 +207,7 @@ function show_series_details()
             printf 'TODO' # TODO
             ;;
           'Download')
+            create_loading_screen_notification "Downloading patch(es)"$'\n'"- ${patch_title}"
             download_series "$total_patches" "$patch_url" "${lore_config['download_to']}" "$patch_title"
             ;;
         esac

--- a/tests/lib/dialog_ui_test.sh
+++ b/tests/lib/dialog_ui_test.sh
@@ -121,6 +121,32 @@ function test_create_simple_checklist_use_all_options()
   assert_equals_helper 'Expected simple checklist' "$LINENO" "${output}" "${expected_cmd}"
 }
 
+function test_create_loading_screen_notification_rely_on_some_default_options()
+{
+  local loading_message='kunit test inside kw'
+  local expected_cmd="dialog --colors"
+  local output
+
+  expected_cmd+=" --infobox \$'${loading_message}'"
+  expected_cmd+=" '8' '60'"
+
+  output=$(create_loading_screen_notification "$loading_message" '' '' 'TEST_MODE')
+  assert_equals_helper 'Expected loading screen with some default options' "$LINENO" "${output}" "${expected_cmd}"
+}
+
+function test_create_loading_screen_notification_use_all_options()
+{
+  local loading_message='kunit test inside kw'
+  local expected_cmd="dialog --colors"
+  local output
+
+  expected_cmd+=" --infobox \$'${loading_message}'"
+  expected_cmd+=" '1234' '4321'"
+
+  output=$(create_loading_screen_notification "$loading_message" '1234' '4321' 'TEST_MODE')
+  assert_equals_helper 'Expected loading screen with some default options' "$LINENO" "${output}" "${expected_cmd}"
+}
+
 function test_prettify_string_failures()
 {
   prettify_string


### PR DESCRIPTION
When the user tries to access patches from the public mailing list or download a given patch (or series) there is a possible delay between the requisiton and the completion (i.e. the display of the new screen). There is no visual notification to the user (for the dialog view there is only a black screen with a cursor) which does not indicate whether an error happened or if it is just a delay.

This commit adds this visual notification with the addition of the create_loading_screen function that accepts a custom message to be displayed to the user. In case of the dialog view, this message is displayed inside an info box.

Note that this function may be expanded to display a progress bar or gauge.

Closes: #797