### PR TITLE
src: upstream_patches_ui: Fix relative paths in 'Kernel Tree Path'

### DIFF
--- a/src/upstream_patches_ui.sh
+++ b/src/upstream_patches_ui.sh
@@ -268,6 +268,7 @@ function show_settings_screen()
               if ! is_kernel_root "$new_value"; then
                 create_message_box 'Error' "${new_value}: Not a Linux kernel source tree."
               else
+                new_value=$(realpath "$new_value")
                 save_new_lore_config 'kernel_tree_path' "$new_value" "$lore_config_path"
                 # As we changed the kernel tree, we set the target branch to empty
                 save_new_lore_config 'kernel_tree_branch' '' "$lore_config_path"


### PR DESCRIPTION
When selecting a Linux kernel source tree through the `upstream-patches-ui` feature, relative paths are accepted when they refer to a kernel tree, but the relative path is registered in the `lore.config` file, which can break parts of the feature, depending where it is executed.

This commit fixes this by still allowing relative paths but converting them to absolute paths using the `realpath` command.

Closes: #865