### PR TITLE
`patch-hub`: Refactor lore mailing lists screen

### DIFF
--- a/src/ui/patch_hub/lore_mailing_lists.sh
+++ b/src/ui/patch_hub/lore_mailing_lists.sh
@@ -1,0 +1,63 @@
+include "${KW_LIB_DIR}/ui/patch_hub/patch_hub_core.sh"
+
+# Screen used to manage the mailing lists
+function show_mailing_lists_screen()
+{
+  local message_box
+  local new_list
+  local -a menu_list_string_array
+  local -a check_statuses=()
+  local index=0
+  local lore_config_path="${PWD}/.kw/lore.config"
+  local ret
+
+  if [[ ! -f "${lore_config_path}" ]]; then
+    lore_config_path="${KW_ETC_DIR}/lore.config"
+  fi
+
+  create_loading_screen_notification 'Retrieving available mailing lists from lore.kernel.org'
+  retrieve_available_mailing_lists
+
+  # shellcheck disable=SC2207
+  IFS=$'\n' menu_list_string_array=($(sort <<< "${!available_lore_mailing_lists[*]}"))
+  unset IFS
+
+  # Put check marks on mailing lists already registered
+  for list in "${menu_list_string_array[@]}"; do
+    check_statuses["$index"]=0
+    # substring of others (e.g. 'yocto' and 'yocto-docs') may lead to false positives.
+    IFS=',' read -r -a registered_lists <<< "${lore_config['lists']}"
+    for registered_list in "${registered_lists[@]}"; do
+      [[ "$list" == "$registered_list" ]] && check_statuses["$index"]=1
+    done
+    ((index++))
+  done
+
+  if [[ -z "${lore_config['lists']}" ]]; then
+    message_box="It looks like that you don't have any lore list registered."
+    message_box+=" Please, select one or more of the list below:"
+  fi
+
+  create_simple_checklist 'Register/Unresgister Mailing Lists' "$message_box" 'menu_list_string_array' \
+    'check_statuses' 1
+  ret="$?"
+
+  new_list=$(printf '%s' "$menu_return_string" | tr -s '[:blank:]' ',')
+
+  case "$ret" in
+    0) # OK
+      if [[ -n "$new_list" ]]; then
+        screen_sequence['SHOW_SCREEN']='dashboard'
+        lore_config['lists']="${new_list}"
+        IFS=',' read -r -a registered_lists <<< "$new_list"
+        sed -i -r "s<(lists=).*<\1${new_list}<" "$lore_config_path"
+      fi
+      ;;
+    1) # Exit
+      handle_exit "$ret"
+      ;;
+    3) # Return
+      screen_sequence['SHOW_SCREEN']='dashboard'
+      ;;
+  esac
+}

--- a/src/ui/patch_hub/lore_mailing_lists.sh
+++ b/src/ui/patch_hub/lore_mailing_lists.sh
@@ -54,7 +54,6 @@ function show_lore_mailing_lists()
   esac
 }
 
-# TODO: Test this function
 # This function converts the available mailing lists from lore.kernel.org stored in the
 # associative array to an array. The way `available_lore_mailing_lists` is structured is
 # that the keys are the names of the lists and the values are the descriptions. This
@@ -72,7 +71,6 @@ function convert_available_lore_mailing_lists_to_array()
   unset IFS
 }
 
-# TODO: Test this function
 # This function assigns the check status of the lists in the `@_lists` array
 # and stores it in the `@_lists_check_status` array using the `@registered_lists_string`
 # string. A list is considered 'checked' if it is a registered list.

--- a/src/ui/patch_hub/lore_mailing_lists.sh
+++ b/src/ui/patch_hub/lore_mailing_lists.sh
@@ -1,7 +1,7 @@
 include "${KW_LIB_DIR}/ui/patch_hub/patch_hub_core.sh"
 
 # Screen used to manage the mailing lists
