### PR TITLE
`src/lib/dialog_ui`: Reduce duplicated code and add pattern to file

### DIFF
--- a/src/lib/dialog_ui.sh
+++ b/src/lib/dialog_ui.sh
@@ -76,20 +76,13 @@ function create_menu_options()
   width=${width:-$DEFAULT_WIDTH}
   cancel_label=${cancel_label:-'Exit'}
   max_elements_displayed_in_the_menu=${max_elements_displayed_in_the_menu:-'0'}
-  back_title=${back_title:-$KW_PATCH_HUB_TITLE}
 
   # Escape all single quotes to avoid breaking arguments
-  back_title=$(str_escape_single_quotes "$back_title")
   menu_title=$(str_escape_single_quotes "$menu_title")
   cancel_label=$(str_escape_single_quotes "$cancel_label")
   menu_message_box=$(str_escape_single_quotes "$menu_message_box")
 
-  # Start to compose menu
-  if [[ -n "$DIALOG_LAYOUT" ]]; then
-    cmd="DIALOGRC=${DIALOG_LAYOUT} "
-  fi
-
-  cmd+="dialog --backtitle $'${back_title}' --title $'${menu_title}' --clear --colors"
+  cmd=$(build_dialog_command_preamble "$menu_title")
 
   # Change cancel label
   cmd+=" --cancel-label $'${cancel_label}'"
@@ -163,20 +156,13 @@ function create_simple_checklist()
   width=${width:-$DEFAULT_WIDTH}
   list_height=${list_height:-'0'}
   cancel_label=${cancel_label:-'Exit'}
-  back_title=${back_title:-$KW_PATCH_HUB_TITLE}
 
   # Escape all single quotes to avoid breaking arguments
-  back_title=$(str_escape_single_quotes "$back_title")
   menu_title=$(str_escape_single_quotes "$menu_title")
   cancel_label=$(str_escape_single_quotes "$cancel_label")
   menu_message_box=$(str_escape_single_quotes "$menu_message_box")
 
-  # Start to compose menu
-  if [[ -n "$DIALOG_LAYOUT" ]]; then
-    cmd="DIALOGRC=${DIALOG_LAYOUT} "
-  fi
-
-  cmd+="dialog --backtitle $'${back_title}' --title $'${menu_title}' --clear --colors"
+  cmd=$(build_dialog_command_preamble "$menu_title")
 
   # Change cancel label
   cmd+=" --cancel-label $'${cancel_label}'"
@@ -235,7 +221,6 @@ function create_loading_screen_notification()
   flag=${flag:-'SILENT'}
   height=${height:-'8'}
   width=${width:-'60'}
-  back_title=${back_title:-$"$KW_PATCH_HUB_TITLE"}
 
   # Add dialog layout if there is one
   if [[ -n "$DIALOG_LAYOUT" ]]; then
@@ -290,19 +275,12 @@ function create_message_box()
   flag=${flag:-'SILENT'}
   height=${height:-'15'}
   width=${width:-'40'}
-  back_title=${back_title:-"${KW_PATCH_HUB_TITLE}"}
 
   # Escape all single quotes to avoid breaking arguments
-  back_title=$(str_escape_single_quotes "$back_title")
   box_title=$(str_escape_single_quotes "$box_title")
   message_box=$(str_escape_single_quotes "$message_box")
 
-  # Add layout to dialog
-  if [[ -n "$DIALOG_LAYOUT" ]]; then
-    cmd="DIALOGRC=${DIALOG_LAYOUT}"
-  fi
-
-  cmd+=" dialog --backtitle $'${back_title}' --title $'${box_title}' --clear --colors"
+  cmd=$(build_dialog_command_preamble "$box_title")
 
   cmd+=" --msgbox $'${message_box}'"
 
@@ -344,19 +322,11 @@ function create_directory_selection_screen()
   flag=${flag:-'SILENT'}
   height=${height:-'15'}
   width=${width:-'80'}
-  back_title=${back_title:-"${KW_PATCH_HUB_TITLE}"}
 
   # Escape all single quotes to avoid breaking arguments
-  back_title=$(str_escape_single_quotes "$back_title")
   box_title=$(str_escape_single_quotes "$box_title")
 
-  # Add layout to dialog
-  if [[ -n "$DIALOG_LAYOUT" ]]; then
-    cmd="DIALOGRC=${DIALOG_LAYOUT}"
-  fi
-
-  # Add general information to the dialog box
-  cmd+=" dialog --backtitle $'${back_title}' --title $'${box_title}' --clear --colors"
+  cmd=$(build_dialog_command_preamble "$box_title")
   # Add help button
   cmd+=" --help-button"
   # Add directory selection screen
