### PR TITLE
Adding 'Apply' action and 'Kernel Config File' setting menu to `kw upstream-patches-ui`

### DIFF
--- a/documentation/dependencies/debian.dependencies
+++ b/documentation/dependencies/debian.dependencies
@@ -28,3 +28,4 @@ curl
 libxml-xpath-perl
 coreutils
 b4
+wiggle

--- a/documentation/dependencies/fedora.dependencies
+++ b/documentation/dependencies/fedora.dependencies
@@ -24,3 +24,4 @@ curl
 perl-XML-XPath
 coreutils
 b4
+wiggle

--- a/etc/dialog_help/file_selection_help.txt
+++ b/etc/dialog_help/file_selection_help.txt
@@ -1,0 +1,12 @@
+[file_selection_help_box_title]:
+File Selection Help
+[file_selection_help_message_box]:
+There are 4 regions in the Directory Selection screen:
+- [Upper Left Box]: list of directories in the current path.
+- [Upper Right Box]: list of files in the current path.
+- [Lower Box]: the current path (input box).
+- [Buttons]: "OK" to confirm file path, "Cancel" to cancel selection and "Help" to show this screen.
+
+To move between the regions, use the <TAB> key.
+To complete the current path with the highlighted directory/file, use the <SPACE> key.
+Typing while in the Upper Box or the Lower Box alters the current path.

--- a/etc/lore.config
+++ b/etc/lore.config
@@ -17,3 +17,6 @@ kernel_tree_path=
 
 # Target branch of kernel tree for basing application of patches
 kernel_tree_branch=
+
+# Path to config file used to build the kernel
+kernel_config_file_path=

--- a/src/lib/dialog_ui.sh
+++ b/src/lib/dialog_ui.sh
@@ -373,6 +373,69 @@ function create_directory_selection_screen()
   return "$ret"
 }
 
+# Create file selection screen.
+#
+# @starting_path: Path that is in the input box when screen starts
+# @box_title: Title of the box
+# @extra_label: Label to override 'Extra' button. If empty, 'Extra' button
+#   is not displayed.
+# @height: Menu height in lines size
+# @width: Menu width in column size
+# @flag How to display a command, the default value is
+#   "SILENT". For more options see `src/kwlib.sh` function `cmd_manager`
+#
+# Return:
+# Returns 0 if the 'OK' button is pressed, 1 if the 'Cancel' button is pressed
+# and 2 if the 'Help' button is pressed. The string in the input box (current
+# path) is returned via the `menu_return_string` variable.
+function create_file_selection_screen()
+{
+  local starting_path="$1"
+  local box_title="$2"
+  local extra_label="$3"
+  local height="$4"
+  local width="$5"
+  local flag="$6"
+  local cmd
+  local ret
+
+  flag=${flag:-'SILENT'}
+  height=${height:-'15'}
+  width=${width:-'80'}
+  back_title=${back_title:-"${KW_UPSTREAM_TITLE}"}
+
+  # Escape all single quotes to avoid breaking arguments
+  back_title=$(str_escape_single_quotes "$back_title")
+  box_title=$(str_escape_single_quotes "$box_title")
+  extra_label=$(str_escape_single_quotes "$extra_label")
+
+  # Add layout to dialog
+  if [[ -n "$DIALOG_LAYOUT" ]]; then
+    cmd="DIALOGRC=${DIALOG_LAYOUT}"
+  fi
+
+  # Add general information to the dialog box
+  cmd+=" dialog --backtitle $'${back_title}' --title $'${box_title}' --clear --colors"
+  # Add help button
+  cmd+=" --help-button"
+  # Add extra button, if needed
+  if [[ -n "$extra_label" ]]; then
+    cmd+=" --extra-button --extra-label $'${extra_label}'"
+  fi
+  # Add file selection screen
+  cmd+=" --fselect '${starting_path}'"
+  # Set height and width
+  cmd+=" '${height}' '${width}'"
+
+  [[ "$flag" == 'TEST_MODE' ]] && printf '%s' "$cmd" && return 0
+
+  exec 3>&1
+  menu_return_string=$(cmd_manager "$flag" "$cmd" 2>&1 1>&3)
+  ret="$?"
+  exec 3>&-
+  return "$ret"
+}
+
 # Create a screen with a list of choices.
 #
 # @box_title: Title of the box

