### PR TITLE
Fix kw init wrong template name

### DIFF
--- a/documentation/man/features/init.rst
+++ b/documentation/man/features/init.rst
@@ -6,8 +6,8 @@ kw-init
 
 SYNOPSIS
 ========
-| *kw* *init* [\--template[=name]]
-| *kw* *init* [\--arch <name>][\--remote <user>@<ip>:<port>][\--target <target>]
+| *kw* *init* [(-v | \--verbose)] [\--template[=name]]
+| *kw* *init* [(-v | \--verbose)] [\--arch <name>][\--remote <user>@<ip>:<port>][\--target <target>]
 
 DESCRIPTION
 ===========
@@ -36,6 +36,9 @@ OPTIONS
 \--target <target>:
   Set the variable `default_deploy_target` from **kworkflow.config** to
   *<target>*, which can be local or remote.
+
+-v, \--verbose:
+  Verbose mode allows the user to see the commands executed under the hood.
 
 EXAMPLES
 ========

--- a/src/init.sh
+++ b/src/init.sh
@@ -68,57 +68,56 @@ function init_kw()
   notification_config_file_template="${KW_ETC_DIR}/notification_template.config"
   remote_file_template="${KW_ETC_DIR}/remote.config"
 
-  if [[ -f "$config_file_template" && -f "$build_config_file_template" ]]; then
-    mkdir -p "$PWD/$KW_DIR"
-    cp "$config_file_template" "$PWD/$KW_DIR/$name"
-    cp "$vm_config_file_template" "${PWD}/${KW_DIR}/${vm_name}"
-    cp "$build_config_file_template" "${PWD}/${KW_DIR}/${build_name}"
-    cp "$deploy_config_file_template" "${PWD}/${KW_DIR}/${deploy_name}"
-    cp "$mail_config_file_template" "${PWD}/${KW_DIR}/${mail_name}"
-    cp "$notification_config_file_template" "${PWD}/${KW_DIR}/${notification_name}"
-    cp "$remote_file_template" "${PWD}/${KW_DIR}/${remote_name}"
-
-    sed -i -e "s/USERKW/$USER/g" -e '/^#?.*/d' "$PWD/$KW_DIR/${vm_name}"
-    sed -i -e "s,SOUNDPATH,$KW_SOUND_DIR,g" -e '/^#?.*/d' "$PWD/$KW_DIR/${notification_name}"
-
-    if [[ -n "${options_values['ARCH']}" ]]; then
-      if [[ -d "$PWD/arch/${options_values['ARCH']}" || -n "${options_values['FORCE']}" ]]; then
-        set_config_value 'arch' "${options_values['ARCH']}" "${PWD}/${KW_DIR}/${build_name}"
-      elif [[ -z "${options_values['FORCE']}" ]]; then
-        complain 'This arch was not found in the arch directory'
-        complain 'You can use --force next time if you want to proceed anyway'
-        say 'Available architectures:'
-        find "$PWD/arch" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | sort -d
-      fi
-    fi
-
-    if [[ -n "${options_values['REMOTE']}" ]]; then
-      populate_remote_info "${options_values['REMOTE']}"
-      if [[ "$?" == 22 ]]; then
-        complain 'Invalid remote:' "${options_values['REMOTE']}"
-        exit 22 # EINVAL
-      else
-        set_config_value 'ssh_user' "${remote_parameters['REMOTE_USER']}"
-        set_config_value 'ssh_ip' "${remote_parameters['REMOTE_IP']}"
-        set_config_value 'ssh_port' "${remote_parameters['REMOTE_PORT']}"
-      fi
-    fi
-
-    if [[ -n "${options_values['TARGET']}" ]]; then
-      case "${options_values['TARGET']}" in
-        vm | local | remote)
-          set_config_value 'default_deploy_target' "${options_values['TARGET']}" \
-            "${PWD}/${KW_DIR}/${deploy_name}"
-          ;;
-        *)
-          complain 'Target can only be vm, local or remote.'
-          ;;
-      esac
-    fi
-
-  else
+  if [[ ! -f "$config_file_template" || ! -f "$build_config_file_template" ]]; then
     complain "No such: $config_file_template"
     exit 2 # ENOENT