@@ -402,20 +372,12 @@ function create_file_selection_screen()
   flag=${flag:-'SILENT'}
   height=${height:-'15'}
   width=${width:-'80'}
-  back_title=${back_title:-"${KW_PATCH_HUB_TITLE}"}
 
   # Escape all single quotes to avoid breaking arguments
-  back_title=$(str_escape_single_quotes "$back_title")
   box_title=$(str_escape_single_quotes "$box_title")
   extra_label=$(str_escape_single_quotes "$extra_label")
 
-  # Add layout to dialog
-  if [[ -n "$DIALOG_LAYOUT" ]]; then
-    cmd="DIALOGRC=${DIALOG_LAYOUT}"
-  fi
-
-  # Add general information to the dialog box
-  cmd+=" dialog --backtitle $'${back_title}' --title $'${box_title}' --clear --colors"
+  cmd=$(build_dialog_command_preamble "$box_title")
   # Add help button
   cmd+=" --help-button"
   # Add extra button, if needed
@@ -470,20 +432,12 @@ function create_choice_list_screen()
   flag=${flag:-'SILENT'}
   height=${height:-$DEFAULT_HEIGHT}
   width=${width:-$DEFAULT_WIDTH}
-  back_title=${back_title:-"${KW_PATCH_HUB_TITLE}"}
 
   # Escape all single quotes to avoid breaking arguments
-  back_title=$(str_escape_single_quotes "$back_title")
   box_title=$(str_escape_single_quotes "$box_title")
   message_box=$(str_escape_single_quotes "$message_box")
 
-  # Add layout to dialog
-  if [[ -n "$DIALOG_LAYOUT" ]]; then
-    cmd="DIALOGRC=${DIALOG_LAYOUT}"
-  fi
-
-  # Add general information to the dialog box
-  cmd+=" dialog --backtitle $'${back_title}' --title $'${box_title}' --clear --colors"
+  cmd=$(build_dialog_command_preamble "$box_title")
   # Add radiolist screen
   cmd+=" --radiolist $'${message_box}'"
   # Set height and width
@@ -542,23 +496,15 @@ function create_yes_no_prompt()
   flag=${flag:-'SILENT'}
   height=${height:-'15'}
   width=${width:-'40'}
-  back_title=${back_title:-"${KW_PATCH_HUB_TITLE}"}
 
   # Escape all single quotes to avoid breaking arguments
-  back_title=$(str_escape_single_quotes "$back_title")
   box_title=$(str_escape_single_quotes "$box_title")
   message_box=$(str_escape_single_quotes "$message_box")
   yes_label=$(str_escape_single_quotes "$yes_label")
   no_label=$(str_escape_single_quotes "$no_label")
   extra_label=$(str_escape_single_quotes "$extra_label")
 
-  # Add layout to dialog
-  if [[ -n "$DIALOG_LAYOUT" ]]; then
-    cmd="DIALOGRC=${DIALOG_LAYOUT}"
-  fi
-
-  # Add general information to the dialog box
-  cmd+=" dialog --backtitle $'${back_title}' --title $'${box_title}' --clear --colors"
+  cmd=$(build_dialog_command_preamble "$box_title")
   # Add labels
   cmd+=" --yes-label $'${yes_label}' --no-label $'${no_label}'"
   if [[ -n "${extra_label}" ]]; then
@@ -609,6 +555,34 @@ function create_help_screen()
   create_message_box "$box_title" "$message_box" '15' '70' "$flag"
 }
 
+# This function outputs the preamble of most dialog command. This preamble consists
+# of the configuration of a dialog layout, in case there is one, and the dialog box
+# back title and title.
+#
+# @title: Main title of dialog box.
+# @back_title: Back title of dialog box. If null, use `KW_PATCH_HUB_TITLE` as the
+#   default back title.
+function build_dialog_command_preamble()
+{
+  local title="$1"
+  local back_title="$2"
+  local cmd
+
+  # Add layout (if existent) to command.
+  if [[ -n "$DIALOG_LAYOUT" ]]; then
+    cmd="DIALOGRC=${DIALOG_LAYOUT}"
+  fi
+
+  # Define `back_title` value and escape single quotes for safety
+  back_title=${back_title:-$KW_PATCH_HUB_TITLE}
+  back_title=$(str_escape_single_quotes "$back_title")
+
+  # Add dialog box back title and title to command.
+  cmd+=" dialog --backtitle $'${back_title}' --title $'${title}' --clear --colors"
+
+  printf '%s' "$cmd"
+}
+
 # This function is responsible for handling the dialog exit.
 #
 # @exit_status: Exit code
