### PR TITLE
src: upstream_patches_ui: Add bookmark feature

### DIFF
--- a/documentation/dependencies/arch.dependencies
+++ b/documentation/dependencies/arch.dependencies
@@ -28,3 +28,4 @@ python-setuptools
 dialog
 curl
 perl-xml-xpath
+coreutils

--- a/documentation/dependencies/debian.dependencies
+++ b/documentation/dependencies/debian.dependencies
@@ -28,3 +28,4 @@ ccache
 dialog
 curl
 libxml-xpath-perl
+coreutils

--- a/documentation/dependencies/fedora.dependencies
+++ b/documentation/dependencies/fedora.dependencies
@@ -25,3 +25,4 @@ sqlite
 dialog
 curl
 perl-XML-XPath
+coreutils

--- a/src/kwlib.sh
+++ b/src/kwlib.sh
@@ -680,3 +680,21 @@ function get_current_env_name()
 
   return "$ret"
 }
+
+# A common task is to remove files/directories. This function is a predicate
+# to check if a given path is safe to remove (e.g. is not the '/')
+#
+# @path: Path to be checked
+#
+# Return:
+# Returns 0 if the path is safe to remove, 1 if it is not and 2 if it doesn't
+# exists.
+function is_safe_path_to_remove()
+{
+  local path="$1"
+
+  [[ ! -e "$path" ]] && return 2   # ENOENT
+  [[ "$path" == '/' ]] && return 1 # EPERM
+
+  return 0
+}

--- a/src/lib/dialog_ui.sh
+++ b/src/lib/dialog_ui.sh
@@ -247,7 +247,7 @@ function handle_exit()
 
   # Handling stop
   case "$exit_status" in
-    1 | 255) # Exit
+    1 | 22 | 255) # Exit
       clear
       exit 0
       ;;

--- a/src/lib/dialog_ui.sh
+++ b/src/lib/dialog_ui.sh
@@ -238,6 +238,55 @@ function create_loading_screen_notification()
   return "$ret"
 }
 
+# Create simple message box. Can be used for displaying errors and notifications.
+#
+# @box_title: Title of the box
+# @message_box: The message to be displayed.
+# @height: Menu height in lines size
+# @width: Menu width in column size
+# @flag How to display a command, the default value is
+#   "SILENT". For more options see `src/kwlib.sh` function `cmd_manager`
+#
+# Return:
+# Unlike other dialog screens, this one doesn't return a menu_return_string,
+# just the status code of the command which should be 0, if everything worked
+# as expected.
+function create_message_box()
+{
+  local box_title="$1"
+  local message_box="$2"
+  local height="$3"
+  local width="$4"
+  local flag="$5"
+  local cmd
+  local ret
+
+  flag=${flag:-'SILENT'}
+  height=${height:-'15'}
+  width=${width:-'40'}
+  back_title=${back_title:-"${KW_UPSTREAM_TITLE}"}
+
+  # Add layout to dialog
+  if [[ -n "$DIALOG_LAYOUT" ]]; then
+    cmd="DIALOGRC=${DIALOG_LAYOUT}"
+  fi
+
+  cmd+=" dialog --backtitle \$'${back_title}' --title \$'${box_title}' --clear --colors"
+
+  cmd+=" --msgbox \$'${message_box}'"
+
+  # Set height and width
+  cmd+=" '${height}' '${width}'"
+
+  [[ "$flag" == 'TEST_MODE' ]] && printf '%s' "$cmd" && return 0
+
+  exec 3>&1
+  cmd_manager "$flag" "$cmd" 2>&1 1>&3
+  ret="$?"
+  exec 3>&-
+  return "$ret"
+}
+
 # This function is responsible for handling the dialog exit.
 #
 # @exit_status: Exit code

--- a/src/lib/dialog_ui.sh
+++ b/src/lib/dialog_ui.sh
@@ -122,6 +122,7 @@ function create_menu_options()
 # @menu_title: This is the menu title used on the top left of the dialog screen.
 # @menu_message_box: The instruction text used for this menu.
 # @_menu_list_string_array: An array reference containing all the strings to be used in the menu.
