### PR TITLE
src: kw_ssh: adding support to send and get files via kw ssh

### DIFF
--- a/documentation/man/features/ssh.rst
+++ b/documentation/man/features/ssh.rst
@@ -9,6 +9,8 @@ SYNOPSIS
 | *kw* (*s* | *ssh*) [(-s | \--script) <script-path>] [\--verbose]
 | *kw* (*s* | *ssh*) [(-c | \--command) <string-command>] [\--verbose]
 | *kw* (*s* | *ssh*) [(-r | \--remote) <USER@IP:PORT | CONFIG_HOST_NAME>] [\--verbose]
+| *kw* (*s* | *ssh*) \--send <from-local-path> [\--to <to-remote-path>] [\--verbose]
+| *kw* (*s* | *ssh*) \--get <from-remote-path> [\--to <to-local-path>] [\--verbose]
 
 DESCRIPTION
 ===========
@@ -34,6 +36,18 @@ OPTIONS
   its progress. This functionality is very useful during the debugging process, allowing
   you to identify possible errors more easily.
 
+\--send <from-local-path> \--to <to-remote-path>:
+  Transfers a file or directory located in *<from-local-path>* to the remote destination
+  specified in *<remote-path>*. If the user does not supply the ``--to`` option, the file or
+  directory specified in *<from-local-path>* will be transferred to the user's home folder
+  on the remote destination.
+
+\--get <from-remote-path> \--to <to-local-path>:
+  Gets a file or directory from the specified remote path *<from-remote-path>* and saves
+  it to the local machine at the specified path *<to-local-path>*. When the user does not
+  specify the ``--to`` option, the default destination directory is automatically set
+  to the current directory where the user is located.
+
 EXAMPLES
 ========
 
@@ -44,3 +58,11 @@ After you start your VM you can ssh into it with::
 
   kw s -c "dmesg -wH"
   kw s
+
+If you want to send a file or directory to a remote machine::
+
+  kw s --send /path/to/file/or/folder --to /tmp/
+
+If you want to get a file or directory from a remote machine::
+
+  kw s --get /path/to/file/or/folder --to /path/to/save

--- a/src/_kw
+++ b/src/_kw
@@ -456,11 +456,19 @@ _kw_self-update()
 _kw_s() { _kw_ssh }
 _kw_ssh()
 {
+  local to=''
+
+  if ((words[(I)--send|--get])); then
+    to='--to[specify the destination path]: : '
+  fi
+
   _arguments : \
     '(--verbose)--verbose[enable verbose mode]' \
-    '(-r --remote)'{-r,--remote}'[explicitly tell which target machine to ssh into]: : ' \
-    '(-s --script -c --command)'{-s,--script}'[execute a bash command in the target machine]: : ' \
-    '(-c --command -s --script)'{-c,--command}'[execute a bash script in the target machine]: : '
+    '(-s --script -c --command --send --get)'{-s,--script}'[execute a bash command in the target machine]: : ' \
+    '(-c --command -s --script --send --get)'{-c,--command}'[execute a bash script in the target machine]: : ' \
+    '(-s --script -c --command --get)--send[send a file or directory to the remote machine]: : ' \
+    '(-s --script -c --command --send)--get[get a file or directory from the remote machine]: : ' \
+    $to
 }
 
 _kw_patch-hub()

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -35,7 +35,7 @@ function _kw_autocomplete()
   kw_options['diff']='--no-interactive'
   kw_options['df']="${kw_options['diff']}"
 
-  kw_options['ssh']='--remote --script --command --verbose --help'
+  kw_options['ssh']='--remote --script --command --verbose --help --send --get --to'
   kw_options['s']="${kw_options['ssh']}"
 
   kw_options['self-update']='--unstable --help --verbose'

--- a/src/kw_ssh.sh
+++ b/src/kw_ssh.sh
@@ -24,6 +24,7 @@ function kw_ssh_main()
   local remote_file
   local remote_file_host
   local ssh_compose='ssh'