@@ -629,7 +603,6 @@ function handle_exit()
 #
 # @box_title: Title of the box
 # @message_box: The message to be displayed
-# @back_title: Dialog back title
 # @_fields_list: Array of labels
 # @ok_label: Label for the traditional Ok button. By default, it is 'Ok'
 # @cancel_label: Label for the traditional Cancel button. By default, it is 'Cancel'
@@ -648,13 +621,12 @@ function create_form_screen()
   local box_title="$1"
   local message_box="$2"
   local -n _fields_list="$3"
-  local back_title="$4"
-  local ok_label="$5"
-  local cancel_label="$6"
-  local extra_label="$7"
-  local height="$8"
-  local width="$9"
-  local flag="${10}"
+  local ok_label="$4"
+  local cancel_label="$5"
+  local extra_label="$6"
+  local height="$7"
+  local width="$8"
+  local flag="$9"
   local auxiliar_label_size=0
   local start_text_field=0
   local row=1
@@ -668,22 +640,14 @@ function create_form_screen()
   extra_label=$(str_escape_single_quotes "$extra_label")
   box_title=$(str_escape_single_quotes "$box_title")
   message_box=$(str_escape_single_quotes "$message_box")
-  back_title=$(str_escape_single_quotes "$back_title")
 
   height=${height:-"${DEFAULT_HEIGHT}"}
   width=${width:-"${DEFAULT_WIDTH}"}
-  back_title=${back_title:-"${KW_UPSTREAM_TITLE}"}
   cancel_label=${cancel_label:-'Cancel'}
   ok_label=${ok_label:-'Ok'}
   flag=${flag:-'SILENT'}
 
-  # Add layout to dialog
-  if [[ -n "$DIALOG_LAYOUT" ]]; then
-    cmd="DIALOGRC=${DIALOG_LAYOUT}"
-  fi
-
-  # Add general information to the dialog box
-  cmd+=" dialog --backtitle $'${back_title}' --title $'${box_title}' --clear --colors"
+  cmd=$(build_dialog_command_preamble "$box_title")
 
   # Override OK and cancel labels
   cmd+=" --ok-label $'${ok_label}'"

--- a/tests/lib/dialog_ui_test.sh
+++ b/tests/lib/dialog_ui_test.sh
@@ -61,7 +61,7 @@ function test_create_menu_options_rely_on_some_default_options()
   local menu_title='kunit test inside kw'
   local menu_message_box='This should be a useful message box'
   local -a menu_list_string_array=("I'm number 1" "I'm number 2")
-  local expected_cmd="dialog --backtitle \$'${KW_PATCH_HUB_TITLE}'"
+  local expected_cmd=" dialog --backtitle \$'${KW_PATCH_HUB_TITLE}'"
   local output
 
   expected_cmd+=" --title $'${menu_title}' --clear --colors --cancel-label $'Exit' --menu $'${menu_message_box}'"
@@ -77,7 +77,7 @@ function test_create_menu_options_use_all_options()
   local menu_title='kunit test inside kw'
   local menu_message_box='This should be a useful message box'
   local -a menu_list_string_array=("I'm number 1" "I'm number 2")
-  local expected_cmd="dialog --backtitle \$'${KW_PATCH_HUB_TITLE}'"
+  local expected_cmd=" dialog --backtitle \$'${KW_PATCH_HUB_TITLE}'"
   local output
 
   expected_cmd+=" --title $'${menu_title}' --clear --colors --cancel-label $'Xpto'"
@@ -95,7 +95,7 @@ function test_create_simple_checklist_rely_on_some_default_options()
   local menu_message_box="This shouldn't be a useful dialog's screen message box"
   local -a menu_list_string_array=('Checklist 1' 'Checklist 2')
   local -a check_statuses=(1 0)
-  local expected_cmd="dialog --backtitle \$'${KW_PATCH_HUB_TITLE}'"
+  local expected_cmd=" dialog --backtitle \$'${KW_PATCH_HUB_TITLE}'"
   local output
 
   expected_cmd+=" --title $'${menu_title}' --clear --colors --cancel-label $'Exit'"
@@ -113,7 +113,7 @@ function test_create_simple_checklist_use_all_options()
   local menu_message_box="This shouldn't be a useful dialog's screen message box"
   local -a menu_list_string_array=('Checklist 1' 'Checklist 2')
   local -a check_statuses=(1 0)
-  local expected_cmd="dialog --backtitle \$'${KW_PATCH_HUB_TITLE}'"
+  local expected_cmd=" dialog --backtitle \$'${KW_PATCH_HUB_TITLE}'"
   local output
 
   expected_cmd+=" --title $'${menu_title}' --clear --colors --cancel-label $'Nop'"