+# @_check_statuses: An array reference containing all the statuses of the checks (if they are on/off).
 # @cancel_label: Cancel label. If not set, the default is 'Exit']
 # @height: Menu height in lines size
 # @width: Menu width in column size
@@ -137,12 +138,14 @@ function create_simple_checklist()
   local menu_title="$1"
   local menu_message_box="$2"
   local -n _menu_list_string_array="$3"
-  local back_button_label="$4"
-  local cancel_label="$5"
-  local height="$6"
-  local width="$7"
-  local list_height="$8"
-  local flag="$9"
+  local -n _check_statuses="$4"
+  local back_button_label="$5"
+  local cancel_label="$6"
+  local height="$7"
+  local width="$8"
+  local list_height="$9"
+  local flag="${10}"
+  local index=0
   local cmd
   local ret
 
@@ -175,7 +178,12 @@ function create_simple_checklist()
   cmd+=" '${height}' '${width}' '${list_height}'"
 
   for item in "${_menu_list_string_array[@]}"; do
-    cmd+=" '${item}' '' 'off'"
+    if [[ -n "${_check_statuses}" && -n ${_check_statuses["$index"]} ]]; then
+      cmd+=" '${item}' '' 'on'"
+    else
+      cmd+=" '${item}' '' 'off'"
+    fi
+    ((index++))
   done
 
   [[ "$flag" == 'TEST_MODE' ]] && printf '%s' "$cmd" && return 0

--- a/src/lib/lore.sh
+++ b/src/lib/lore.sh
@@ -679,3 +679,33 @@ function parse_raw_series()
   _series['patch_id']="${columns[7]}"
   _series['timestamp']="${columns[8]}"
 }
+
+# This function is a predicate about the existence of given patch in the local
+# bookmark database.
+#
+# @target_patch: The patch metadata. Used to get the target patch id.
+#
+# Return:
+# Returns 0 if given patch is present in local database, 1 if it is not and 2 if
+# there is no local database.
+#
+# TODO:
+# - Revise the return value of 1.
+function is_bookmarked()
+{
+  local target_patch="$1"
+  local patch_id
+  local count
+
+  if [[ ! -f "${BOOKMARKED_SERIES_PATH}" ]]; then
+    return 2 # ENOENT
+  fi
+
+  patch_id=$(printf '%s' "${target_patch}" | sha256sum | cut -d ' ' -f1)
+  count=$(grep --count "${patch_id}" "${BOOKMARKED_SERIES_PATH}")
+  if [[ "$count" != 0 ]]; then
+    return 0
+  fi
+
+  return 1
+}

--- a/src/upstream_patches_ui.sh
+++ b/src/upstream_patches_ui.sh
@@ -135,6 +135,7 @@ function show_bookmarked_series_details()
   local series_index="$1"
   declare -A series
   local -a action_list
+  local -a check_statuses=('')
   local patch_metadata
   local raw_series
   local message_box
@@ -159,7 +160,7 @@ function show_bookmarked_series_details()
   patch_metadata+=$(prettify_string 'Patches:' "${series['total_patches']}")
   message_box="$patch_metadata"
 
-  create_simple_checklist 'Bookmarked Series info and actions' "$message_box" 'action_list' 1
+  create_simple_checklist 'Bookmarked Series info and actions' "$message_box" 'action_list' 'check_statuses' 1
   ret="$?"
 
   case "$ret" in
@@ -250,6 +251,7 @@ function show_series_details()
   local -n _target_patch_metadata="$2"
   declare -A series
   local -a action_list
+  local -a check_statuses=('' '')
   local patch_metadata
   local raw_series
   local message_box
@@ -266,7 +268,14 @@ function show_series_details()
   patch_metadata+=$(prettify_string 'Patches:' "${series['total_patches']}")
   message_box="$patch_metadata"
 
-  create_simple_checklist 'Patch(es) info and actions' "$message_box" 'action_list' 1
+  is_bookmarked "${raw_series}"
+  if [[ "$?" == 0 ]]; then
+    check_statuses[0]=1
+    # TODO: when we refine the 'Download' action, we should revise the set below
+    check_statuses[1]=1
+  fi
+
+  create_simple_checklist 'Patch(es) info and actions' "$message_box" 'action_list' 'check_statuses' 1
   ret="$?"
 
   case "$ret" in