+  fi
+
+  mkdir -p "$PWD/$KW_DIR"
+  cp "$config_file_template" "$PWD/$KW_DIR/$name"
+  cp "$vm_config_file_template" "${PWD}/${KW_DIR}/${vm_name}"
+  cp "$build_config_file_template" "${PWD}/${KW_DIR}/${build_name}"
+  cp "$deploy_config_file_template" "${PWD}/${KW_DIR}/${deploy_name}"
+  cp "$mail_config_file_template" "${PWD}/${KW_DIR}/${mail_name}"
+  cp "$notification_config_file_template" "${PWD}/${KW_DIR}/${notification_name}"
+  cp "$remote_file_template" "${PWD}/${KW_DIR}/${remote_name}"
+
+  sed -i -e "s/USERKW/$USER/g" -e '/^#?.*/d' "$PWD/$KW_DIR/${vm_name}"
+  sed -i -e "s,SOUNDPATH,$KW_SOUND_DIR,g" -e '/^#?.*/d' "$PWD/$KW_DIR/${notification_name}"
+
+  if [[ -n "${options_values['ARCH']}" ]]; then
+    if [[ -d "$PWD/arch/${options_values['ARCH']}" || -n "${options_values['FORCE']}" ]]; then
+      set_config_value 'arch' "${options_values['ARCH']}" "${PWD}/${KW_DIR}/${build_name}"
+    elif [[ -z "${options_values['FORCE']}" ]]; then
+      complain 'This arch was not found in the arch directory'
+      complain 'You can use --force next time if you want to proceed anyway'
+      say 'Available architectures:'
+      find "$PWD/arch" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | sort -d
+    fi
+  fi
+
+  if [[ -n "${options_values['REMOTE']}" ]]; then
+    populate_remote_info "${options_values['REMOTE']}"
+    if [[ "$?" == 22 ]]; then
+      complain 'Invalid remote:' "${options_values['REMOTE']}"
+      exit 22 # EINVAL
+    else
+      set_config_value 'ssh_user' "${remote_parameters['REMOTE_USER']}"
+      set_config_value 'ssh_ip' "${remote_parameters['REMOTE_IP']}"
+      set_config_value 'ssh_port' "${remote_parameters['REMOTE_PORT']}"
+    fi
+  fi
+
+  if [[ -n "${options_values['TARGET']}" ]]; then
+    case "${options_values['TARGET']}" in
+      vm | local | remote)
+        set_config_value 'default_deploy_target' "${options_values['TARGET']}" \
+          "${PWD}/${KW_DIR}/${deploy_name}"
+        ;;
+      *)
+        complain 'Target can only be vm, local or remote.'
+        ;;
+    esac
   fi
 
   say "Initialized kworkflow directory in $PWD/$KW_DIR based on $USER data"

--- a/src/init.sh
+++ b/src/init.sh
@@ -69,7 +69,7 @@ function init_kw()
     exit 2 # ENOENT
   fi
 
-  mkdir -p "${PWD}/${KW_DIR}"
+  mkdir --parents "${PWD}/${KW_DIR}"
   cp "$config_file_template" "${PWD}/${KW_DIR}/${name}"
   cp "$vm_config_file_template" "${PWD}/${KW_DIR}/${vm_name}"
   cp "$build_config_file_template" "${PWD}/${KW_DIR}/${build_name}"
@@ -78,8 +78,8 @@ function init_kw()
   cp "$notification_config_file_template" "${PWD}/${KW_DIR}/${notification_name}"
   cp "$remote_file_template" "${PWD}/${KW_DIR}/${remote_name}"
 
-  sed -i -e "s/USERKW/${USER}/g" -e '/^#?.*/d' "${PWD}/${KW_DIR}/${vm_name}"
-  sed -i -e "s,SOUNDPATH,${KW_SOUND_DIR},g" -e '/^#?.*/d' "${PWD}/${KW_DIR}/${notification_name}"
+  sed --in-place --expression "s/USERKW/${USER}/g" -e '/^#?.*/d' "${PWD}/${KW_DIR}/${vm_name}"
+  sed --in-place --expression "s,SOUNDPATH,${KW_SOUND_DIR},g" -e '/^#?.*/d' "${PWD}/${KW_DIR}/${notification_name}"
 
   if [[ -n "${options_values['ARCH']}" ]]; then
     if [[ -d "${PWD}/arch/${options_values['ARCH']}" || -n "${options_values['FORCE']}" ]]; then
