### PR TITLE
tests: utils: Improve compare_command_sequence output

### DIFF
--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -33,6 +33,11 @@ LOCAL_TO_DEPLOY_DIR="to_deploy"
 LOCAL_REMOTE_DIR="remote"
 KERNEL_INSTALL_PLUGIN_PATH="src/plugins/kernel_install/"
 
+# Colors
+readonly KW_COLOR_NONE='\033[0m'
+readonly KW_COLOR_RED='\033[1;31m'
+readonly KW_COLOR_GREEN='\033[1;32m'
+
 function init_env()
 {
   unset -v KW_LIB_DIR KWORKFLOW
@@ -304,10 +309,12 @@ function compare_command_sequence()
 
   while read -r f; do
     if [[ "${expected_res[$count]}" != "${f}" ]]; then
-      fail "line $line, statement $count: $msg
-Expected: \"${expected_res[$count]}\"
-but got:  \"${f}\"
-"
+      if ! fail &> /dev/null; then
+        printf '%bASSERT:%b line %s, statement %d: %s\n  %bExpected:%b %b\"%s\"%b\n  %b-> but got:%b %b\"%s\"%b\n' \
+          "$KW_COLOR_RED" "$KW_COLOR_NONE" "$line" "$count" "${msg}" \
+          "$KW_COLOR_GREEN" "$KW_COLOR_NONE" "$KW_COLOR_GREEN" "${expected_res[$count]}" "$KW_COLOR_NONE" \
+          "$KW_COLOR_RED" "$KW_COLOR_NONE" "$KW_COLOR_RED" "${f}" "$KW_COLOR_NONE"
+      fi
     fi
     ((count++))
   done <<< "$result_to_compare"

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -383,11 +383,6 @@ function assert_no_line_match()
 # @result_to_compare Raw output to be compared
 function assert_equals_helper()
 {
-  # colors to use to print error
-  local color_none='\033[0m'
-  local color_red='\033[1;31m'
-  local color_green='\033[1;32m'
-
   local msg="$1"
   local line="$2"
   local expected="$3"
@@ -397,9 +392,9 @@ function assert_equals_helper()
 
   if ! assertEquals "$expected" "$result_to_compare" &> /dev/null; then
     printf '%bASSERT:%b line %s: %s\n  %bExpected Result:%b %b%s%b\n  %b-> Actual Result:%b %b%s%b\n' \
-      "$color_red" "$color_none" "$line" "$msg" \
-      "$color_green" "$color_none" "$color_green" "$expected" "$color_none" \
-      "$color_red" "$color_none" "$color_red" "$result_to_compare" "$color_none"
+      "$KW_COLOR_RED" "$KW_COLOR_NONE" "$line" "${msg}" \
+      "$KW_COLOR_GREEN" "$KW_COLOR_NONE" "$KW_COLOR_GREEN" "${expected}" "$KW_COLOR_NONE" \
+      "$KW_COLOR_RED" "$KW_COLOR_NONE" "$KW_COLOR_RED" "${result_to_compare}" "$KW_COLOR_NONE"
     return "$?"
   fi
 }


### PR DESCRIPTION
Earlier, compare_command_sequence showed the actual output and expected result
in following format:

        ASSERT:line 140, statement 1:
        Expected: ""
        but got:  "Build             19 00:03:40 00:00:06 00:00:23"

Now it prints in slightly changed format:

        ASSERT: line 140, statement 1:
          Expected: ""
          -> but got: "Build             19 00:03:40 00:00:06 00:00:23"

Also the color of Expected result is set to green and the line with actual
result is set to red