### PR TITLE
Add Bash and Zsh completions for `upstream-patches-ui`

### DIFF
--- a/src/_kw
+++ b/src/_kw
@@ -42,6 +42,7 @@ _kw()
     'report:Show kw pomodoro reports and kw usage statistics'
     'self-update:kw self-update mechanism'
     'ssh:SSH support'
+    'upstream-patches-ui: Open UI with lore.kernel.org archives'
     'vars:Show variables'
     'version:Show kw version'
   )
@@ -456,6 +457,11 @@ _kw_ssh()
     '(-r --remote)'{-r,--remote}'[explicitly tell which target machine to ssh into]: : ' \
     '(-s --script -c --command)'{-s,--script}'[execute a bash command in the target machine]: : ' \
     '(-c --command -s --script)'{-c,--command}'[execute a bash script in the target machine]: : '
+}
+
+_kw_upstream-patches-ui()
+{
+  _nothing
 }
 
 _kw_vars()

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -15,7 +15,7 @@ function _kw_autocomplete()
 
   kw_options['kw']='backup bd build clear-cache codestyle kernel-config-manager debug deploy
                     device diff drm explore help init maintainers mail man mount
-                    pomodoro report ssh umount up vars version config remote env'
+                    pomodoro report ssh umount up upstream-patches-ui vars version config remote env'
 
   kw_options['backup']='--restore --force --help'
 
@@ -74,6 +74,8 @@ function _kw_autocomplete()
 
   kw_options['self-update']='--unstable --help'
   kw_options['u']="${kw_options['self-update']}"
+
+  kw_options['upstream-patches-ui']='--help'
 
   kw_options['vm']='--mount --umount --up --help'
 


### PR DESCRIPTION
This PR just adds Bash and Zsh completions for the `upstream-patches-ui` feature.

Closes: #841 