### PR TITLE
documentation: tutorials: kw-env: fixing typo

### DIFF
--- a/documentation/tutorials/kw-env.rst
+++ b/documentation/tutorials/kw-env.rst
@@ -59,7 +59,7 @@ Switch between envs
 
 Let's say that you want to switch from one config to another, you can just use::
 
- kw env --use X86_32_CONFIG_TO_TEST_MACHINE_P]
+ kw env --use X86_32_CONFIG_TO_TEST_MACHINE_P
 
 If you want to check if everything looks correct, you can use::
 


### PR DESCRIPTION
The command `kw env --use X86_32_CONFIG_TO_TEST_MACHINE_P]` had an extra closing square bracket at the end, which was causing an error. This commit removes the unnecessary bracket and fixes the command.