### PR TITLE
Add 'Settings' menu for `upstream-patches-ui`

### DIFF
--- a/etc/dialog_help/directory_selection_help.txt
+++ b/etc/dialog_help/directory_selection_help.txt
@@ -1,0 +1,11 @@
+[directory_selection_help_box_title]:
+Directory Selection Help
+[directory_selection_help_message_box]:
+There are 3 regions in the Directory Selection screen:
+- [Upper Box]: list of directories in the current path.
+- [Lower Box]: the current path (input box).
+- [Buttons]: "OK" to confirm directory path, "Cancel" to cancel selection and "Help" to show this screen.
+
+To move between the regions, use the <TAB> key.
+To complete the current path with the highlighted directory, use the <SPACE> key.
+Typing while in the Upper Box or the Lower Box alters the current path.

--- a/etc/lore.config
+++ b/etc/lore.config
@@ -1,5 +1,13 @@
-# Specify which list the user is following
-default_ui=dialog
-dialog_layout=black_and_white
+# This file holds configurations related to the 'upstream_patches_ui' feature
+
+# Registered mailing lists
 lists=
+
+# Target directory for downloading patches
 download_to=/tmp/kw_download
+
+# Default UI used by the feature (dialog, web, etc.)
+default_ui=dialog
+
+# Theme used by the dialog UI
+dialog_layout=black_and_white

--- a/etc/lore.config
+++ b/etc/lore.config
@@ -11,3 +11,9 @@ default_ui=dialog
 
 # Theme used by the dialog UI
 dialog_layout=black_and_white
+
+# Linux kernel source tree path
+kernel_tree_path=
+
+# Target branch of kernel tree for basing application of patches
+kernel_tree_branch=

--- a/etc/lore.config
+++ b/etc/lore.config
@@ -4,7 +4,7 @@
 lists=
 
 # Target directory for downloading patches
-download_to=/tmp/kw_download
+save_patches_to=/tmp/kw_download
 
 # Default UI used by the feature (dialog, web, etc.)
 default_ui=dialog

--- a/src/lib/dialog_ui.sh
+++ b/src/lib/dialog_ui.sh
@@ -194,7 +194,7 @@ function create_simple_checklist()
 
   for item in "${_menu_list_string_array[@]}"; do
     item=$(str_escape_single_quotes "$item")
-    if [[ -n "${_check_statuses}" && -n ${_check_statuses["$index"]} ]]; then
+    if [[ "${_check_statuses["$index"]}" == 1 ]]; then
       cmd+=" $'${item}' '' 'on'"
     else
       cmd+=" $'${item}' '' 'off'"

--- a/src/lib/lore.sh
+++ b/src/lib/lore.sh
@@ -710,3 +710,25 @@ function extract_message_id_from_url()
   message_id=$(printf '%s' "$series_url" | cut --delimiter '/' -f5)
   printf '%s' "$message_id"
 }
+
+# This function sets a configuration in a 'lore.config' file.
+#
+# @setting: Name of the setting to be updated
+# @new_value: New value to be set
+# @lore_config_path: Path to the target 'lore.config' file
+#
+# Return:
+# Returns 2 (ENOENT) if `@lore_config_path` doesn't exist and 0, otherwise.
+function save_new_lore_config()
+{
+  local setting="$1"
+  local new_value="$2"
+  local lore_config_path="$3"
+
+  if [[ ! -f "$lore_config_path" ]]; then
+    complain "${lore_config_path}: file doesn't exists"
+    return 2 # ENOENT
+  fi
+
+  sed --in-place --regexp-extended "s<(${setting}=).*<\1${new_value}<" "$lore_config_path"
+}

--- a/src/upstream_patches_ui.sh
+++ b/src/upstream_patches_ui.sh
@@ -63,6 +63,10 @@ upstream_patches_ui_main()
         show_bookmarked_patches
         ret="$?"
         ;;
