### PR TITLE
src: upstream-patches-ui: Add basic feature documentation

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -178,6 +178,7 @@ man_pages = [
     ('man/features/vars', 'vars', 'view kw config values', [author], 1),
     ('man/features/vm', 'vm', 'commands to work with QEMU VMs', [author], 1),
     ('man/features/self-update', 'self-update', 'kw self-update mechanism', ['David Tadokoro, Everaldo Junior'], 1),
+    ('man/features/upstream-patches-ui', 'upstream-patches-ui', 'UI with lore.kernel.org archives', ['David Tadokoro, Rodrigo Siqueira'], 1),
 ]
 
 

--- a/documentation/man/features/upstream-patches-ui.rst
+++ b/documentation/man/features/upstream-patches-ui.rst
@@ -1,0 +1,30 @@
+======================
+kw-upstream-patches-ui
+======================
+
+.. _upstream-patches-ui-doc:
+
+SYNOPSIS
+========
+| *kw upstream-patches-ui* 
+
+DESCRIPTION
+===========
+The `kw upstream-patches-ui` feature provides an interface with the public mailing
+lists archived on `https://lore.kernel.org`. The feature can be used to just consult
+patch series from a given list, but, as it integrates with other kw features, it
+simplifies the process of reviewing patch series, like:
+
+- Applying a patch series to a git tree
+- Building the series version of the kernel
+- Deploying the series version of the kernel
+- Replying with `Reviewed-by/Tested-by`
+
+`kw upstream-patches-ui` provides routines to automate and simplify these actions.
+
+EXAMPLES
+========
+The feature is screen-focused, and to open the UI with the public mailing lists,
+just run::
+
+  kw upstream-patches-ui

--- a/documentation/man/kw.rst
+++ b/documentation/man/kw.rst
@@ -76,6 +76,15 @@ dmesg. All the debug options are intended to support remote and local targets.
 
   :ref:`kw-debug<debug-doc>`
 
+COMMAND TO INTERACT WITH THE PUBLIC MAILING LISTS
+-------------------------------------------------
+
+Some projects like the Linux kernel are collaboratively developed using
+public mailing lists. kw has a feature that provides a friendly UI to these
+lists and also integrates other kw features to allow a unified kernel development.
+
+  :ref:`kw-upstream-patches-ui<upstream-patches-ui-doc>`
+
 OTHER COMMANDS
 --------------
 This section describes a tool available in **kw** to help developers keep track

--- a/src/_kw
+++ b/src/_kw
@@ -382,7 +382,8 @@ _kw_man()
 {
   _values 'kw commands' \
     'backup' 'build' 'codestyle' 'config' 'debug' 'deploy' 'device' 'diff' 'drm' 'env' \
-    'explore' 'init' 'mail' 'maintainers' 'pomodoro' 'remote' 'report' 'self-update' 'ssh' 'vars'
+    'explore' 'init' 'mail' 'maintainers' 'pomodoro' 'remote' 'report' 'self-update' 'ssh' \
+    'upstream-patches-ui' 'vars'
 }
 
 _kw_p() { _kw_pomodoro }

--- a/src/upstream_patches_ui.sh
+++ b/src/upstream_patches_ui.sh
@@ -412,8 +412,9 @@ function register_mailing_list()
 function upstream_patches_ui_help()
 {
   if [[ "$1" == --help ]]; then
-    # TODO: Make man page for this feature
-    exit
+    include "${KW_LIB_DIR}/help.sh"
+    kworkflow_man 'upstream-patches-ui'
+    return
   fi
   printf '%s\n' 'kw upstream_patches_ui:' \
     '  upstream_patches_ui - Open UI with lore.kernel.org archives'


### PR DESCRIPTION
This commit adds some `kw upstream-patches-ui` documentation:
- Dedicated man page
- Summary of feature in main kw man page
- Add Zsh completion for `kw man`

Closes: #830