### PR TITLE
tests: utils: Improve assert_equal_help output

### DIFF
--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -376,18 +376,25 @@ function assert_no_line_match()
 # @result_to_compare Raw output to be compared
 function assert_equals_helper()
 {
+  # colors to use to print error
+  local color_none='\033[0m'
+  local color_red='\033[1;31m'
+  local color_green='\033[1;32m'
+
   local msg="$1"
   local line="$2"
-  # See bugs section in github.com/koalaman/shellcheck/wiki/SC2178
-  # shellcheck disable=SC2178
   local expected="$3"
   local result_to_compare="$4"
 
   line=${line:-'Unknown line'}
 
-  # See bugs section in github.com/koalaman/shellcheck/wiki/SC2178
-  # shellcheck disable=2128
-  assertEquals "line $line: $msg" "$result_to_compare" "$expected"
+  if ! assertEquals "$expected" "$result_to_compare" &> /dev/null; then
+    printf '%bASSERT:%b line %s: %s\n  %bExpected Result:%b %b%s%b\n  %b-> Actual Result:%b %b%s%b\n' \
+      "${color_red}" "${color_none}" "$line" "$msg" \
+      "${color_green}" "${color_none}" "${color_green}" "$expected" "${color_none}" \
+      "${color_red}" "${color_none}" "${color_red}" "$result_to_compare" "${color_none}"
+    return "$?"
+  fi
 }
 
 # Create an invalid file path


### PR DESCRIPTION
Earlier, assert_equal_help showed the actual output and expected result next to each other:

ASSERT: line (128): expected:<31> but was:<32>

Now it prints in new lines. New format is:

ASSERT: line (128): Use this year
Expected Result: 31
-> Actual Result: 32

Also the color of Expected result is set to blue and Actual Result to Red

Closes: #554