@@ -334,12 +334,11 @@ function test_create_form_screen_default_options()
 {
   local box_title='Simple form'
   local message_box='This is a simple form'
-  local back_title='Back title form'
   declare -a fields_list=('User' 'IP' 'Port')
   local expected_cmd
   local output
 
-  expected_cmd=" dialog --backtitle $'${back_title}' --title $'${box_title}'"
+  expected_cmd=" dialog --backtitle $'${KW_PATCH_HUB_TITLE}' --title $'${box_title}'"
   expected_cmd+=' --clear --colors'
   expected_cmd+=" --ok-label $'Ok' --cancel-label $'Cancel'"
   expected_cmd+=" --form $'${message_box}'"
@@ -348,7 +347,7 @@ function test_create_form_screen_default_options()
   expected_cmd+=" $'IP:' $'2' 1 $'' $'2' $'6' 10 0"
   expected_cmd+=" $'Port:' $'3' 1 $'' $'3' $'6' 10 0"
 
-  output=$(create_form_screen "$box_title" "$message_box" 'fields_list' "$back_title" '' '' '' "${EXPECTED_DEFAULT_WIDTH}" "${EXPECTED_DEFAULT_HEIGHT}" 'TEST_MODE')
+  output=$(create_form_screen "$box_title" "$message_box" 'fields_list' '' '' '' "${EXPECTED_DEFAULT_WIDTH}" "${EXPECTED_DEFAULT_HEIGHT}" 'TEST_MODE')
 
   assert_equals_helper 'Expected form with default values' "$LINENO" "$expected_cmd" "$output"
 }
@@ -357,7 +356,6 @@ function test_create_form_screen_all_options()
 {
   local box_title='Simple form'
   local message_box='This is a simple form'
-  local back_title='Back title form'
   local ok_label='Next'
   local cancel_label='Previous'
   local extra_label='Cancel'
@@ -365,7 +363,7 @@ function test_create_form_screen_all_options()
   local expected_cmd
   local output
 
-  expected_cmd=" dialog --backtitle $'${back_title}' --title $'${box_title}'"
+  expected_cmd=" dialog --backtitle $'${KW_PATCH_HUB_TITLE}' --title $'${box_title}'"
   expected_cmd+=' --clear --colors'
   expected_cmd+=" --ok-label $'${ok_label}' --cancel-label $'${cancel_label}'"
   expected_cmd+=" --extra-button --extra-label ${extra_label}"
@@ -375,9 +373,34 @@ function test_create_form_screen_all_options()
   expected_cmd+=" $'IP:' $'2' 1 $'' $'2' $'6' 10 0"
   expected_cmd+=" $'Port:' $'3' 1 $'' $'3' $'6' 10 0"
 
-  output=$(create_form_screen "$box_title" "$message_box" 'fields_list' "$back_title" "$ok_label" "$cancel_label" "$extra_label" 200 344 'TEST_MODE')
+  output=$(create_form_screen "$box_title" "$message_box" 'fields_list' "$ok_label" "$cancel_label" "$extra_label" 200 344 'TEST_MODE')
 
   assert_equals_helper 'Expected form with default values' "$LINENO" "$expected_cmd" "$output"
+}
+
+function test_build_dialog_command_preamble()
+{
+  local output
+  local expected
+
+  # No dialog layout
+  DIALOG_LAYOUT=''
+  output=$(build_dialog_command_preamble 'title')
+  expected=" dialog --backtitle \$'kw patch-hub' --title \$'title' --clear --colors"
+  assert_equals_helper 'Wrong command built' "$LINENO" "$expected" "$output"
+
+  # With dialog layout
+  DIALOG_LAYOUT='/path/to/dialog/layout'
+  output=$(build_dialog_command_preamble 'title')
+  expected='DIALOGRC=/path/to/dialog/layout'
+  expected+=" dialog --backtitle \$'kw patch-hub' --title \$'title' --clear --colors"
+  assert_equals_helper 'Wrong command built' "$LINENO" "$expected" "$output"
+
+  # With custom back title
+  DIALOG_LAYOUT=''
+  output=$(build_dialog_command_preamble 'title' 'back title')
+  expected=" dialog --backtitle \$'back title' --title \$'title' --clear --colors"
+  assert_equals_helper 'Wrong command built' "$LINENO" "$expected" "$output"
 }
 
 function test_prettify_string_failures()


### PR DESCRIPTION
This PR introduces three commits that do some refactorings in `src/lib/dialog_ui.sh`. In this library file, most functions have the purpose of showing dialog screens and are implemented in a very similar manner. The first two commits extract functions of duplicated code that appears in these functions. The last one just adds/enforces a pattern to these functions.

Closes: #864 