+      'settings')
+        show_settings_screen
+        ret="$?"
+        ;;
       'show_series_details')
         show_series_details "${screen_sequence['SHOW_SCREEN_PARAMETER']}" list_of_mailinglist_patches
         ret="$?"
@@ -87,8 +91,7 @@ function dashboard_entry_menu()
   local message_box
   local ret
 
-  # TODO: Get list from liblore
-  menu_list_string_array=('Registered mailing list' 'Bookmarked patches')
+  menu_list_string_array=('Registered mailing list' 'Bookmarked patches' 'Settings')
 
   message_box=''
 
@@ -105,6 +108,9 @@ function dashboard_entry_menu()
       ;;
     2) # Bookmarked patches
       screen_sequence['SHOW_SCREEN']='bookmarked_patches'
+      ;;
+    3) # Settings
+      screen_sequence['SHOW_SCREEN']='settings'
       ;;
   esac
 }
@@ -189,6 +195,33 @@ function show_bookmarked_series_details()
     3) # Return
       screen_sequence['SHOW_SCREEN']='bookmarked_patches'
       screen_sequence['RETURNING']=1
+      ;;
+  esac
+}
+
+# Screen that shows all types of settings available.
+function show_settings_screen()
+{
+  local -a menu_list_string_array
+  local ret
+
+  menu_list_string_array=('Register/Unregister Mailing Lists')
+  create_menu_options 'Settings' '' 'menu_list_string_array' 1
+  ret="$?"
+
+  case "$ret" in
+    0) # OK
+      case "$menu_return_string" in
+        1) # Register/Unregister Mailing Lists
+          screen_sequence['SHOW_SCREEN']='register'
+          ;;
+      esac
+      ;;
+    1) # Exit
+      handle_exit "$ret"
+      ;;
+    3) # Return
+      screen_sequence['SHOW_SCREEN']='dashboard'
       ;;
   esac
 }

--- a/src/upstream_patches_ui.sh
+++ b/src/upstream_patches_ui.sh
@@ -8,6 +8,7 @@ include "${KW_LIB_DIR}/kw_config_loader.sh"
 include "${KW_LIB_DIR}/lib/dialog_ui.sh"
 include "${KW_LIB_DIR}/lib/lore.sh"
 include "${KW_LIB_DIR}/kwio.sh"
+include "${KW_LIB_DIR}/kwlib.sh"
 
 declare -ga registered_lists
 declare -ga patches_from_mailing_list
@@ -205,13 +206,21 @@ function show_settings_screen()
   local -a menu_list_string_array
   local new_value
   local output
+  declare -A branches
+  local index
+  local -a check_statuses
   local ret
 
   if [[ ! -f "${lore_config_path}" ]]; then
     lore_config_path="${KW_ETC_DIR}/lore.config"
   fi
 
-  menu_list_string_array=('Register/Unregister Mailing Lists' 'Save Patches To')
+  menu_list_string_array=(
+    'Register/Unregister Mailing Lists'
+    'Save Patches To'
+    'Kernel Tree Path'
+    'Kernel Tree Target Branch'
+  )
   create_menu_options 'Settings' '' 'menu_list_string_array' 1
   ret="$?"
 
@@ -247,6 +256,57 @@ function show_settings_screen()
               ;;
           esac
 