-function show_mailing_lists_screen()
+function show_lore_mailing_lists()
 {
   local message_box
   local new_list

--- a/src/ui/patch_hub/lore_mailing_lists.sh
+++ b/src/ui/patch_hub/lore_mailing_lists.sh
@@ -1,13 +1,14 @@
 include "${KW_LIB_DIR}/ui/patch_hub/patch_hub_core.sh"
 
-# Screen used to manage the mailing lists
+# This function displays a checklist menu of the available mailing lists from lore.kernel.org
+# sorted by lexicographic order for the user to define the set of registered lists.
 function show_lore_mailing_lists()
 {
+  local -a available_lore_mailing_lists_array
+  local -a lists_check_status=()
+  local menu_title
   local message_box
-  local new_list
-  local -a menu_list_string_array
-  local -a check_statuses=()
-  local index=0
+  local new_registered_lists
   local lore_config_path="${PWD}/.kw/lore.config"
   local ret
 
@@ -16,42 +17,33 @@ function show_lore_mailing_lists()
   fi
 
   create_loading_screen_notification 'Retrieving available mailing lists from lore.kernel.org'
+
+  # This call retrieves the available mailing lists archived on lore.kernel.org and
+  # stores it in the `available_lore_mailing_lists` associative array.
   retrieve_available_mailing_lists
+  convert_available_lore_mailing_lists_to_array 'available_lore_mailing_lists' 'available_lore_mailing_lists_array'
+  get_lists_check_status 'available_lore_mailing_lists_array' 'lists_check_status' "${lore_config['lists']}"
 
-  # shellcheck disable=SC2207
-  IFS=$'\n' menu_list_string_array=($(sort <<< "${!available_lore_mailing_lists[*]}"))
-  unset IFS
-
-  # Put check marks on mailing lists already registered
-  for list in "${menu_list_string_array[@]}"; do
-    check_statuses["$index"]=0
-    # substring of others (e.g. 'yocto' and 'yocto-docs') may lead to false positives.
-    IFS=',' read -r -a registered_lists <<< "${lore_config['lists']}"
-    for registered_list in "${registered_lists[@]}"; do
-      [[ "$list" == "$registered_list" ]] && check_statuses["$index"]=1
-    done
-    ((index++))
-  done
-
+  menu_title='Register/Unresgister Mailing Lists'
+  # Add a message to the user in case there are no registered list.
   if [[ -z "${lore_config['lists']}" ]]; then
     message_box="It looks like that you don't have any lore list registered."
     message_box+=" Please, select one or more of the list below:"
   fi
 
-  create_simple_checklist 'Register/Unresgister Mailing Lists' "$message_box" 'menu_list_string_array' \
-    'check_statuses' 1
+  create_simple_checklist "$menu_title" "$message_box" 'available_lore_mailing_lists_array' \
+    'lists_check_status' 1
   ret="$?"
-
-  new_list=$(printf '%s' "$menu_return_string" | tr -s '[:blank:]' ',')
 
   case "$ret" in
     0) # OK
-      if [[ -n "$new_list" ]]; then
-        screen_sequence['SHOW_SCREEN']='dashboard'
-        lore_config['lists']="${new_list}"
-        IFS=',' read -r -a registered_lists <<< "$new_list"
-        sed -i -r "s<(lists=).*<\1${new_list}<" "$lore_config_path"
-      fi
+      new_registered_lists=$(printf '%s' "$menu_return_string" | tr -s '[:blank:]' ',')
+      save_new_lore_config 'lists' "$new_registered_lists" "$lore_config_path"
+
+      # As we altered the settings, we need to reload lore.config
+      load_lore_config
+
+      screen_sequence['SHOW_SCREEN']='dashboard'
       ;;
     1) # Exit
       handle_exit "$ret"
@@ -60,4 +52,51 @@ function show_lore_mailing_lists()
       screen_sequence['SHOW_SCREEN']='dashboard'
       ;;
   esac
+}
+
+# TODO: Test this function
+# This function converts the available mailing lists from lore.kernel.org stored in the
+# associative array to an array. The way `available_lore_mailing_lists` is structured is
+# that the keys are the names of the lists and the values are the descriptions. This
+# converts the keys (i.e. the names of the lists) into a sorted array
+#
+# @_available_lore_mailing_lists: Associative array reference to lore mailing lists
+# @_available_lore_mailing_lists_array: Array reference to store sorted lore mailing lists
+function convert_available_lore_mailing_lists_to_array()
+{
+  local -n _available_lore_mailing_lists="$1"
+  local -n _available_lore_mailing_lists_array="$2"
+
+  # shellcheck disable=SC2207
+  IFS=$'\n' _available_lore_mailing_lists_array=($(sort <<< "${!_available_lore_mailing_lists[*]}"))
+  unset IFS
+}
+
+# TODO: Test this function
+# This function assigns the check status of the lists in the `@_lists` array
+# and stores it in the `@_lists_check_status` array using the `@registered_lists_string`
+# string. A list is considered 'checked' if it is a registered list.
+#
+# @_lists: Array reference to the lists
+# @_lists_check_status: Array reference to the check statuses of the lists
+# @registered_lists_string: String containing the registered lists (which are
+#   considered checked) separated by comma
+function get_lists_check_status()
+{
+  local -n _lists="$1"
+  local -n _lists_check_status="$2"
+  local registered_lists_string="$3"
+  local index=0
+
+  for list in "${_lists[@]}"; do
+    _lists_check_status["$index"]=0
+
+    # substring of others (e.g. 'yocto' and 'yocto-docs') may lead to false positives.
+    IFS=',' read -r -a registered_lists <<< "$registered_lists_string"
+    for registered_list in "${registered_lists[@]}"; do
+      [[ "$list" == "$registered_list" ]] && _lists_check_status["$index"]=1
+    done
+
+    ((index++))
+  done
 }