+  local transfer_type=''
 
   parser_ssh_options "$@"
   if [[ "$?" -gt 0 ]]; then
@@ -40,6 +41,9 @@ function kw_ssh_main()
   flag=${options_values['TEST_MODE']}
   script_path=${options_values['SCRIPT']}
   cmd=${options_values['CMD']}
+  send=${options_values['SEND']}
+  get=${options_values['GET']}
+  to=${options_values['TO']}
 
   [[ -n "${options_values['VERBOSE']}" ]] && flag='VERBOSE'
   flag=${flag:-'SILENT'}
@@ -57,6 +61,13 @@ function kw_ssh_main()
 
   if [[ -n "$script_path" ]]; then
     run_script_in_the_remote "$flag"
+    return "$?"
+  fi
+
+  [[ -n "$get" ]] && transfer_type='get'
+  [[ -n "$send" ]] && transfer_type='send'
+  if [[ -n ${transfer_type} ]]; then
+    ssh_transfer_file "$flag" "$transfer_type"
     return "$?"
   fi
 
@@ -112,6 +123,127 @@ function run_command_in_the_remote()
   cmd_manager "$flag" "$ssh_compose"
 }
 
+# This function transfers a local file or directory to a
+# specified remote destination or gets a file or directory
+# from the specified remote path and saves it to the local
+# machine at the specified path.
+#
+# @flag: Expecting a flag, by default, cmd_manager does not
+# expects flags and always show the command. For more details
+# see the function `cmd_manager` in `src/lib/kwlib.sh`.
+# @transfer_type: Transfer type, either 'send' or 'get'.
+#
+# Returns:
+# return 2 (ENOENT): Indicates source file/directory doesn't exist.
+# return 125 (ECANCELED): Indicates user-cancelled operation.
+function ssh_transfer_file()
+{
+  local flag="$1"
+  local transfer_type="$2"
+  local user
+  local port
+  local remote
+  local remote_file
+  local remote_file_host
+  local transfer_path
+  local to_path
+  local cmd
+  local ssh_compose
+  local filename
+  local filename_path
+  local exist_path
+  local rsync_options
+
+  flag=${flag:-'SILENT'}
+
+  user="${remote_parameters['REMOTE_USER']}"
+  port="${remote_parameters['REMOTE_PORT']}"
+  remote="${remote_parameters['REMOTE_IP']}"
+  remote_file="${remote_parameters['REMOTE_FILE']}"
+  remote_file_host="${remote_parameters['REMOTE_FILE_HOST']}"
+
+  send=${options_values['SEND']}
+  get=${options_values['GET']}
+  to_path=${options_values['TO']:-'.'}
+
+  transfer_path="${get:-$send}"
+  ssh_compose=$(handle_ssh)
+  filename=$(basename "$transfer_path")
+  exist_path="$to_path"
+
+  case "$transfer_type" in
+    'send')
+      cmd_manager "$flag" "${ssh_compose} '[[ -f ${to_path}/${filename} ]]'"
+
+      if [[ "$?" -eq 0 ]]; then
+        complain "The '${filename}' file already exists on the remote machine."
+        if [[ $(ask_yN 'Do you wish to overwrite it?') =~ '0' ]]; then
+          return 125 # ECANCELED
+        fi
+      fi
+
+      if [[ ! -e "$transfer_path" ]]; then
+        complain "The file or directory '${transfer_path}' does not exist."
+        return 2 # ENOENT
+      fi
+
+      cmd="rsync -avzq ${transfer_path} -e "
+      rsync_options="'ssh -p ${port}' ${user}@${remote}:${to_path}"
+
+      if [[ -f "$remote_file" ]]; then
+        rsync_options="'ssh -F ${remote_file}' ${remote_file_host}:${to_path}"
+      fi
+
+      cmd+="$rsync_options"
+
+      cmd_manager "$flag" "$cmd"
+
+      rsync_return_code="$?"
+      if [[ "$rsync_return_code" -ne 0 ]]; then
+        complain "An error occurred while uploading the file(s). rsync return code: ${rsync_return_code}"
+        return "$rsync_return_code"
+      fi
+
+      success 'File(s) uploaded successfully.'
+      ;;
+    'get')
+      cmd_manager "$flag" "${ssh_compose} [[ ! -e '${transfer_path}' ]]"
+      if [[ "$?" -eq 0 ]]; then
+        complain "The file or directory '${transfer_path}' does not exist on the remote machine."
+      fi
+
+      if [[ -f "${to_path}/${filename}" ]]; then
+        complain "The '${filename}' file already exists."
+
+        if [[ $(ask_yN 'Do you wish to overwrite it?') =~ '0' ]]; then
+          return 125 # ECANCELED
+        fi
+      fi
+
+      cmd='rsync -e '
+      rsync_options="'ssh -p ${port}' -avzq ${user}@${remote}:${transfer_path} ${to_path}"
+
+      if [[ -f "$remote_file" ]]; then
+        rsync_options="'ssh -F ${remote_file}' -avzq ${remote_file_host}:${transfer_path} ${to_path}"
+      fi
+
+      cmd+="$rsync_options"
+
+      cmd_manager "$flag" "$cmd"
+      rsync_return_code="$?"
+      if [[ "$rsync_return_code" -ne 0 ]]; then
+        complain "An error occurred while uploading the file(s). rsync return code: ${rsync_return_code}"
+        exit "$rsync_return_code"
+      fi
+
+      success 'The file(s) have been successfully received.'
+      ;;
+    *)
+      complain "Invalid transfer type: '${transfer_type}'"
+      ;;
+  esac
+}
+
 function run_script_in_the_remote()
 {
   local script_path
@@ -149,7 +281,7 @@ function ssh_remote()
 function parser_ssh_options()
 {
   local options
-  local long_options='help,test_mode,script:,command:,remote:,verbose'
+  local long_options='help,test_mode,script:,command:,remote:,verbose,send:,get:,to:'
   local short_options='h,s:,c:,r:'
   local transition_variables
 
@@ -161,6 +293,9 @@ function parser_ssh_options()
   fi
 
   options_values['SCRIPT']=''
+  options_values['SEND']=''
+  options_values['GET']=''
+  options_values['TO']=''
   options_values['COMMAND']=''
   options_values['VERBOSE']=''
   options_values['TEST_MODE']=''
@@ -194,6 +329,18 @@ function parser_ssh_options()
         options_values['VERBOSE']=1
         shift
         ;;
+      --send)
+        options_values['SEND']="$2"
+        shift 2
+        ;;
+      --get)
+        options_values['GET']="$2"
+        shift 2
+        ;;
+      --to)
+        options_values['TO']="$2"
+        shift 2
+        ;;
       --help | -h)
         ssh_help "$1"
         exit
@@ -225,5 +372,7 @@ function ssh_help()
     '  ssh (--verbose) - enable verbose for ssh operation' \
     '  ssh (-r | --remote) - ssh command line remote' \
     '  ssh (-s | --script) <script-path> - Script path in the host that will run in the target' \
-    '  ssh (-c | --command) <string-command> - Command to be executed in the target machine'
+    '  ssh (-c | --command) <string-command> - Command to be executed in the target machine' \
+    '  ssh (--send <local-path> [--to <remote-path>])- Sends a file or directory from the local machine to the specified remote path.' \
+    '  ssh (--get <remote-path> [--to <local-path>])- Gets a file or directory from the specified remote path and saves it to the local machine.'
 }


### PR DESCRIPTION
After this commit the user will be allowed to send and get files via SSH.
Users can now use the kw ssh --send command to send files or folders
to a remote machine. Likewise, the kw ssh --get command allows users
to get files or folders from the remote machine.

Closes: #662