### PR TITLE
src: lib: remote: Fix ssh connection fail message with remote.config

### DIFF
--- a/tests/samples/remote_samples/remote_4.config
+++ b/tests/samples/remote_samples/remote_4.config
@@ -1,0 +1,21 @@
+Host steamos
+  Hostname steamdeck
+  Port 8888
+  User jozzi
+Host fedora-test
+#  Hostname hostname
+#  Port 2718
+     Hostname fedora-tm
+#  User abc
+#  Port 22
+Host origin
+#  Hostname wrong-hostname
+			User root
+	Port 123
+#  User wrong-user
+#  User wrong-user
+    Hostname deb-tm
+Host arch-test
+  Hostname arch-tm
+  Port 22
+  User abc


### PR DESCRIPTION
When a ssh connection using a `remote.config` file fails, the message shown about the failed attempt displays the wrong IP, User and Port values, if the `remote.config` file doesn't follows this pattern for each host:

Host \<host\>
&nbsp;&nbsp;Hostname \<IP address\>
&nbsp;&nbsp;Port \<port number\>
&nbsp;&nbsp;User \<username\>

For example, if there are commented lines inbetween, or the order is different, the values displayed on a failed ssh connection will be messed.

This happens because the implementation to build the fail message considered that the file would strictly follow the pattern above and picked the Hostname by the line after the 'Host' line, the Port by the second line after the 'Host' line and the User by the third line after the 'Host' line.

This commit fixes this bug by fetching the IP, User and Port values in the `remote.config` file more reliably, using pattern matching with grep instead of assuming a "well-formatted" file. It also adds an unit test to reproduce a "bad-formatted" `remote.config` file case.

Closes: #883