### PR TITLE
src: upstream_patches_ui: Fix 'New Patches' screen title bug

### DIFF
--- a/src/upstream_patches_ui.sh
+++ b/src/upstream_patches_ui.sh
@@ -13,6 +13,7 @@ include "${KW_LIB_DIR}/kwlib.sh"
 declare -ga registered_lists
 declare -ga patches_from_mailing_list
 declare -ga bookmarked_series
+declare -g current_mailing_list
 
 declare -gA screen_sequence=(
   ['SHOW_SCREEN']='manage_mailing_lists'
@@ -350,22 +351,22 @@ function registered_mailing_list()
 
 function show_new_patches_in_the_mailing_list()
 {
-  local list_name="$1"
   local -a new_patches
   local fallback_message
 
-  # Query patches from mailing list, this info will be saved at
-  # ${list_of_mailinglist_patches[@]}
-  if [[ -z "${screen_sequence['RETURNING']}" ]]; then
-    create_loading_screen_notification "Loading patches from ${list_name} list"
-    get_patches_from_mailing_list "$list_name" patches_from_mailing_list
+  # If returning from a 'show_series_details' screen, i.e., we already fetched the information needed to render this screen.
+  if [[ -n "${screen_sequence['RETURNING']}" ]]; then
+    # Avoiding stale value
+    screen_sequence['RETURNING']=''
+  else
+    current_mailing_list="$1"
+    create_loading_screen_notification "Loading patches from ${current_mailing_list} list"
+    # Query patches from mailing list, this info will be saved at "${list_of_mailinglist_patches[@]}".
+    get_patches_from_mailing_list "$current_mailing_list" patches_from_mailing_list
   fi
 
-  # Avoiding stale value
-  screen_sequence['RETURNING']=''
-
   fallback_message='kw could not retrieve patches from this mailing list'
-  list_patches "Patches from ${screen_sequence['SHOW_SCREEN_PARAMETER']}" patches_from_mailing_list \
+  list_patches "Patches from ${current_mailing_list}" patches_from_mailing_list \
     "${screen_sequence['SHOW_SCREEN']}" "${fallback_message}"
 }
 

--- a/tests/upstream_patches_ui_test.sh
+++ b/tests/upstream_patches_ui_test.sh
@@ -185,4 +185,35 @@ function test_show_settings_screen()
   assert_equals_helper 'Should set next screen to "manage_mailing_lists"' "$LINENO" 'manage_mailing_lists' "${screen_sequence['SHOW_SCREEN']}"
 }
 
+function test_show_new_patches_in_the_mailing_list_title()
+{
+  declare current_mailing_list=''
+
+  # shellcheck disable=SC2317
+  function create_loading_screen_notification()
+  {
+    return
+  }
+  # shellcheck disable=SC2317
+  function get_patches_from_mailing_list()
+  {
+    return
+  }
+  # shellcheck disable=SC2317
+  function list_patches()
+  {
+    return
+  }
+
+  # Not returning from a (supposed) series detail screen should set "$current_mailing_list" global variable to "$1"
+  screen_sequence['RETURNING']=''
+  show_new_patches_in_the_mailing_list 'amd-gfx'
+  assert_equals_helper 'Wrong "current_mailing_list" value' "$LINENO" 'amd-gfx' "$current_mailing_list"
+
+  # Returning from a (supposed) series detail screen should use the old "$current_mailing_list" value
+  screen_sequence['RETURNING']=1
+  show_new_patches_in_the_mailing_list 'arbitrary-value'
+  assert_equals_helper 'Wrong "current_mailing_list" value' "$LINENO" 'amd-gfx' "$current_mailing_list"
+}
+
 invoke_shunit


### PR DESCRIPTION
In the `upstream-patches-ui` feature, the title of the screen where new patches from a given mailing list are shown is incorrectly displayed when returning from a series details screen. In other words, when we first visit the 'New Patches' screen, the title is correct (something like 'Patches from amd-gfx)'. But, if we select a patch series to see its details and return to the previous screen ('New Patches' screen), the title will be wrong (something like 'Patches from 0').

This commit fixes this by adding a global variable named `current_mailing_list` to keep track of the latest mailing list queried, i.e., the latest mailing list that the feature has fetched new patches. We already checked to see if `screen_sequence['RETURNING']` was set, signaling that we are (supposedly) returning from a series details screen and we don't need to query the mailing list again, but the list name displayed was resetted (with `screen_sequence['SCREEN_PARAMETER']` value) regardless. Now, the list name displayed is defined by the `current_mailing_list` value and it is only set when not returning from a (supposed) series details screen.

Closes: #849