@@ -363,6 +372,7 @@ function register_mailing_list()
   local message_box
   local new_list
   local -a menu_list_string_array
+  local -a check_statuses=()
   local lore_config_path="${PWD}/.kw/lore.config"
   local ret
 
@@ -379,7 +389,7 @@ function register_mailing_list()
   message_box="It looks like that you don't have any lore list registered; please"
   message_box+=" select one or more of the below list:"
 
-  create_simple_checklist 'Lore list' "$message_box" 'menu_list_string_array'
+  create_simple_checklist 'Lore list' "$message_box" 'menu_list_string_array' 'check_statuses'
   ret="$?"
 
   new_list=$(printf '%s' "$menu_return_string" | tr -s '[:blank:]' ',')

--- a/tests/kwlib_test.sh
+++ b/tests/kwlib_test.sh
@@ -786,6 +786,7 @@ function test_get_kernel_release()
 {
   local output
 
+  # shellcheck disable=SC2317
   function get_current_env_name()
   {
     printf ''
@@ -801,6 +802,7 @@ function test_get_kernel_release_with_env()
   local output
   local expected="make kernelrelease O=${KW_CACHE_DIR}/envs/fake_env --silent 2> /dev/null"
 
+  # shellcheck disable=SC2317
   function get_current_env_name()
   {
     printf 'fake_env'
@@ -814,6 +816,7 @@ function test_get_kernel_version()
 {
   local output
 
+  # shellcheck disable=SC2317
   function get_current_env_name()
   {
     printf ''
@@ -829,6 +832,7 @@ function test_get_kernel_version_with_env()
   local output
   local expected="make kernelversion O=${KW_CACHE_DIR}/envs/fake_env --silent 2> /dev/null"
 
+  # shellcheck disable=SC2317
   function get_current_env_name()
   {
     printf 'fake_env'

--- a/tests/kwlib_test.sh
+++ b/tests/kwlib_test.sh
@@ -863,4 +863,32 @@ function test_get_current_env_name()
   }
 }
 
+function test_is_safe_path_to_remove()
+{
+  local path
+
+  cd "${SHUNIT_TMPDIR}" || {
+    fail "($LINENO): It was not possible to move into ${SHUNIT_TMPDIR}"
+    return
+  }
+
+  path='some/random/path/that/doesnt/exists'
+  is_safe_path_to_remove "$path"
+  assertEquals "($LINENO) - Should return 2 as path doesn't exists" 2 "$?"
+
+  path='/'
+  is_safe_path_to_remove "$path"
+  assertEquals "($LINENO) - Should return 1 as path is root" 1 "$?"
+
+  path='a/safe/path'
+  mkdir -p "$path"
+  is_safe_path_to_remove "$path"
+  assertEquals "($LINENO) - Should return 0 as is safe to remove" 0 "$?"
+
+  cd "${ORIGINAL_DIR}" || {
+    fail "($LINENO): It was not possible to move back to original directory"
+    return
+  }
+}
+
 invoke_shunit

--- a/tests/lib/dialog_ui_test.sh
+++ b/tests/lib/dialog_ui_test.sh
@@ -147,6 +147,34 @@ function test_create_loading_screen_notification_use_all_options()
   assert_equals_helper 'Expected loading screen with some default options' "$LINENO" "${output}" "${expected_cmd}"
 }
 
+function test_create_message_box_rely_on_some_default_options()
+{
+  local box_title='Bookmarked patches'
+  local message_box='There are no bookmarked patches...'
+  local expected_cmd=" dialog --backtitle \$'${KW_UPSTREAM_TITLE}'"
+  local output
+
+  expected_cmd+=" --title \$'${box_title}' --clear --colors"
+  expected_cmd+=" --msgbox \$'${message_box}'"
+  expected_cmd+=" '15' '40'"
+  output=$(create_message_box "${box_title}" "${message_box}" '' '' 'TEST_MODE')
+  assert_equals_helper 'Expected message box with some default options' "$LINENO" "$output" "${expected_cmd}"
+}
+
+function test_create_message_box_use_all_options()
+{
+  local box_title='Bookmarked patches'
+  local message_box='There are no bookmarked patches...'
+  local expected_cmd=" dialog --backtitle \$'${KW_UPSTREAM_TITLE}'"
+  local output
+
+  expected_cmd+=" --title \$'${box_title}' --clear --colors"
+  expected_cmd+=" --msgbox \$'${message_box}'"
+  expected_cmd+=" '1234' '4321'"
+  output=$(create_message_box "${box_title}" "${message_box}" '1234' '4321' 'TEST_MODE')
+  assert_equals_helper 'Expected message box with all custom options' "$LINENO" "$output" "${expected_cmd}"
+}
+
 function test_prettify_string_failures()
 {
   prettify_string

--- a/tests/lib/dialog_ui_test.sh
+++ b/tests/lib/dialog_ui_test.sh
@@ -92,14 +92,15 @@ function test_create_simple_checklist_rely_on_some_default_options()
   local menu_title='kunit test inside kw'
   local menu_message_box='This should be a useful message box'
   local -a menu_list_string_array=('Checklist 1' 'Checklist 2')
+  local -a check_statuses=(1 '')
   local expected_cmd="dialog --backtitle \$'${KW_UPSTREAM_TITLE}'"
   local output
 
   expected_cmd+=" --title \$'${menu_title}' --clear --colors --cancel-label $'Exit' --checklist $\"${menu_message_box}\""
   expected_cmd+=" '${EXPECTED_DEFAULT_HEIGHT}' '${EXPECTED_DEFAULT_WIDTH}' '0'"
-  expected_cmd+=" 'Checklist 1' '' 'off' 'Checklist 2' '' 'off'"
+  expected_cmd+=" 'Checklist 1' '' 'on' 'Checklist 2' '' 'off'"
 
-  output=$(create_simple_checklist "$menu_title" "$menu_message_box" menu_list_string_array '' '' '' '' '' 'TEST_MODE')
+  output=$(create_simple_checklist "$menu_title" "$menu_message_box" 'menu_list_string_array' 'check_statuses' '' '' '' '' '' 'TEST_MODE')
   assert_equals_helper 'Expected simple checklist' "$LINENO" "${output}" "${expected_cmd}"
 }
 
@@ -108,6 +109,7 @@ function test_create_simple_checklist_use_all_options()
   local menu_title='kunit test inside kw'
   local menu_message_box='This should be a useful message box'
   local -a menu_list_string_array=('Checklist 1' 'Checklist 2')
+  local -a check_statuses=(1 '')
   local expected_cmd="dialog --backtitle \$'${KW_UPSTREAM_TITLE}'"
   local output
 
@@ -115,9 +117,9 @@ function test_create_simple_checklist_use_all_options()
   expected_cmd+=" --extra-button --extra-label 'Return'"
   expected_cmd+=" --checklist $\"${menu_message_box}\""
   expected_cmd+=" '442' '244' '3'"
-  expected_cmd+=" 'Checklist 1' '' 'off' 'Checklist 2' '' 'off'"
+  expected_cmd+=" 'Checklist 1' '' 'on' 'Checklist 2' '' 'off'"
 
-  output=$(create_simple_checklist "$menu_title" "$menu_message_box" menu_list_string_array 1 'Nop' '442' '244' '3' 'TEST_MODE')
+  output=$(create_simple_checklist "$menu_title" "$menu_message_box" 'menu_list_string_array' 'check_statuses' 1 'Nop' '442' '244' '3' 'TEST_MODE')
   assert_equals_helper 'Expected simple checklist' "$LINENO" "${output}" "${expected_cmd}"
 }
 

--- a/tests/lib/lore_test.sh
+++ b/tests/lib/lore_test.sh
@@ -315,4 +315,26 @@ function test_get_bookmarked_series_by_index()
   assertEquals "($LINENO) - Should get the second entry" "$expected" "$output"
 }
 
+function test_is_boookmarked()
+{
+  # The below are the sha256sum of 'entry1', 'entry2' and 'entry3', respectively
+  {
+    printf 'c17dd9010a5c6b0e5b2ad5a845762d8b206e6166a4e63d32deca8c5664fdfcac\n'
+    printf 'ad2063741cce2d9f2862b07152b06528d175e9e658ade8f2daa416834c9c089a\n'
+    printf 'a671a481a0edc8cd6eab7640f9c8e225a82e5c8e49122a86158f20fa22254409\n'
+  } >> "${BOOKMARKED_SERIES_PATH}"
+
+  is_bookmarked 'entry2'
+  assertEquals "($LINENO) - Should return 0 (patch bookmarked)" 0 "$?"
+
+  is_bookmarked 'entry1234'
+  assertEquals "($LINENO) - Should return 1 (patch not bookmarked)" 1 "$?"
+
+  if [[ "${BOOKMARKED_SERIES_PATH}" != '/' ]]; then
+    rm "${BOOKMARKED_SERIES_PATH}"
+  fi
+  is_bookmarked 'entry3'
+  assertEquals "($LINENO) - Should return 2 (local bookmark database non-existent)" 2 "$?"
+}
+
 invoke_shunit

--- a/tests/upstream_patches_ui_test.sh
+++ b/tests/upstream_patches_ui_test.sh
@@ -6,6 +6,21 @@ include './tests/utils.sh'
 function setUp()
 {
   screen_sequence['SHOW_SCREEN']=''
+
+  export ORIGINAL_PATH="$PWD"
+
+  cd "${SHUNIT_TMPDIR}" || {
+    fail "($LINENO): setUp(): It was not possible to move into ${SHUNIT_TMPDIR}"
+    return
+  }
+}
+
+function tearDown()
+{
+  cd "${ORIGINAL_PATH}" || {
+    fail "($LINENO): tearDown(): It was not possible to move into ${ORIGINAL_PATH}"
+    return
+  }
 }
 
 function test_dashboard_entry_menu_check_valid_options()
@@ -46,13 +61,6 @@ function test_dashboard_entry_menu_check_failed()
   assert_equals_helper 'Expected failure' "$LINENO" "$?" 22
 }
 
