### PR TITLE
src: lib: lore: Use b4 tool for downloading patch series

### DIFF
--- a/documentation/dependencies/arch.dependencies
+++ b/documentation/dependencies/arch.dependencies
@@ -25,3 +25,4 @@ dialog
 curl
 perl-xml-xpath
 coreutils
+b4

--- a/documentation/dependencies/debian.dependencies
+++ b/documentation/dependencies/debian.dependencies
@@ -27,3 +27,4 @@ dialog
 curl
 libxml-xpath-perl
 coreutils
+b4

--- a/documentation/dependencies/fedora.dependencies
+++ b/documentation/dependencies/fedora.dependencies
@@ -23,3 +23,4 @@ dialog
 curl
 perl-XML-XPath
 coreutils
+b4

--- a/src/upstream_patches_ui.sh
+++ b/src/upstream_patches_ui.sh
@@ -169,7 +169,7 @@ function show_bookmarked_series_details()
       for option in "${selected_options[@]}"; do
         case "$option" in
           'Unbookmark')
-            delete_series_from_local_storage "${series['download_dir_path']}" "${series['patch_title']}"
+            delete_series_from_local_storage "${series['download_dir_path']}" "${series['patch_url']}"
             if [[ "$?" != 0 ]]; then
               create_message_box 'Error' 'Could not delete patch(es)'$'\n'"- ${series['patch_title']}"
               continue
@@ -255,6 +255,7 @@ function show_series_details()
   local patch_metadata
   local raw_series
   local message_box
+  local output
 
   # TODO: Add apply patch
   action_list=('Bookmark' 'Download')
@@ -285,9 +286,9 @@ function show_series_details()
         case "$option" in
           'Bookmark')
             create_loading_screen_notification 'Bookmarking patch(es)'$'\n'"- ${series['patch_title']}"
-            download_series "${series['total_patches']}" "${series['patch_url']}" "${lore_config['download_to']}" "${series['patch_title']}"
+            output=$(download_series "${series['patch_url']}" "${lore_config['download_to']}")
             if [[ "$?" != 0 ]]; then
-              create_message_box 'Error' 'Could not download patch(es)'$'\n'"- ${series['patch_title']}"
+              create_message_box 'Error' 'Could not download patch(es):'$'\n'"- ${series['patch_title']}"$'\n'"[error message] ${output}"
               continue
             fi
             add_series_to_bookmark "${raw_series}" "${lore_config['download_to']}"
@@ -297,9 +298,9 @@ function show_series_details()
             ;;
           'Download')
             create_loading_screen_notification 'Downloading patch(es)'$'\n'"- ${series['patch_title']}"
-            download_series "${series['total_patches']}" "${series['patch_url']}" "${lore_config['download_to']}" "${series['patch_title']}"
+            output=$(download_series "${series['patch_url']}" "${lore_config['download_to']}")
             if [[ "$?" != 0 ]]; then
-              create_message_box 'Error' 'Could not download patch(es)'$'\n'"- ${series['patch_title']}"
+              create_message_box 'Error' 'Could not download patch(es):'$'\n'"- ${series['patch_title']}"$'\n'"[error message] ${output}"
             fi
             ;;
         esac


### PR DESCRIPTION
The download of a patch series in `upstream-patches-ui` was done using an in-house implementation. Although functional, the `b4` tool is better suited for this task, as this is a dedicated tool, and its capabilities are more vast and robust. Also, considering `b4` reliable, this results in less code to maintain.

This commits makes `upstream-patches-ui` use `b4` to do the task of downloading a series. The downloaded file is in a .mbx format and ready to be applied to a git tree, i.e., the patches are in order, there are no discussion messages and there is no cover letter. The in-house implementation did this, but there was a file for each patch and it considered the cover letter as a patch (which resulted in a bug).

Note: The in-house implementation is still used for fetching metadata from the lore.kernel.org API (e.g. for checking available mailing list and patch series). `b4` doesn't seem to handle this task, but it may be beneficial to find a way to also delegate it.

Closes: https://github.com/kworkflow/kworkflow/issues/842

Signed-off-by: David Tadokoro <davidbtadokoro@usp.br>