@@ -129,7 +129,7 @@ function set_config_value()
   local value="$2"
   local path="${3:-"${PWD}/${KW_DIR}/${name}"}"
 
-  sed -i -r "s/(${option}=).*/\1${value}/" "$path"
+  sed --in-place --regexp-extended "s/(${option}=).*/\1${value}/" "$path"
 }
 
 function config_file_already_exist_question()

--- a/src/init.sh
+++ b/src/init.sh
@@ -168,9 +168,8 @@ function get_template_name()
     available_templates+=('exit kw init templates')
     say 'You may choose one of the following templates to start your configuration.'
     printf '(enter the corresponding number to choose)\n'
-    select user_choice in "${available_templates[@]^}"; do
-      [[ "$user_choice" =~ ^Skip ]] && return
-      [[ "$user_choice" =~ ^Exit ]] && exit
+    select user_choice in "${available_templates[@]}"; do
+      [[ "$user_choice" == 'exit kw init templates' ]] && exit
 
       template="${user_choice,,}"
       break

--- a/src/init.sh
+++ b/src/init.sh
@@ -65,12 +65,12 @@ function init_kw()
   remote_file_template="${KW_ETC_DIR}/remote.config"
 
   if [[ ! -f "$config_file_template" || ! -f "$build_config_file_template" ]]; then
-    complain "No such: $config_file_template"
+    complain "No such: ${config_file_template}"
     exit 2 # ENOENT
   fi
 
-  mkdir -p "$PWD/$KW_DIR"
-  cp "$config_file_template" "$PWD/$KW_DIR/$name"
+  mkdir -p "${PWD}/${KW_DIR}"
+  cp "$config_file_template" "${PWD}/${KW_DIR}/${name}"
   cp "$vm_config_file_template" "${PWD}/${KW_DIR}/${vm_name}"
   cp "$build_config_file_template" "${PWD}/${KW_DIR}/${build_name}"
   cp "$deploy_config_file_template" "${PWD}/${KW_DIR}/${deploy_name}"
@@ -78,17 +78,17 @@ function init_kw()
   cp "$notification_config_file_template" "${PWD}/${KW_DIR}/${notification_name}"
   cp "$remote_file_template" "${PWD}/${KW_DIR}/${remote_name}"
 
-  sed -i -e "s/USERKW/$USER/g" -e '/^#?.*/d' "$PWD/$KW_DIR/${vm_name}"
-  sed -i -e "s,SOUNDPATH,$KW_SOUND_DIR,g" -e '/^#?.*/d' "$PWD/$KW_DIR/${notification_name}"
+  sed -i -e "s/USERKW/${USER}/g" -e '/^#?.*/d' "${PWD}/${KW_DIR}/${vm_name}"
+  sed -i -e "s,SOUNDPATH,${KW_SOUND_DIR},g" -e '/^#?.*/d' "${PWD}/${KW_DIR}/${notification_name}"
 
   if [[ -n "${options_values['ARCH']}" ]]; then
-    if [[ -d "$PWD/arch/${options_values['ARCH']}" || -n "${options_values['FORCE']}" ]]; then
+    if [[ -d "${PWD}/arch/${options_values['ARCH']}" || -n "${options_values['FORCE']}" ]]; then
       set_config_value 'arch' "${options_values['ARCH']}" "${PWD}/${KW_DIR}/${build_name}"
     elif [[ -z "${options_values['FORCE']}" ]]; then
       complain 'This arch was not found in the arch directory'
       complain 'You can use --force next time if you want to proceed anyway'
       say 'Available architectures:'
-      find "$PWD/arch" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | sort -d
+      find "${PWD}/arch" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | sort -d
     fi
   fi
 
@@ -116,7 +116,7 @@ function init_kw()
     esac
   fi
 
-  say "Initialized kworkflow directory in $PWD/$KW_DIR based on $USER data"
+  say "Initialized kworkflow directory in ${PWD}/${KW_DIR} based on ${USER} data"
 }
 
 # This function sets variables in the config file to a specified value.