+          # Just to be safe
+          screen_sequence['SHOW_SCREEN']='settings'
+          ;;
+        3) # Kernel Tree Path
+          create_directory_selection_screen "${lore_config['kernel_tree_path']}" 'Select Linux kernel source tree'
+          case "$?" in
+            0) # OK
+              new_value=$(printf '%s' "$menu_return_string" | sed 's/\/$//')
+              if ! is_kernel_root "$new_value"; then
+                create_message_box 'Error' "${new_value}: Not a Linux kernel source tree."
+              else
+                save_new_lore_config 'kernel_tree_path' "$new_value" "$lore_config_path"
+                # As we changed the kernel tree, we set the target branch to empty
+                save_new_lore_config 'kernel_tree_branch' '' "$lore_config_path"
+                # As we altered the settings, we need to reload lore.config
+                load_lore_config
+              fi
+              ;;
+            1) # Cancel
+              ;;
+            2) # Help
+              create_directory_selection_help_screen
+              ;;
+          esac
+          # Just to be safe
+          screen_sequence['SHOW_SCREEN']='settings'
+          ;;
+        4) # Kernel Tree Target Branch
+          if [[ -z "${lore_config['kernel_tree_path']}" ]]; then
+            create_message_box 'Error' 'You need to set "Kernel Tree Path" first.'
+          else
+            get_git_repository_branches "${lore_config['kernel_tree_path']}" 'branches'
+            index=0
+            for branch in "${!branches[@]}"; do
+              [[ "${lore_config['kernel_tree_branch']}" == "$branch" ]] && check_statuses["$index"]=1
+              ((index++))
+            done
+            message_box='Select the target branch of the Linux kernel tree.'$'\n'
+            message_box+='When applying patches, this branch will be used as base.'
+            create_choice_list_screen 'Kernel Tree Target Branch' "$message_box" 'branches' 'check_statuses'
+            case "$?" in
+              0) # OK
+                new_value=$(printf '%s' "$menu_return_string" | sed 's/\/$//')
+                save_new_lore_config 'kernel_tree_branch' "$new_value" "$lore_config_path"
+                # As we altered the settings, we need to reload lore.config
+                load_lore_config
+                ;;
+              1) # Cancel
+                ;;
+            esac
+          fi
           # Just to be safe
           screen_sequence['SHOW_SCREEN']='settings'
           ;;

--- a/tests/lib/dialog_ui_test.sh
+++ b/tests/lib/dialog_ui_test.sh
@@ -94,7 +94,7 @@ function test_create_simple_checklist_rely_on_some_default_options()
   local menu_title='kunit test inside kw'
   local menu_message_box="This shouldn't be a useful dialog's screen message box"
   local -a menu_list_string_array=('Checklist 1' 'Checklist 2')
-  local -a check_statuses=(1 '')
+  local -a check_statuses=(1 0)
   local expected_cmd="dialog --backtitle \$'${KW_UPSTREAM_TITLE}'"
   local output
 
@@ -112,7 +112,7 @@ function test_create_simple_checklist_use_all_options()
   local menu_title='kunit test inside kw'
   local menu_message_box="This shouldn't be a useful dialog's screen message box"
   local -a menu_list_string_array=('Checklist 1' 'Checklist 2')
-  local -a check_statuses=(1 '')
+  local -a check_statuses=(1 0)
   local expected_cmd="dialog --backtitle \$'${KW_UPSTREAM_TITLE}'"
   local output
 

--- a/tests/lib/dialog_ui_test.sh
+++ b/tests/lib/dialog_ui_test.sh
@@ -17,6 +17,8 @@ function setUp()
 
   mkdir -p "$TMP_DIR"
   mkdir -p "$KW_ETC_DIR"
