### PR TITLE
tests: utils: Remove extra char

### DIFF
--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -391,7 +391,7 @@ function assert_equals_helper()
   line=${line:-'Unknown line'}
 
   if ! assertEquals "$expected" "$result_to_compare" &> /dev/null; then
-    printf '%bASSERT:%b line %s: %s\n  %bExpected Result:%b %b%s%b\n  %b-> Actual Result:%b %b%s%b\n' \
+    printf '%bASSERT:%b line %s: %s\n  %bExpected Result:%b %b%s%b\n  %b  Actual Result:%b %b%s%b\n' \
       "$KW_COLOR_RED" "$KW_COLOR_NONE" "$line" "${msg}" \
       "$KW_COLOR_GREEN" "$KW_COLOR_NONE" "$KW_COLOR_GREEN" "${expected}" "$KW_COLOR_NONE" \
       "$KW_COLOR_RED" "$KW_COLOR_NONE" "$KW_COLOR_RED" "${result_to_compare}" "$KW_COLOR_NONE"


### PR DESCRIPTION
When assert_equals_helper helper fails, the failed and expected strings are misaligned for a single character, making it hard to compare the final result. This commit just removes the extra character, that way, it will be visually evident the fail pattern.