@@ -127,19 +127,19 @@ function set_config_value()
 {
   local option="$1"
   local value="$2"
-  local path="${3:-"$PWD/$KW_DIR/$name"}"
+  local path="${3:-"${PWD}/${KW_DIR}/${name}"}"
 
-  sed -i -r "s/($option=).*/\1$value/" "$path"
+  sed -i -r "s/(${option}=).*/\1${value}/" "$path"
 }
 
 function config_file_already_exist_question()
 {
   local name='kworkflow.config'
 
-  if [[ -f "$PWD/$KW_DIR/$name" ]]; then
+  if [[ -f "${PWD}/${KW_DIR}/${name}" ]]; then
     if [[ -n "${options_values['FORCE']}" ||
       $(ask_yN 'It looks like you already have a kw config file. Do you want to overwrite it?') =~ '1' ]]; then
-      mv "$PWD/$KW_DIR/$name" '/tmp'
+      mv "${PWD}/${KW_DIR}/${name}" '/tmp'
     else
       say 'Initialization aborted!'
       exit 0
@@ -250,7 +250,7 @@ function parse_init_options()
 function init_help()
 {
   if [[ "$1" == --help ]]; then
-    include "$KW_LIB_DIR/help.sh"
+    include "${KW_LIB_DIR}/help.sh"
     kworkflow_man 'init'
     return
   fi

--- a/src/init.sh
+++ b/src/init.sh
@@ -49,15 +49,11 @@ function init_kw()
 
   config_file_already_exist_question
 
-  if [[ -n "${options_values['TEMPLATE']}" ]]; then
-    get_template_name ''
-    ret="$?"
-    if [[ "$?" != 0 ]]; then
-      complain 'Invalid template, try: kw init --template'
-      return "$ret"
-    fi
-  else
-    options_values['TEMPLATE']='x86-64'
+  get_template_name ''
+  ret="$?"
+  if [[ "$?" != 0 ]]; then
+    complain 'Invalid template, try: kw init --template'
+    return "$ret"
   fi
 
   config_file_template="${config_template_folder}/${options_values['TEMPLATE']}/kworkflow_template.config"
@@ -159,7 +155,7 @@ function config_file_already_exist_question()
 function get_template_name()
 {
   local test_mode="$1"
-  local template="${options_values['TEMPLATE']:1}" # removes colon
+  local template="${options_values['TEMPLATE']}" # removes colon
   local templates_path="$KW_ETC_DIR/init_templates"
 
   if [[ -z "$template" ]]; then
@@ -211,7 +207,7 @@ function parse_init_options()
 
   options_values['ARCH']=''
   options_values['FORCE']=''
-  options_values['TEMPLATE']=''
+  options_values['TEMPLATE']='x86-64'
 
   eval "set -- $options"
 
@@ -236,7 +232,7 @@ function parse_init_options()
         ;;
       --template)
         option="$(str_strip "${2,,}")"
-        options_values['TEMPLATE']=":$option" # colon sets the option
+        options_values['TEMPLATE']="$option"
         shift 2
         ;;
       --)

--- a/tests/init_test.sh
+++ b/tests/init_test.sh
@@ -183,11 +183,11 @@ function test_force_wrong_etc_path()
 
 function test_get_template_name_noniteractive()
 {
-  options_values['TEMPLATE']=':x86-64'
+  options_values['TEMPLATE']='x86-64'
   get_template_name
   assertEquals "($LINENO)" 'x86-64' "${options_values['TEMPLATE']}"
 
-  options_values['TEMPLATE']=':rpi4-raspbian-64-cross-x86-arm'
+  options_values['TEMPLATE']='rpi4-raspbian-64-cross-x86-arm'
   get_template_name
 
   assertEquals "($LINENO)" 'rpi4-raspbian-64-cross-x86-arm' "${options_values['TEMPLATE']}"
@@ -270,12 +270,12 @@ function test_parse_init_options()
   unset options_values
   declare -gA options_values
   parse_init_options --template='rpi4-raspbian-64-cross-x86-arm'
-  assertEquals "($LINENO):" ':rpi4-raspbian-64-cross-x86-arm' "${options_values['TEMPLATE']}"
+  assertEquals "($LINENO):" 'rpi4-raspbian-64-cross-x86-arm' "${options_values['TEMPLATE']}"
 
   unset options_values
   declare -gA options_values
   parse_init_options --template
-  assertEquals "($LINENO):" ':' "${options_values['TEMPLATE']}"
+  assertEquals "($LINENO):" '' "${options_values['TEMPLATE']}"
 }
 
 invoke_shunit


### PR DESCRIPTION
Do not prepend ':' to the template name. It was necessary to set a
default template if the option `--template` is not used. This is not
necessary anymore.

Closes #748