### PR TITLE
src: deploy: Ensure that deploy setup run in A/B partition

### DIFF
--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -26,6 +26,7 @@ include "$KW_LIB_DIR/signal_manager.sh"
 # on the host that will be used for centralizing files required for the new
 # deploy.
 REMOTE_KW_DEPLOY='/opt/kw'
+KW_STATUS_BASE_PATH='/boot'
 KW_DEPLOY_TMP_FILE='/tmp/kw'
 REMOTE_INTERACE_CMD_PREFIX="bash $REMOTE_KW_DEPLOY/remote_deploy.sh --kw-path '$REMOTE_KW_DEPLOY' --kw-tmp-files '$KW_DEPLOY_TMP_FILE'"
 
@@ -372,7 +373,7 @@ function update_status_log()
   flag=${flag:-'SILENT'}
 
   log_date=$(date +'%m/%d/%Y-%H:%M:%S')
-  status_cmd="printf '%s;%s\n' '$target' '$log_date' >> $REMOTE_KW_DEPLOY/status"
+  status_cmd="printf '%s;%s\n' '$target' '$log_date' >> ${KW_STATUS_BASE_PATH}/kw_status"
 
   case "$target" in
     2) # LOCAL_TARGET
@@ -399,7 +400,7 @@ function check_setup_status()
 {
   local target="$1"
   local flag="$2"
-  local cmd="test -f $REMOTE_KW_DEPLOY/status"
+  local cmd="test -f ${KW_STATUS_BASE_PATH}/kw_status"
   local ret
 
   flag=${flag:-'SILENT'}

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -22,6 +22,7 @@ function setUp()
   export DEPLOY_SCRIPT="$test_path/$kernel_install_path/deploy.sh"
   export KW_PLUGINS_DIR="$PWD/src/plugins"
   export REMOTE_KW_DEPLOY='/opt/kw'
+  export KW_STATUS_BASE_PATH="$SHUNIT_TMPDIR"
 
   KW_LIB_DIR="$PWD/$SAMPLES_DIR"
 
@@ -336,15 +337,14 @@ function test_update_status_log()
 
   # Remote
   log_date=$(date)
-  cmd="\"printf '%s;%s\n' '3' '$log_date' >> $REMOTE_KW_DEPLOY/status\""
+  cmd="\"printf '%s;%s\n' '3' '$log_date' >> ${KW_STATUS_BASE_PATH}/kw_status\""
   output=$(update_status_log 3 'TEST_MODE')
 
   assert_equals_helper 'Status file remote' "$LINENO" "$ssh_prefix $cmd" "$output"
 
   # Local
-  REMOTE_KW_DEPLOY="$SHUNIT_TMPDIR"
   update_status_log 2
-  output=$(cat "$SHUNIT_TMPDIR/status")
+  output=$(cat "$SHUNIT_TMPDIR/kw_status")
   expected_data='2;12/31/2021-09:49:21'
 
   assert_equals_helper 'Status file data' "$LINENO" "$expected_data" "$output"
@@ -354,7 +354,7 @@ function test_check_setup_status()
 {
   local output
   local expected_cmd
-  local cmd_check="test -f $REMOTE_KW_DEPLOY/status"
+  local cmd_check="test -f ${KW_STATUS_BASE_PATH}/kw_status"
   local ssh_prefix='ssh -p 3333 juca@127.0.0.1 sudo'
 
   # Remote
@@ -370,7 +370,7 @@ function test_check_setup_status()
   assert_equals_helper 'Wrong return value' "($LINENO)" 2 "$?"
 
   # 2. Success case
-  touch "$REMOTE_KW_DEPLOY/status"
+  touch "${KW_STATUS_BASE_PATH}/kw_status"
   check_setup_status 2
   assert_equals_helper 'Wrong return value' "($LINENO)" 0 "$?"
 }


### PR DESCRIPTION
SteamOS uses a mechanism named A/B partition, where a partition (A) is completely replaced by another similar partition (B), which makes it easy to update devices in the user's hand. One of the affected folders from this A/B system is the /boot directory and the directories that get apps installed via pacman, which cause issues on kw deploy after this update. This commit addresses this problem by moving the status file from /opt/kw to /boot/; by doing it when the A/B partition gets updated, the kw_status file will be removed. Finally, when kw tries to check if the deploy was executed, it will notice that kw_status was removed, and it will rerun kw setup.