--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -50,7 +50,7 @@ function patch_hub_main_loop()
   # In case the user doesn't have any mailing list registered, the first
   # state should be "Register/Unregister Mailing Lists"
   if [[ "${#registered_lists[@]}" == 0 ]]; then
-    screen_sequence['SHOW_SCREEN']='manage_mailing_lists'
+    screen_sequence['SHOW_SCREEN']='lore_mailing_lists'
   fi
 
   # Main loop of the state-machine
@@ -60,8 +60,8 @@ function patch_hub_main_loop()
         dashboard_entry_menu
         ret="$?"
         ;;
-      'manage_mailing_lists')
-        show_mailing_lists_screen
+      'lore_mailing_lists')
+        show_lore_mailing_lists
         ret="$?"
         ;;
       'registered_mailing_list')

--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -14,6 +14,7 @@ include "${KW_LIB_DIR}/lib/dialog_ui.sh"
 include "${KW_LIB_DIR}/lib/lore.sh"
 include "${KW_LIB_DIR}/lib/kwio.sh"
 include "${KW_LIB_DIR}/lib/kwlib.sh"
+include "${KW_LIB_DIR}/ui/patch_hub/lore_mailing_lists.sh"
 include "${KW_LIB_DIR}/ui/patch_hub/settings.sh"
 include "${KW_LIB_DIR}/ui/patch_hub/series_details.sh"
 
@@ -233,68 +234,6 @@ function list_patches()
           ;;
       esac
       screen_sequence['SHOW_SCREEN_PARAMETER']="$selected_patch"
-      ;;
-    1) # Exit
-      handle_exit "$ret"
-      ;;
-    3) # Return
-      screen_sequence['SHOW_SCREEN']='dashboard'
-      ;;
-  esac
-}
-
-# Screen used to manage the mailing lists
-function show_mailing_lists_screen()
-{
-  local message_box
-  local new_list
-  local -a menu_list_string_array
-  local -a check_statuses=()
-  local index=0
-  local lore_config_path="${PWD}/.kw/lore.config"
-  local ret
-
-  if [[ ! -f "${lore_config_path}" ]]; then
-    lore_config_path="${KW_ETC_DIR}/lore.config"
-  fi
-
-  create_loading_screen_notification 'Retrieving available mailing lists from lore.kernel.org'
-  retrieve_available_mailing_lists
-
-  # shellcheck disable=SC2207
-  IFS=$'\n' menu_list_string_array=($(sort <<< "${!available_lore_mailing_lists[*]}"))
-  unset IFS
-
-  # Put check marks on mailing lists already registered
-  for list in "${menu_list_string_array[@]}"; do
-    check_statuses["$index"]=0
-    # substring of others (e.g. 'yocto' and 'yocto-docs') may lead to false positives.
-    IFS=',' read -r -a registered_lists <<< "${lore_config['lists']}"
-    for registered_list in "${registered_lists[@]}"; do
-      [[ "$list" == "$registered_list" ]] && check_statuses["$index"]=1
-    done
-    ((index++))
-  done
-
-  if [[ -z "${lore_config['lists']}" ]]; then
-    message_box="It looks like that you don't have any lore list registered."
-    message_box+=" Please, select one or more of the list below:"
-  fi
-
-  create_simple_checklist 'Register/Unresgister Mailing Lists' "$message_box" 'menu_list_string_array' \
-    'check_statuses' 1
-  ret="$?"
-
-  new_list=$(printf '%s' "$menu_return_string" | tr -s '[:blank:]' ',')
-
-  case "$ret" in
-    0) # OK
-      if [[ -n "$new_list" ]]; then
-        screen_sequence['SHOW_SCREEN']='dashboard'
-        lore_config['lists']="${new_list}"
-        IFS=',' read -r -a registered_lists <<< "$new_list"
-        sed -i -r "s<(lists=).*<\1${new_list}<" "$lore_config_path"
-      fi
       ;;
     1) # Exit
       handle_exit "$ret"