--- a/src/lib/dialog_ui.sh
+++ b/src/lib/dialog_ui.sh
@@ -446,6 +446,75 @@ function create_choice_list_screen()
   return "$ret"
 }
 
+# Create a screen with a Yes/No prompt.
+#
+# @box_title: Title of the box
+# @message_box: The message to be displayed
+# @ok_label: Label for the 'Yes' button
+# @no_label: Label for the 'No' button
+# @extra_label: Label for the 'Extra' button
+# @height: Menu height in lines size
+# @width: Menu width in column size
+# @flag How to display a command, the default value is
+#   "SILENT". For more options see `src/kwlib.sh` function `cmd_manager`
+#
+# Return:
+# Returns 0 if the 'Yes' button is pressed, 1 if the 'No' button is pressed and
+# 3 if the 'Extra' button is pressed.
+function create_yes_no_prompt()
+{
+  local box_title="$1"
+  local message_box="$2"
+  local yes_label="$3"
+  local no_label="$4"
+  local extra_label="$5"
+  local height="$6"
+  local width="$7"
+  local flag="$8"
+  local cmd
+  local ret
+
+  yes_label=${yes_label:-'Yes'}
+  no_label=${no_label:-'No'}
+  flag=${flag:-'SILENT'}
+  height=${height:-'15'}
+  width=${width:-'40'}
+  back_title=${back_title:-"${KW_UPSTREAM_TITLE}"}
+
+  # Escape all single quotes to avoid breaking arguments
+  back_title=$(str_escape_single_quotes "$back_title")
+  box_title=$(str_escape_single_quotes "$box_title")
+  message_box=$(str_escape_single_quotes "$message_box")
+  yes_label=$(str_escape_single_quotes "$yes_label")
+  no_label=$(str_escape_single_quotes "$no_label")
+  extra_label=$(str_escape_single_quotes "$extra_label")
+
+  # Add layout to dialog
+  if [[ -n "$DIALOG_LAYOUT" ]]; then
+    cmd="DIALOGRC=${DIALOG_LAYOUT}"
+  fi
+
+  # Add general information to the dialog box
+  cmd+=" dialog --backtitle $'${back_title}' --title $'${box_title}' --clear --colors"
+  # Add labels
+  cmd+=" --yes-label $'${yes_label}' --no-label $'${no_label}'"
+  if [[ -n "${extra_label}" ]]; then
+    cmd+=" --extra-button --extra-label $'${extra_label}'"
+  fi
+  # Add Yes/No screen
+  cmd+=" --yesno $'${message_box}'"
+  # Set height and width
+  cmd+=" '${height}' '${width}'"
+
+  [[ "$flag" == 'TEST_MODE' ]] && printf '%s' "$cmd" && return 0
+
+  exec 3>&1
+  cmd_manager "$flag" "$cmd" 2>&1 1>&3
+  ret="$?"
+  exec 3>&-
+  return "$ret"
+}
+
 # Creates a help message box for a dialog's screen. There must be a file
 # that follows the pattern of `load_module_text`, for reference see `src/kwio.sh`.
 #

--- a/tests/lib/dialog_ui_test.sh
+++ b/tests/lib/dialog_ui_test.sh
@@ -267,6 +267,39 @@ function test_create_choice_list_screen_use_all_options()
   assert_equals_helper 'Expected choice list with all custom options' "$LINENO" "$expected_cmd" "$output"
 }
 