+
+  cp --recursive 'etc/dialog_help' "${TMP_DIR}/dialog_help"
   # Let's run all test in a well-contained folder
   cd "${TMP_DIR}" || {
     fail "($LINENO): setUp: It was not possible to move into ${TMP_DIR}"
@@ -176,6 +178,57 @@ function test_create_message_box_use_all_options()
   expected_cmd+=" '1234' '4321'"
   output=$(create_message_box "${box_title}" "${message_box}" '1234' '4321' 'TEST_MODE')
   assert_equals_helper 'Expected message box with all custom options' "$LINENO" "$output" "${expected_cmd}"
+}
+
+function test_create_directory_selection_screen_rely_on_some_default_options()
+{
+  local starting_path='/some/creative/path'
+  local box_title="Choose 'a' Directory!"
+  local expected_cmd
+  local output
+
+  expected_cmd=" dialog --backtitle $'${KW_UPSTREAM_TITLE}'"
+  expected_cmd+=" --title $'Choose \'a\' Directory!' --clear --colors"
+  expected_cmd+=" --help-button --dselect '${starting_path}'"
+  expected_cmd+=" '15' '80'"
+  output=$(create_directory_selection_screen "${starting_path}" "${box_title}" '' '' 'TEST_MODE')
+  assert_equals_helper 'Expected directory selection with some default options' "$LINENO" "$expected_cmd" "$output"
+}
+
+function test_create_directory_selection_screen_use_all_options()
+{
+  local starting_path='/some/creative/path'
+  local box_title="Choose 'a' Directory!"
+  local expected_cmd
+  local output
+
+  expected_cmd=" dialog --backtitle $'${KW_UPSTREAM_TITLE}'"
+  expected_cmd+=" --title $'Choose \'a\' Directory!' --clear --colors"
+  expected_cmd+=" --help-button --dselect '${starting_path}'"
+  expected_cmd+=" '2718' '281828'"
+  output=$(create_directory_selection_screen "${starting_path}" "${box_title}" '2718' '281828' 'TEST_MODE')
+  assert_equals_helper 'Expected directory selection with all custom options' "$LINENO" "$expected_cmd" "$output"
+}
+
+function test_create_help_screen()
+{
+  local expected_cmd
+  local output
+
+  create_help_screen 'fake_screen' 'TEST_MODE'
+  assert_equals_helper 'Invalid screen name should return 2' "$LINENO" 2 "$?"
+
+  expected_cmd=" dialog --backtitle $'${KW_UPSTREAM_TITLE}' --title $'Directory Selection Help' --clear --colors --msgbox"
+  expected_cmd+=" $'There are 3 regions in the Directory Selection screen:"$'\n'
+  expected_cmd+='- [Upper Box]: list of directories in the current path.'$'\n'
+  expected_cmd+='- [Lower Box]: the current path (input box).'$'\n'
+  expected_cmd+='- [Buttons]: "OK" to confirm directory path, "Cancel" to cancel selection and "Help" to show this screen.'$'\n'$'\n'
+  expected_cmd+='To move between the regions, use the <TAB> key.'$'\n'
+  expected_cmd+='To complete the current path with the highlighted directory, use the <SPACE> key.'$'\n'
+  expected_cmd+="Typing while in the Upper Box or the Lower Box alters the current path.'"
+  expected_cmd+=" '15' '70'"
+  output=$(create_help_screen 'directory_selection' 'TEST_MODE')
+  assert_equals_helper 'Wrong help screen for Directory Selection' "$LINENO" "$expected_cmd" "$output"
 }
 
 function test_prettify_string_failures()

--- a/tests/lib/dialog_ui_test.sh
+++ b/tests/lib/dialog_ui_test.sh
@@ -231,6 +231,42 @@ function test_create_help_screen()
   assert_equals_helper 'Wrong help screen for Directory Selection' "$LINENO" "$expected_cmd" "$output"
 }
 
