### PR TITLE
Fix variable name in remote2host

### DIFF
--- a/src/remote.sh
+++ b/src/remote.sh
@@ -182,7 +182,7 @@ function remote2host()
 
   if [[ -z "$remote" && -z "$port" && -z "$user" ]]; then
     if [[ -n ${remote_parameters['REMOTE_FILE']} ]]; then
-      rsync_target="'ssh -F ${remote_parameters['REMOTE_FILE']}' ${remote_parameters['REMOTE_FILE_HOST']}:${src} ${dsc}"
+      rsync_target="'ssh -F ${remote_parameters['REMOTE_FILE']}' ${remote_parameters['REMOTE_FILE_HOST']}:${src} ${dst}"
     fi
   else
     rsync_target="'ssh -p ${port}' ${user}@${remote}:${src} ${dst}"


### PR DESCRIPTION
One of the variables passed to the rsync command had a typo, so operations like fetching a config file from a remote machine would not succeed. Replace `dsc` with `dst` in the rsync command.