### PR TITLE
src: upstream_patches_ui: Fix Dashboard screen message box

### DIFF
--- a/src/upstream_patches_ui.sh
+++ b/src/upstream_patches_ui.sh
@@ -86,13 +86,13 @@ function dashboard_entry_menu()
 {
   local message_box
   local -a menu_list_string_array
+  local message_box
   local ret
 
   # TODO: Get list from liblore
   menu_list_string_array=('Registered mailing list' 'Bookmarked patches')
 
-  message_box="It looks like that you don't have any lore list registered; please"
-  message_box+=' select one or more of the below list:'
+  message_box=''
 
   create_menu_options 'Dashboard' "$message_box" 'menu_list_string_array'
   ret="$?"


### PR DESCRIPTION
The Dashboard screen message box isn't related to the screen. This commit fixes this by making the message box empty (no message), as the title 'Dashboard' is already indicative and this is a generic screen that assumes the menu options are self-descriptive. Also declared the variable used 'message_box' for safety keeping.

Closes: #805