### PR TITLE
src: build: Fix failure in the save-log option

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -122,7 +122,7 @@ function build_kernel_main()
     return "$?"
   fi
 
-  command="make ${optimizations} ${llvm}ARCH=${platform_ops}${warnings}${output_path}${output_kbuild_flag}"
+  command="make ${optimizations} ${llvm}ARCH=${platform_ops}${warnings}${output_kbuild_flag}${output_path}"
 
   # Let's avoid menu question by default
   cmd_manager "$flag" "make -j ${llvm}ARCH=${platform_ops} --silent olddefconfig${output_kbuild_flag}"

--- a/tests/build_test.sh
+++ b/tests/build_test.sh
@@ -876,7 +876,7 @@ function test_kernel_build_inside_an_env()
 
   declare -a expected_cmd=(
     "make -j ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- --silent olddefconfig O=${env_output}"
-    "make -j${PARALLEL_CORES} ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- W=2 2>&1 | tee ./log O=${env_output}"
+    "make -j${PARALLEL_CORES} ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- W=2 O=${env_output} 2>&1 | tee ./log"
   )
 
   compare_command_sequence '' "$LINENO" 'expected_cmd' "$output"


### PR DESCRIPTION
Due to the recent set of updates in the env feature, kw got a regression in the save-log-to option since it tries to concatenate the 'O=...' parameter with the 'tee' command. This commit fixes this issue by adding the 'O=...' option in the right place.