-declare -ga bookmarked_patches=(
-  '2022-11-10 | #1   | drm/amd/pm: Enable bad memory page/channel recording support for smu v13_0_0'
-  '2021-05-10 | #255 | DC Patches November 19, 2022'
-  '2000-01-29 | #12  | drm/amdgpu: add drv_vram_usage_va for virt data exchange'
-  '2022-07-01 | #7   | drm/amdgpu: fix pci device refcount leak'
-)
-
 declare -ga patch_list_with_metadata=(
   'Joe DoeÆjoedoe@lala.comÆV1Æ1Ædrm/amd/pm: Enable bad memory page/channel recording support for smu v13_0_0Æhttp://something.la'
   'Juca PiramaÆjucapirama@xpto.comÆV1Æ255ÆDC Patches November 19, 2022Æhttp://anotherthing.la'
@@ -85,6 +93,39 @@ function test_show_series_details()
   assert_equals_helper 'Expected failure' "$LINENO" $"$output" $"$expected_result"
 }
 
+function test_show_bookmarked_series_details()
+{
+  local output
+  local expected_result='Bookmarked Series info and actions'
+
+  expected_result+=' \Zb\Z6Series:\ZnDC Patches November 19, 2022\n'
+  expected_result+='\Zb\Z6Author:\ZnJuca Pirama\n\Zb\Z6Version:\ZnV1\n'
+  expected_result+='\Zb\Z6Patches:\Zn255\n'
+  expected_result+=' action_list'
+
+  # shellcheck disable=SC2317
+  function get_bookmarked_series_by_index()
+  {
+    if [[ "$1" == 2 ]]; then
+      printf 'Juca PiramaÆjucapirama@xpto.comÆV1Æ255ÆDC Patches November 19, 2022Æhttp://anotherthing.la'
+    fi
+  }
+
+  # Mock failed scenario
+  # shellcheck disable=SC2317
+  function create_simple_checklist()
+  {
+    local title="$1"
+    local message_box="$2"
+    local action="$3"
+
+    printf '%s %s %s' "$title" "$message_box" "$action"
+  }
+
+  output=$(show_bookmarked_series_details 1)
+  assert_equals_helper 'Expected failure' "$LINENO" $"$output" $"$expected_result"
+}
+
 function test_list_patches()
 {
   # shellcheck disable=SC2317
@@ -93,8 +134,12 @@ function test_list_patches()
     menu_return_string='3'
   }
 