+function test_create_yes_no_prompt_rely_on_some_default_options()
+{
+  local box_title="Choose Yes 'or' No!"
+  local message_box="This is \`a Yes/No' prompt."
+  local expected_cmd
+  local output
+
+  expected_cmd=" dialog --backtitle $'${KW_UPSTREAM_TITLE}'"
+  expected_cmd+=" --title $'Choose Yes \'or\' No!' --clear --colors"
+  expected_cmd+=" --yes-label $'Yes' --no-label $'No'"
+  expected_cmd+=" --yesno $'This is \`a Yes/No\' prompt.'"
+  expected_cmd+=" '15' '40'"
+  output=$(create_yes_no_prompt "$box_title" "$message_box" '' '' '' '' '' 'TEST_MODE')
+  assert_equals_helper 'Expected Yes/No prompt with some default options' "$LINENO" "$expected_cmd" "$output"
+}
+
+function test_create_yes_no_prompt_use_all_options()
+{
+  local box_title="Choose Yes 'or' No!"
+  local message_box="This is \`a Yes/No' prompt."
+  local expected_cmd
+  local output
+
+  expected_cmd=" dialog --backtitle $'${KW_UPSTREAM_TITLE}'"
+  expected_cmd+=" --title $'Choose Yes \'or\' No!' --clear --colors"
+  expected_cmd+=" --yes-label $'No' --no-label $'Yes'"
+  expected_cmd+=" --extra-button --extra-label $'Not Extra'"
+  expected_cmd+=" --yesno $'This is \`a Yes/No\' prompt.'"
+  expected_cmd+=" '31415' '2718281828'"
+  output=$(create_yes_no_prompt "$box_title" "$message_box" 'No' 'Yes' 'Not Extra' '31415' '2718281828' 'TEST_MODE')
+  assert_equals_helper 'Expected Yes/No prompt with all custom options' "$LINENO" "$expected_cmd" "$output"
+}
+
 function test_prettify_string_failures()
 {
   prettify_string

--- a/tests/lib/dialog_ui_test.sh
+++ b/tests/lib/dialog_ui_test.sh
@@ -210,6 +210,36 @@ function test_create_directory_selection_screen_use_all_options()
   assert_equals_helper 'Expected directory selection with all custom options' "$LINENO" "$expected_cmd" "$output"
 }
 
+function test_create_file_selection_screen_rely_on_some_default_options()
+{
+  local starting_path='/some/creative/path'
+  local box_title="Choose 'a' File!"
+  local expected_cmd
+  local output
+
+  expected_cmd=" dialog --backtitle $'${KW_UPSTREAM_TITLE}'"
+  expected_cmd+=" --title $'Choose \'a\' File!' --clear --colors"
+  expected_cmd+=" --help-button --fselect '${starting_path}'"
+  expected_cmd+=" '15' '80'"
+  output=$(create_file_selection_screen "${starting_path}" "${box_title}" '' '' '' 'TEST_MODE')
+  assert_equals_helper 'Expected file selection with some default options' "$LINENO" "$expected_cmd" "$output"
+}
+
+function test_create_file_selection_screen_use_all_options()
+{
+  local starting_path='/some/creative/path'
+  local box_title="Choose 'a' File!"
+  local expected_cmd
+  local output
+
+  expected_cmd=" dialog --backtitle $'${KW_UPSTREAM_TITLE}'"
+  expected_cmd+=" --title $'Choose \'a\' File!' --clear --colors"
+  expected_cmd+=" --help-button --extra-button --extra-label $'EXTRA' --fselect '${starting_path}'"
+  expected_cmd+=" '2718' '281828'"
+  output=$(create_file_selection_screen "${starting_path}" "${box_title}" 'EXTRA' '2718' '281828' 'TEST_MODE')
+  assert_equals_helper 'Expected file selection with all custom options' "$LINENO" "$expected_cmd" "$output"
+}
+
 function test_create_help_screen()
 {
   local expected_cmd


### PR DESCRIPTION
This PR has the objective of integrating the `kw upstream-patches-ui` feature with `kw build`, i.e., allowing the user to build a patch version of the kernel through the feature's UI. The steps involved are:

- [x] Add the 'Apply' action to apply the patch version of the kernel to a given kernel tree and a target branch
- [x] Add the 'Kernel Config File' setting to let the user define which .config file to use
- ~~Add the 'Build' action to build the patch version of the kernel to a given kernel tree and a target branch~~

It is expected that 'Apply' triggers the 'Download' action and 'Build' triggers 'Apply'.

**[UPDATE]**
This PR was reduced to not integrate the feature with `kw build`, as the feature needs to be cleaned and refactored. Integrating `kw build` before it will only increase the mess.