### PR TITLE
src: upstream_patches_ui: Replace undefined help function call

### DIFF
--- a/src/upstream_patches_ui.sh
+++ b/src/upstream_patches_ui.sh
@@ -278,7 +278,10 @@ function show_settings_screen()
             1) # Cancel
               ;;
             2) # Help
-              create_directory_selection_help_screen
+              create_help_screen 'directory_selection'
+              if [[ "$?" != 0 ]]; then
+                create_message_box 'Error' 'Cannot create help screen'
+              fi
               ;;
           esac
           # Just to be safe


### PR DESCRIPTION
When calling a help screen for an arbitrary dialog screen, we use a generic function named `create_help_screen` passing the name of the screen in question. In the 'Save Patches To' menu, the wrong function is called, named `create_directory_selection_help_screen` (a function that existed when there was no generic help function).

This commit fixes this by replacing this undefined function call for the right one.