-  list_patches 'Message test' 'bookmarked_patches'
+  list_patches 'Message test' 'patches_from_mailing_list' 'show_new_patches_in_the_mailing_list'
   assert_equals_helper 'Expected screen' "$LINENO" "${screen_sequence['SHOW_SCREEN']}" 'show_series_details'
+  assert_equals_helper 'Expected screen' "$LINENO" "${screen_sequence['SHOW_SCREEN_PARAMETER']}" 2
+
+  list_patches 'Message test' 'bookmarked_patches' 'bookmarked_patches'
+  assert_equals_helper 'Expected screen' "$LINENO" "${screen_sequence['SHOW_SCREEN']}" 'show_bookmarked_series_details'
   assert_equals_helper 'Expected screen' "$LINENO" "${screen_sequence['SHOW_SCREEN_PARAMETER']}" 2
 }
 

--- a/tests/upstream_patches_ui_test.sh
+++ b/tests/upstream_patches_ui_test.sh
@@ -126,21 +126,48 @@ function test_show_bookmarked_series_details()
   assert_equals_helper 'Expected failure' "$LINENO" $"$output" $"$expected_result"
 }
 
-function test_list_patches()
+function test_list_patches_with_patches()
 {
+  local target_array_list
+
   # shellcheck disable=SC2317
   function create_menu_options()
   {
     menu_return_string='3'
   }
 
-  list_patches 'Message test' 'patches_from_mailing_list' 'show_new_patches_in_the_mailing_list'
+  target_array_list=(
+    'some_patch'
+    'some_other_patch'
+    'more_patches'
+  )
+
+  list_patches 'Message test' target_array_list 'show_new_patches_in_the_mailing_list' ''
   assert_equals_helper 'Expected screen' "$LINENO" "${screen_sequence['SHOW_SCREEN']}" 'show_series_details'
   assert_equals_helper 'Expected screen' "$LINENO" "${screen_sequence['SHOW_SCREEN_PARAMETER']}" 2
 
-  list_patches 'Message test' 'bookmarked_patches' 'bookmarked_patches'
+  list_patches 'Message test' target_array_list 'bookmarked_patches' ''
   assert_equals_helper 'Expected screen' "$LINENO" "${screen_sequence['SHOW_SCREEN']}" 'show_bookmarked_series_details'
   assert_equals_helper 'Expected screen' "$LINENO" "${screen_sequence['SHOW_SCREEN_PARAMETER']}" 2
+}
+
+function test_list_patches_without_patches()
+{
+  local target_array_list
+
+  # shellcheck disable=SC2317
+  function create_message_box()
+  {
+    return
+  }
+
+  target_array_list=()
+
+  list_patches 'Message test' target_array_list 'show_new_patches_in_the_mailing_list' ''
+  assert_equals_helper 'Expected screen' "$LINENO" "${screen_sequence['SHOW_SCREEN']}" 'dashboard'
+
+  list_patches 'Message test' target_array_list 'bookmarked_patches' ''
+  assert_equals_helper 'Expected screen' "$LINENO" "${screen_sequence['SHOW_SCREEN']}" 'dashboard'
 }
 
 invoke_shunit


### PR DESCRIPTION
This commit adds a barebones implementation of the bookmark feature. This feature refers to the ability to choose a certain patch series from a public mailing list and save it to later consultation. After bookmarking a patch series, it will become available in the 'Bookmarked Patches' screen. At the moment, the only action available is to 'Unbookmark' a patch series, but it should be kind of simple to plug in new actions.

From the implementation point of view, kw needs to maintain a local database of all bookmarked patch series and this is done by creating and managing a file inside the kw data directory (much like kw kernel-config-manager). Although efficient and simple to manage, if the feature needs scaling (change/add entities/fields), a real DBMS should be considered. Also worth mentioning that, under the hood, bookmarking a patch series downloads it first in the same manner of the 'Download' action, i.e., saves the .mbox files inside a directory defined by the user in lore.config. Unbookmarking patches series also removes them first from local storage.

Closes: #796