--- a/src/ui/patch_hub/settings.sh
+++ b/src/ui/patch_hub/settings.sh
@@ -24,7 +24,7 @@ function show_settings_screen()
     0) # OK
       case "$menu_return_string" in
         1) # Register/Unregister Mailing Lists
-          screen_sequence['SHOW_SCREEN']='manage_mailing_lists'
+          screen_sequence['SHOW_SCREEN']='lore_mailing_lists'
           ;;
         2) # Save Patches To
           change_save_patches_to_setting "$lore_config_path"

--- a/tests/ui/patch_hub/lore_mailing_lists_test.sh
+++ b/tests/ui/patch_hub/lore_mailing_lists_test.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+include './src/ui/patch_hub/lore_mailing_lists.sh'
+include './tests/utils.sh'
+
+function setUp()
+{
+  export ORIGINAL_PATH="$PWD"
+
+  cd "${SHUNIT_TMPDIR}" || {
+    fail "($LINENO): setUp(): It was not possible to move into ${SHUNIT_TMPDIR}"
+    return
+  }
+}
+
+function tearDown()
+{
+  cd "${ORIGINAL_PATH}" || {
+    fail "($LINENO): tearDown(): It was not possible to move into ${ORIGINAL_PATH}"
+    return
+  }
+}
+
+function test_convert_available_lore_mailing_lists_to_array()
+{
+  declare -A available_lore_mailing_lists=(
+    ['A']='Description E'
+    ['B']='Description A'
+    ['C']='Description C'
+    ['D']='Description D'
+    ['E']='Description B'
+  )
+  local -a available_lore_mailing_lists_array
+  local -a expected_array=('A' 'B' 'C' 'D' 'E')
+  local test_fail_message
+
+  convert_available_lore_mailing_lists_to_array 'available_lore_mailing_lists' 'available_lore_mailing_lists_array'
+  test_fail_message='Arrays are different:'$'\n'"${expected_array[*]}"$'\n'"${available_lore_mailing_lists_array[*]}"
+  [[ "${expected_array[*]}" == "${available_lore_mailing_lists_array[*]}" ]]
+  assert_equals_helper "$test_fail_message" "$LINENO" 0 "$?"
+}
+
+function test_get_lists_check_status()
+{
+  local -a lists=('List1' 'List2' 'List3' 'List4' 'List5')
+  local -a lists_check_status
+  local registered_lists_string='List2,List5'
+  local -a expected_array=(0 1 0 0 1)
+  local test_fail_message
+
+  get_lists_check_status 'lists' 'lists_check_status' "$registered_lists_string"
+  test_fail_message='Arrays are different:'$'\n'"${expected_array[*]}"$'\n'"${lists_check_status[*]}"
+  [[ "${expected_array[*]}" == "${lists_check_status[*]}" ]]
+  assert_equals_helper "$test_fail_message" "$LINENO" 0 "$?"
+}
+
+invoke_shunit

--- a/tests/ui/patch_hub/settings_test.sh
+++ b/tests/ui/patch_hub/settings_test.sh
@@ -35,7 +35,7 @@ function test_show_settings_screen()
   }
 
   show_settings_screen
-  assert_equals_helper 'Should set next screen to "manage_mailing_lists"' "$LINENO" 'manage_mailing_lists' "${screen_sequence['SHOW_SCREEN']}"
+  assert_equals_helper 'Should set next screen to "lore_mailing_lists"' "$LINENO" 'lore_mailing_lists' "${screen_sequence['SHOW_SCREEN']}"
 }
 
 invoke_shunit


### PR DESCRIPTION
This PR continues the refactoring of `ui/patch_hub/patch_hub_core.sh` by extracting the module responsible for showing the screen to register and unregister lore mailing lists (basically, the function `show_mailing_lists_screen`) to a dedicated file `ui/patch_hub/lore_mailing_lists.sh` and refining it with refactorings and a test suite.