+function test_create_choice_list_screen_rely_on_some_default_options()
+{
+  local box_title="Make 'a' choice!"
+  local message_box="Select \`one' of the below options."
+  declare -A choices=(['choice1']='good choice' ['choice2']='bad choice' ['choice3']='a choice is a choice')
+  local -a check_statuses=('' 1 '')
+  local expected_cmd
+  local output
+
+  expected_cmd=" dialog --backtitle $'${KW_UPSTREAM_TITLE}'"
+  expected_cmd+=" --title $'Make \'a\' choice!' --clear --colors"
+  expected_cmd+=" --radiolist $'Select \`one\' of the below options.'"
+  expected_cmd+=" '${EXPECTED_DEFAULT_HEIGHT}' '${EXPECTED_DEFAULT_WIDTH}' '0'"
+  expected_cmd+=" $'choice1' $'${choices['choice1']}' 'off' $'choice2' $'${choices['choice2']}' 'on' $'choice3' $'${choices['choice3']}' 'off'"
+  output=$(create_choice_list_screen "$box_title" "$message_box" 'choices' 'check_statuses' '' '' 'TEST_MODE')
+  assert_equals_helper 'Expected choice list with some default options' "$LINENO" "$expected_cmd" "$output"
+}
+
+function test_create_choice_list_screen_use_all_options()
+{
+  local box_title="Make 'a' choice!"
+  local message_box="Select \`one' of the below options."
+  declare -A choices=(['choice1']='good choice' ['choice2']='bad choice' ['choice3']='a choice is a choice')
+  local -a check_statuses=('' 1 '')
+  local expected_cmd
+  local output
+
+  expected_cmd=" dialog --backtitle $'${KW_UPSTREAM_TITLE}'"
+  expected_cmd+=" --title $'Make \'a\' choice!' --clear --colors"
+  expected_cmd+=" --radiolist $'Select \`one\' of the below options.'"
+  expected_cmd+=" '17041998' '10300507' '0'"
+  expected_cmd+=" $'choice1' $'${choices['choice1']}' 'off' $'choice2' $'${choices['choice2']}' 'on' $'choice3' $'${choices['choice3']}' 'off'"
+  output=$(create_choice_list_screen "$box_title" "$message_box" 'choices' 'check_statuses' '17041998' '10300507' 'TEST_MODE')
+  assert_equals_helper 'Expected choice list with all custom options' "$LINENO" "$expected_cmd" "$output"
+}
+
 function test_prettify_string_failures()
 {
   prettify_string

--- a/tests/samples/lore_sample.config
+++ b/tests/samples/lore_sample.config
@@ -1,0 +1,4 @@
+default_ui=dialog
+dialog_layout=black_and_white
+lists=
+download_path=/tmp/kw_download

--- a/tests/upstream_patches_ui_test.sh
+++ b/tests/upstream_patches_ui_test.sh
@@ -170,4 +170,19 @@ function test_list_patches_without_patches()
   assert_equals_helper 'Expected screen' "$LINENO" "${screen_sequence['SHOW_SCREEN']}" 'dashboard'
 }
 
+function test_show_settings_screen()
+{
+  declare -A screen_sequence=(['SHOW_SCREEN']='')
+
+  # shellcheck disable=SC2317
+  function create_menu_options()
+  {
+    # 'Settings' sub-menu chosen
+    menu_return_string=1
+  }
+
+  show_settings_screen
+  assert_equals_helper 'Should set next screen to "register"' "$LINENO" 'register' "${screen_sequence['SHOW_SCREEN']}"
+}
+
 invoke_shunit

--- a/tests/upstream_patches_ui_test.sh
+++ b/tests/upstream_patches_ui_test.sh
@@ -182,7 +182,7 @@ function test_show_settings_screen()
   }
 
   show_settings_screen
-  assert_equals_helper 'Should set next screen to "register"' "$LINENO" 'register' "${screen_sequence['SHOW_SCREEN']}"
+  assert_equals_helper 'Should set next screen to "manage_mailing_lists"' "$LINENO" 'manage_mailing_lists' "${screen_sequence['SHOW_SCREEN']}"
 }
 
 invoke_shunit


### PR DESCRIPTION
This PR has the purpose of adding a 'Settings' menu for the `upstream-patches-ui` feature. A 'Settings' menu refers to an interface inside the feature to all its settings, mostly located in the `lore.config` file.

The 'Settings' menu is located in the 'Dashboard' screen, and, inside it, there is a submenu for each setting. At the moment, only the 'lists' and 'download_path' settings are configurable via the feature.

It is worth noting that any future setting (be it inside `lore.config` or not) should have a dedicated sub-menu inside the 'Settings' menu.

Closes: #829 
Closes: #811  