### PR TITLE
`kw patch-hub`: Add reliable fetch of latest patchsets from mailing list

### DIFF
--- a/.github/workflows/kcov.yml
+++ b/.github/workflows/kcov.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt install -y kcov shunit2 bc sqlite3 bsdmainutils
+          sudo apt install -y kcov shunit2 bc sqlite3 bsdmainutils libxml-xpath-perl
 
       - name: Prepare for tests
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt install -y shunit2 bc sqlite3 bsdmainutils
+          sudo apt install -y shunit2 bc sqlite3 bsdmainutils libxml-xpath-perl
 
       - name: Prepare for tests
         run: |

--- a/etc/lore.config
+++ b/etc/lore.config
@@ -21,6 +21,3 @@ kernel_tree_branch=
 # Number of patchsets per page used for determining how many patchsets have to
 # be fetched and displayed in a screen
 patchsets_per_page=30
-
-# Size in days of time period considered when querying lore servers for patchses
-lore_requests_timeframe=14

--- a/etc/lore.config
+++ b/etc/lore.config
@@ -17,3 +17,10 @@ kernel_tree_path=
 
 # Target branch of kernel tree for basing application of patches
 kernel_tree_branch=
+
+# Number of patchsets per page used for determining how many patchsets have to
+# be fetched and displayed in a screen
+patchsets_per_page=30
+
+# Size in days of time period considered when querying lore servers for patchses
+lore_requests_timeframe=14

--- a/src/lib/dialog_ui.sh
+++ b/src/lib/dialog_ui.sh
@@ -589,6 +589,79 @@ function create_form_screen()
   run_dialog_command "$cmd" "$flag"
 }
 
+# Create a rangebox to collect an integer from the user. This rangebox can be
+# used to guaranteedly an integer from a restricted range.
+#
+# @box_title: Title of the box
+# @message_box: The message to be displayed
+# @min_value: Minimum value of the range
+# @max_value: Maximum value of the range
+# @default_value: Starting value of the rangebox
+# @extra_label: Extra label. If not set, the 'Extra' button won't be displayed
+# @cancel_label: Cancel label. If not set, the default is 'Exit'
+# @help_label: Help label. If not set, the 'Help' button won't be displayed
+# @height: Menu height in lines size
+# @width: Menu width in column size
+# @flag How to display a command, the default value is
+#   "SILENT". For more options see `src/lib/kwlib.sh` function `cmd_manager`
+#
+# Return:
+# Returns 0 if the 'Ok' button is pressed, 1 if the 'Cancel' button is pressed,
+# 2 if the 'Help' button is pressed, and 3 if the 'Extra' button is pressed.
+# The menu_return_string will store the user selected value.
+function create_rangebox_screen()
+{
+  local box_title="$1"
+  local message_box="$2"
+  local min_value="$3"
+  local max_value="$4"
+  local default_value="$5"
+  local extra_label="$6"
+  local cancel_label="$7"
+  local help_label="$8"
+  local height="$9"
+  local width="${10}"
+  local flag="${11}"
+  local cmd
+
+  min_value=${min_value:-'0'}
+  max_value=${max_value:-'100'}
+  default_value=${default_value:-$(((min_value + max_value) / 2))}
+  cancel_label=${cancel_label:-'Exit'}
+  flag=${flag:-'SILENT'}
+  height=${height:-'10'}
+  width=${width:-'60'}
+
+  # Escape all single quotes to avoid breaking arguments
+  box_title=$(str_escape_single_quotes "$box_title")
+  message_box=$(str_escape_single_quotes "$message_box")
+  cancel_label=$(str_escape_single_quotes "$cancel_label")
+  help_label=$(str_escape_single_quotes "$help_label")
+  extra_label=$(str_escape_single_quotes "$extra_label")
+
+  cmd=$(build_dialog_command_preamble "$box_title")
+  # Override 'Cancel' button label
+  cmd+=" --cancel-label $'${cancel_label}'"
+  # Add 'Extra' button
+  if [[ -n "${extra_label}" ]]; then
+    cmd+=" --extra-button --extra-label $'${extra_label}'"
+  fi
+  # Add 'Help' button
+  if [[ -n "${help_label}" ]]; then
+    cmd+=" --help-button --help-label $'${help_label}'"
+  fi
+  # Add Rangebox screen
+  cmd+=" --rangebox $'${message_box}'"
+  # Set height and width
+  cmd+=" '${height}' '${width}'"
+  # Set range and default value
+  cmd+=" '${min_value}' '${max_value}' '${default_value}'"
+
+  [[ "$flag" == 'TEST_MODE' ]] && printf '%s' "$cmd" && return 0
+
+  run_dialog_command "$cmd" "$flag"
+}
+
 # Creates a help message box for a dialog's screen. There must be a file
 # that follows the pattern of `load_module_text`, for reference see `src/lib/kwio.sh`.
 #

--- a/src/lib/web.sh
+++ b/src/lib/web.sh
@@ -49,3 +49,30 @@ function replace_http_by_https()
 
   return "$ret"
 }
+
+# This function is a predicate to determine if a file is an HTML file. The function
+# tries to do this efficiently by first checking only the first line of the file. In
+# case further checking is needed, we look for other tokens in the whole file to
+# determine if it is an HTML.
+#
+# @file_path: Path to the file to be checked.
+#
+# Return:
+# Returns 0 if the function decided that the file is an HTML file, 1 if the function
+# decided it isn't, and 2 (ENOENT) if `@file_path` doesn't correspond to a file.
+function is_html_file()
+{
+  local file_path="$1"
+  local first_line_of_file
+
+  [[ ! -f "$file_path" ]] && return 2 # ENOENT
+
+  first_line_of_file=$(head --lines 1 "$file_path" | tr '[:upper:]' '[:lower:]')
+  if [[ "$first_line_of_file" =~ ^(<html|<\!doctype html>) ]]; then
+    return 0
+  fi
+
+  grep --silent '\(<head>\|<body>\)' "$file_path"
+  [[ "$?" == 0 ]] && return 0
+  return 1
+}

--- a/src/ui/patch_hub/latest_patchsets_from_mailing_list.sh
+++ b/src/ui/patch_hub/latest_patchsets_from_mailing_list.sh
@@ -1,0 +1,22 @@
+include "${KW_LIB_DIR}/ui/patch_hub/patch_hub_core.sh"
+
+function show_new_patches_in_the_mailing_list()
+{
+  local -a new_patches
+  local fallback_message
+
+  # If returning from a 'patchset_details_and_actions' screen, i.e., we already fetched the
+  # information needed to render this screen.
+  if [[ -n "${screen_sequence['RETURNING']}" ]]; then
+    # Avoiding stale value
+    screen_sequence['RETURNING']=''
+  else
+    current_mailing_list="$1"
+    create_loading_screen_notification "Loading patches from ${current_mailing_list} list"
+    # Query patches from mailing list, this info will be saved at "${list_of_mailinglist_patches[@]}".
+    get_patches_from_mailing_list "$current_mailing_list" patches_from_mailing_list
+  fi
+
+  fallback_message='kw could not retrieve patches from this mailing list'
+  list_patches "Patches from ${current_mailing_list}" patches_from_mailing_list "${fallback_message}"
+}

--- a/src/ui/patch_hub/latest_patchsets_from_mailing_list.sh
+++ b/src/ui/patch_hub/latest_patchsets_from_mailing_list.sh
@@ -14,7 +14,8 @@ function show_latest_patchsets_from_mailing_list()
 
   create_loading_screen_notification "Loading patchsets from ${current_mailing_list} list"
   # Query patches from mailing list, this info will be saved at `list_of_mailinglist_patches[@]`.
-  fetch_latest_patchsets_from "$current_mailing_list" "$PAGE"
+  fetch_latest_patchsets_from "$current_mailing_list" "$PAGE" \
+    "${lore_config['patchsets_per_page']}" "${lore_config['lore_requests_timeframe']}"
   if [[ "$?" != 0 ]]; then
     create_message_box 'Error' "Couldn't fetch patchsets from ${current_mailing_list} list."
     screen_sequence['SHOW_SCREEN']='registered_mailing_lists'
@@ -22,8 +23,8 @@ function show_latest_patchsets_from_mailing_list()
   fi
 
   # Getting the indexes of range from target page
-  starting_index=$(get_page_starting_index "$PAGE")
-  ending_index=$(get_page_ending_index "$PAGE")
+  starting_index=$(get_page_starting_index "$PAGE" "${lore_config['patchsets_per_page']}")
+  ending_index=$(get_page_ending_index "$PAGE" "${lore_config['patchsets_per_page']}")
   # Format and load patchset metadata for display, in case it wasn't done
   if [[ "$((ending_index + 1))" -gt "${#formatted_patchsets_list[@]}" ]]; then
     format_patchsets 'formatted_patchsets_list' "$starting_index" "$ending_index"
@@ -48,7 +49,7 @@ function show_latest_patchsets_from_mailing_list()
     3) # Previous
       ((PAGE--))
       if [[ "$PAGE" == 0 ]]; then
-        reset_current_lore_fetch_session
+        reset_current_lore_fetch_session "${lore_config['lore_requests_timeframe']}"
         PAGE=1
         formatted_patchsets_list=()
         screen_sequence['SHOW_SCREEN']='registered_mailing_lists'

--- a/src/ui/patch_hub/latest_patchsets_from_mailing_list.sh
+++ b/src/ui/patch_hub/latest_patchsets_from_mailing_list.sh
@@ -1,6 +1,8 @@
 include "${KW_LIB_DIR}/ui/patch_hub/patch_hub_core.sh"
 
-function show_new_patches_in_the_mailing_list()
+# This function displays a list of the latest patchsets from a target mailing list.
+# These patchsets are ordered by their recieved time in the lore.kernel.org servers.
+function show_latest_patchsets_from_mailing_list()
 {
   local -a new_patches
   local fallback_message

--- a/src/ui/patch_hub/latest_patchsets_from_mailing_list.sh
+++ b/src/ui/patch_hub/latest_patchsets_from_mailing_list.sh
@@ -1,24 +1,58 @@
 include "${KW_LIB_DIR}/ui/patch_hub/patch_hub_core.sh"
 
+declare -g PAGE=1
+declare -ga formatted_patchsets_list
+
 # This function displays a list of the latest patchsets from a target mailing list.
 # These patchsets are ordered by their recieved time in the lore.kernel.org servers.
 function show_latest_patchsets_from_mailing_list()
 {
-  local -a new_patches
-  local fallback_message
+  local starting_index
+  local ending_index
+  local box_title
+  local extra_label='Previous'
 
-  # If returning from a 'patchset_details_and_actions' screen, i.e., we already fetched the
-  # information needed to render this screen.
-  if [[ -n "${screen_sequence['RETURNING']}" ]]; then
-    # Avoiding stale value
-    screen_sequence['RETURNING']=''
-  else
-    current_mailing_list="$1"
-    create_loading_screen_notification "Loading patches from ${current_mailing_list} list"
-    # Query patches from mailing list, this info will be saved at "${list_of_mailinglist_patches[@]}".
-    get_patches_from_mailing_list "$current_mailing_list" patches_from_mailing_list
+  create_loading_screen_notification "Loading patchsets from ${current_mailing_list} list"
+  # Query patches from mailing list, this info will be saved at `list_of_mailinglist_patches[@]`.
+  fetch_latest_patchsets_from "$current_mailing_list" "$PAGE"
+  if [[ "$?" != 0 ]]; then
+    create_message_box 'Error' "Couldn't fetch patchsets from ${current_mailing_list} list."
+    screen_sequence['SHOW_SCREEN']='registered_mailing_lists'
+    return
   fi
 
-  fallback_message='kw could not retrieve patches from this mailing list'
-  list_patches "Patches from ${current_mailing_list}" patches_from_mailing_list "${fallback_message}"
+  # Getting the indexes of range from target page
+  starting_index=$(get_page_starting_index "$PAGE")
+  ending_index=$(get_page_ending_index "$PAGE")
+  # Format and load patchset metadata for display, in case it wasn't done
+  if [[ "$((ending_index + 1))" -gt "${#formatted_patchsets_list[@]}" ]]; then
+    format_patchsets 'formatted_patchsets_list' "$starting_index" "$ending_index"
+  fi
+  box_title="Patchsets from ${current_mailing_list} (page ${PAGE})"
+  [[ "$PAGE" == 1 ]] && extra_label='Return'
+  create_menu_options "$box_title" '' 'formatted_patchsets_list' "$starting_index" "$ending_index" "$extra_label" 'Next' 'Exit'
+  ret="$?"
+
+  case "$ret" in
+    0) # OK
+      screen_sequence['PREVIOUS_SCREEN']='latest_patchsets_from_mailing_list'
+      screen_sequence['SHOW_SCREEN_PARAMETER']=${list_of_mailinglist_patches["$menu_return_string"]}
+      screen_sequence['SHOW_SCREEN']='patchset_details_and_actions'
+      ;;
+    1) # Next
+      ((PAGE++))
+      ;;
+    2) # Exit
+      handle_exit 1
+      ;;
+    3) # Previous
+      ((PAGE--))
+      if [[ "$PAGE" == 0 ]]; then
+        reset_current_lore_fetch_session
+        PAGE=1
+        formatted_patchsets_list=()
+        screen_sequence['SHOW_SCREEN']='registered_mailing_lists'
+      fi
+      ;;
+  esac
 }

--- a/src/ui/patch_hub/latest_patchsets_from_mailing_list.sh
+++ b/src/ui/patch_hub/latest_patchsets_from_mailing_list.sh
@@ -14,8 +14,7 @@ function show_latest_patchsets_from_mailing_list()
 
   create_loading_screen_notification "Loading patchsets from ${current_mailing_list} list"
   # Query patches from mailing list, this info will be saved at `list_of_mailinglist_patches[@]`.
-  fetch_latest_patchsets_from "$current_mailing_list" "$PAGE" \
-    "${lore_config['patchsets_per_page']}" "${lore_config['lore_requests_timeframe']}"
+  fetch_latest_patchsets_from "$current_mailing_list" "$PAGE" "${lore_config['patchsets_per_page']}"
   if [[ "$?" != 0 ]]; then
     create_message_box 'Error' "Couldn't fetch patchsets from ${current_mailing_list} list."
     screen_sequence['SHOW_SCREEN']='registered_mailing_lists'
@@ -49,7 +48,7 @@ function show_latest_patchsets_from_mailing_list()
     3) # Previous
       ((PAGE--))
       if [[ "$PAGE" == 0 ]]; then
-        reset_current_lore_fetch_session "${lore_config['lore_requests_timeframe']}"
+        reset_current_lore_fetch_session
         PAGE=1
         formatted_patchsets_list=()
         screen_sequence['SHOW_SCREEN']='registered_mailing_lists'

--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -64,8 +64,8 @@ function patch_hub_main_loop()
         show_registered_mailing_lists
         ret="$?"
         ;;
-      'show_new_patches_in_the_mailing_list')
-        show_new_patches_in_the_mailing_list "${screen_sequence['SHOW_SCREEN_PARAMETER']}"
+      'latest_patchsets_from_mailing_list')
+        show_latest_patchsets_from_mailing_list "${screen_sequence['SHOW_SCREEN_PARAMETER']}"
         ret="$?"
         ;;
       'bookmarked_patches')
@@ -155,7 +155,7 @@ function show_registered_mailing_lists()
   selected_list_index=$((menu_return_string - 1)) # Normalize array index
   case "$ret" in
     0) # OK
-      screen_sequence['SHOW_SCREEN']='show_new_patches_in_the_mailing_list'
+      screen_sequence['SHOW_SCREEN']='latest_patchsets_from_mailing_list'
       screen_sequence['SHOW_SCREEN_PARAMETER']="${registered_mailing_lists[$selected_list_index]}"
       ;;
     1) # Exit
@@ -194,8 +194,8 @@ function list_patches()
   case "$ret" in
     0) # OK
       case "${screen_sequence['SHOW_SCREEN']}" in
-        'show_new_patches_in_the_mailing_list')
-          screen_sequence['PREVIOUS_SCREEN']='show_new_patches_in_the_mailing_list'
+        'latest_patchsets_from_mailing_list')
+          screen_sequence['PREVIOUS_SCREEN']='latest_patchsets_from_mailing_list'
           menu_return_string=$((menu_return_string - 1))
           screen_sequence['SHOW_SCREEN_PARAMETER']=${list_of_mailinglist_patches["$menu_return_string"]}
           ;;

--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -153,7 +153,6 @@ function show_registered_mailing_lists()
     0) # OK
       screen_sequence['SHOW_SCREEN']='latest_patchsets_from_mailing_list'
       current_mailing_list="${registered_mailing_lists["$menu_return_string"]}"
-      reset_current_lore_fetch_session "${lore_config['lore_requests_timeframe']}"
       ;;
     1) # Exit
       handle_exit "$ret"

--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -17,6 +17,7 @@ include "${KW_LIB_DIR}/lib/kwlib.sh"
 include "${KW_LIB_DIR}/ui/patch_hub/lore_mailing_lists.sh"
 include "${KW_LIB_DIR}/ui/patch_hub/settings.sh"
 include "${KW_LIB_DIR}/ui/patch_hub/patchset_details_and_actions.sh"
+include "${KW_LIB_DIR}/ui/patch_hub/latest_patchsets_from_mailing_list.sh"
 
 # These are references to data structures used all around the state-machine.
 declare -ga patches_from_mailing_list
@@ -164,27 +165,6 @@ function show_registered_mailing_lists()
       screen_sequence['SHOW_SCREEN']='dashboard'
       ;;
   esac
-}
-
-function show_new_patches_in_the_mailing_list()
-{
-  local -a new_patches
-  local fallback_message
-
-  # If returning from a 'patchset_details_and_actions' screen, i.e., we already fetched the
-  # information needed to render this screen.
-  if [[ -n "${screen_sequence['RETURNING']}" ]]; then
-    # Avoiding stale value
-    screen_sequence['RETURNING']=''
-  else
-    current_mailing_list="$1"
-    create_loading_screen_notification "Loading patches from ${current_mailing_list} list"
-    # Query patches from mailing list, this info will be saved at "${list_of_mailinglist_patches[@]}".
-    get_patches_from_mailing_list "$current_mailing_list" patches_from_mailing_list
-  fi
-
-  fallback_message='kw could not retrieve patches from this mailing list'
-  list_patches "Patches from ${current_mailing_list}" patches_from_mailing_list "${fallback_message}"
 }
 
 # This is a generic function used to show a list of patches. If the user select

--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -153,6 +153,7 @@ function show_registered_mailing_lists()
     0) # OK
       screen_sequence['SHOW_SCREEN']='latest_patchsets_from_mailing_list'
       current_mailing_list="${registered_mailing_lists["$menu_return_string"]}"
+      reset_current_lore_fetch_session "${lore_config['lore_requests_timeframe']}"
       ;;
     1) # Exit
       handle_exit "$ret"

--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -108,13 +108,13 @@ function dashboard_entry_menu()
   fi
 
   case "$menu_return_string" in
-    1) # Registered mailing list
+    0) # Registered mailing list
       screen_sequence['SHOW_SCREEN']='registered_mailing_lists'
       ;;
-    2) # Bookmarked patches
+    1) # Bookmarked patches
       screen_sequence['SHOW_SCREEN']='bookmarked_patches'
       ;;
-    3) # Settings
+    2) # Settings
       screen_sequence['SHOW_SCREEN']='settings'
       ;;
   esac
@@ -140,7 +140,6 @@ function show_registered_mailing_lists()
 {
   local -a registered_mailing_lists
   local message_box
-  local selected_list_index
   local ret
 
   # Load registered mailing lists from config file into array
@@ -149,14 +148,13 @@ function show_registered_mailing_lists()
   message_box='Below, you can see the lore.kernel.org mailing lists that you have registered.'$'\n'
   message_box+='Select a mailing list to see the latest patchsets sent to it.'
 
-  create_menu_options 'Registered Mailing Lists' "$message_box" 'registered_mailing_lists' 1
+  create_menu_options 'Registered Mailing Lists' "$message_box" 'registered_mailing_lists' '' '' 'Return'
   ret="$?"
 
-  selected_list_index=$((menu_return_string - 1)) # Normalize array index
   case "$ret" in
     0) # OK
       screen_sequence['SHOW_SCREEN']='latest_patchsets_from_mailing_list'
-      screen_sequence['SHOW_SCREEN_PARAMETER']="${registered_mailing_lists[$selected_list_index]}"
+      screen_sequence['SHOW_SCREEN_PARAMETER']="${registered_mailing_lists["$menu_return_string"]}"
       ;;
     1) # Exit
       handle_exit "$ret"
@@ -188,7 +186,7 @@ function list_patches()
     return "$?"
   fi
 
-  create_menu_options "${menu_title}" '' '_target_array_list' 1
+  create_menu_options "${menu_title}" '' '_target_array_list' '' '' 'Return'
   ret="$?"
 
   case "$ret" in
@@ -196,11 +194,11 @@ function list_patches()
       case "${screen_sequence['SHOW_SCREEN']}" in
         'latest_patchsets_from_mailing_list')
           screen_sequence['PREVIOUS_SCREEN']='latest_patchsets_from_mailing_list'
-          menu_return_string=$((menu_return_string - 1))
           screen_sequence['SHOW_SCREEN_PARAMETER']=${list_of_mailinglist_patches["$menu_return_string"]}
           ;;
         'bookmarked_patches')
           screen_sequence['PREVIOUS_SCREEN']='bookmarked_patches'
+          menu_return_string=$((menu_return_string + 1))
           screen_sequence['SHOW_SCREEN_PARAMETER']=$(get_bookmarked_series_by_index "$menu_return_string")
           ;;
       esac

--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -20,7 +20,6 @@ include "${KW_LIB_DIR}/ui/patch_hub/patchset_details_and_actions.sh"
 include "${KW_LIB_DIR}/ui/patch_hub/latest_patchsets_from_mailing_list.sh"
 
 # These are references to data structures used all around the state-machine.
-declare -ga patches_from_mailing_list
 declare -ga bookmarked_series
 declare -g current_mailing_list
 
@@ -30,7 +29,6 @@ declare -gA screen_sequence=(
   ['SHOW_SCREEN']=''
   ['SHOW_SCREEN_PARAMETER']=''
   ['PREVIOUS_SCREEN']=''
-  ['RETURNING']=''
 )
 
 # This function is the main loop of the state-machine that represents the feature.
@@ -65,7 +63,7 @@ function patch_hub_main_loop()
         ret="$?"
         ;;
       'latest_patchsets_from_mailing_list')
-        show_latest_patchsets_from_mailing_list "${screen_sequence['SHOW_SCREEN_PARAMETER']}"
+        show_latest_patchsets_from_mailing_list
         ret="$?"
         ;;
       'bookmarked_patches')
@@ -154,7 +152,7 @@ function show_registered_mailing_lists()
   case "$ret" in
     0) # OK
       screen_sequence['SHOW_SCREEN']='latest_patchsets_from_mailing_list'
-      screen_sequence['SHOW_SCREEN_PARAMETER']="${registered_mailing_lists["$menu_return_string"]}"
+      current_mailing_list="${registered_mailing_lists["$menu_return_string"]}"
       ;;
     1) # Exit
       handle_exit "$ret"

--- a/src/ui/patch_hub/patchset_details_and_actions.sh
+++ b/src/ui/patch_hub/patchset_details_and_actions.sh
@@ -52,7 +52,6 @@ function show_patchset_details_and_actions()
 
     3) # Return
       screen_sequence['SHOW_SCREEN']="${screen_sequence['PREVIOUS_SCREEN']}"
-      screen_sequence['RETURNING']=1
       ;;
   esac
 }

--- a/src/ui/patch_hub/settings.sh
+++ b/src/ui/patch_hub/settings.sh
@@ -17,24 +17,24 @@ function show_settings_screen()
     'Kernel Tree Path'
     'Kernel Tree Target Branch'
   )
-  create_menu_options 'Settings' '' 'menu_list_string_array' 1
+  create_menu_options 'Settings' '' 'menu_list_string_array' '' '' 'Return'
   ret="$?"
 
   case "$ret" in
     0) # OK
       case "$menu_return_string" in
-        1) # Register/Unregister Mailing Lists
+        0) # Register/Unregister Mailing Lists
           screen_sequence['SHOW_SCREEN']='lore_mailing_lists'
           ;;
-        2) # Save Patches To
+        1) # Save Patches To
           change_save_patches_to_setting "$lore_config_path"
           screen_sequence['SHOW_SCREEN']='settings'
           ;;
-        3) # Kernel Tree Path
+        2) # Kernel Tree Path
           change_kernel_tree_path_setting "$lore_config_path"
           screen_sequence['SHOW_SCREEN']='settings'
           ;;
-        4) # Kernel Tree Target Branch
+        3) # Kernel Tree Target Branch
           change_kernel_tree_branch_setting "$lore_config_path"
           screen_sequence['SHOW_SCREEN']='settings'
           ;;

--- a/src/ui/patch_hub/settings.sh
+++ b/src/ui/patch_hub/settings.sh
@@ -17,7 +17,6 @@ function show_settings_screen()
     'Kernel Tree Path'
     'Kernel Tree Target Branch'
     'Patchsets Per Page'
-    'Lore Requests Timeframe'
   )
   create_menu_options 'Settings' '' 'menu_list_string_array' '' '' 'Return'
   ret="$?"
@@ -42,10 +41,6 @@ function show_settings_screen()
           ;;
         4) # Patchsets Per Page
           change_patchsets_per_page_setting "$lore_config_path"
-          screen_sequence['SHOW_SCREEN']='settings'
-          ;;
-        5) # Lore Requests Timeframe
-          change_lore_requests_timeframe_setting "$lore_config_path"
           screen_sequence['SHOW_SCREEN']='settings'
           ;;
       esac
@@ -202,74 +197,6 @@ function change_patchsets_per_page_setting()
     0) # OK
       new_value=$(printf '%s' "$menu_return_string" | sed 's/\/$//' | cut --delimiter=' ' -f1)
       save_new_lore_config 'patchsets_per_page' "$new_value" "$lore_config_path"
-
-      # As we altered the settings, we need to reload lore.config
-      load_lore_config
-      ;;
-
-    1) # Cancel
-      ;;
-  esac
-}
-
-# This function handles the action of changing the 'lore_requests_timeframe' setting of lore.
-function change_lore_requests_timeframe_setting()
-{
-  local lore_config_path="$1"
-  local message_box
-  local new_value
-  local -a choices
-  local -a check_statuses
-  local index=0
-
-  choices=(
-    '1 week'
-    '2 weeks'
-    '1 month'
-    '6 months'
-  )
-  index=0
-  for choice in "${choices[@]}"; do
-    case "$choice" in
-      '1 week')
-        [[ "${lore_config['lore_requests_timeframe']}" == 7 ]] && check_statuses["$index"]=1
-        ;;
-      '2 weeks')
-        [[ "${lore_config['lore_requests_timeframe']}" == 14 ]] && check_statuses["$index"]=1
-        ;;
-      '1 month')
-        [[ "${lore_config['lore_requests_timeframe']}" == 30 ]] && check_statuses["$index"]=1
-        ;;
-      '6 months')
-        [[ "${lore_config['lore_requests_timeframe']}" == 180 ]] && check_statuses["$index"]=1
-        ;;
-    esac
-    ((index++))
-  done
-
-  message_box='Select the size of the time period that patch-hub will consider when fetching '
-  message_box+='patches from lore.kernel.org servers.'$'\n'
-  message_box+='For more idle lists, a bigger value may work better.'
-  create_choice_list_screen 'Lore Requests Timeframe' "$message_box" 'choices' 'check_statuses'
-
-  case "$?" in
-    0) # OK
-      new_value=$(printf '%s' "$menu_return_string" | sed 's/\/$//')
-      case "$new_value" in
-        '1 week')
-          new_value=7
-          ;;
-        '2 weeks')
-          new_value=14
-          ;;
-        '1 month')
-          new_value=30
-          ;;
-        '6 months')
-          new_value=180
-          ;;
-      esac
-      save_new_lore_config 'lore_requests_timeframe' "$new_value" "$lore_config_path"
 
       # As we altered the settings, we need to reload lore.config
       load_lore_config

--- a/tests/lib/dialog_ui_test.sh
+++ b/tests/lib/dialog_ui_test.sh
@@ -60,33 +60,34 @@ function test_create_menu_options_rely_on_some_default_options()
 {
   local menu_title='kunit test inside kw'
   local menu_message_box='This should be a useful message box'
-  local -a menu_list_string_array=("I'm number 1" "I'm number 2")
-  local expected_cmd=" dialog --backtitle \$'${KW_PATCH_HUB_TITLE}'"
+  local -a menu_list_string_array=("I'm number 0" "I'm number 1" "I'm number 2" "I'm number 3" "I'm number 4" "I'm number 5")
+  local expected=" dialog --backtitle \$'${KW_PATCH_HUB_TITLE}'"
   local output
 
-  expected_cmd+=" --title $'${menu_title}' --clear --colors --cancel-label $'Exit' --menu $'${menu_message_box}'"
-  expected_cmd+=" '${EXPECTED_DEFAULT_HEIGHT}' '${EXPECTED_DEFAULT_WIDTH}' '0'"
-  expected_cmd+=" '1' $'I\'m number 1' '2' $'I\'m number 2'"
+  expected+=" --title $'${menu_title}' --clear --colors --cancel-label $'Exit' --menu $'${menu_message_box}'"
+  expected+=" '${EXPECTED_DEFAULT_HEIGHT}' '${EXPECTED_DEFAULT_WIDTH}' '0'"
+  expected+=" '0' $'I\'m number 0' '1' $'I\'m number 1' '2' $'I\'m number 2' '3' $'I\'m number 3' '4' $'I\'m number 4' '5' $'I\'m number 5'"
 
-  output=$(create_menu_options "$menu_title" "$menu_message_box" menu_list_string_array '' '' '' '' '' '' 'TEST_MODE')
-  assert_equals_helper 'Expected simple dialog menu' "$LINENO" "${output}" "${expected_cmd}"
+  output=$(create_menu_options "$menu_title" "$menu_message_box" menu_list_string_array '' '' '' '' '' '' '' '' 'TEST_MODE')
+  assert_equals_helper 'Expected menu with some default options' "$LINENO" "$expected" "$output"
 }
 
 function test_create_menu_options_use_all_options()
 {
   local menu_title='kunit test inside kw'
   local menu_message_box='This should be a useful message box'
-  local -a menu_list_string_array=("I'm number 1" "I'm number 2")
-  local expected_cmd=" dialog --backtitle \$'${KW_PATCH_HUB_TITLE}'"
+  local -a menu_list_string_array=("I'm number 0" "I'm number 1" "I'm number 2" "I'm number 3" "I'm number 4" "I'm number 5")
+  local expected=" dialog --backtitle \$'${KW_PATCH_HUB_TITLE}'"
   local output
 
-  expected_cmd+=" --title $'${menu_title}' --clear --colors --cancel-label $'Xpto'"
-  expected_cmd+=" --extra-button --extra-label 'Return' --menu $'${menu_message_box}'"
-  expected_cmd+=" '300' '300' '1'"
-  expected_cmd+=" $'I\'m number 1' '' $'I\'m number 2' ''"
+  expected+=" --title $'${menu_title}' --clear --colors --cancel-label $'Xpto'"
+  expected+=" --extra-button --extra-label $'Return' --help-button --help-label $'LoremIpsum'"
+  expected+=" --menu $'${menu_message_box}'"
+  expected+=" '300' '300' '0'"
+  expected+=" $'I\'m number 2' '' $'I\'m number 3' '' $'I\'m number 4' ''"
 
-  output=$(create_menu_options "$menu_title" "$menu_message_box" menu_list_string_array 1 'Xpto' '300' '300' '1' '1' 'TEST_MODE')
-  assert_equals_helper 'Expected custom dialog menu' "$LINENO" "${output}" "${expected_cmd}"
+  output=$(create_menu_options "$menu_title" "$menu_message_box" menu_list_string_array 2 4 'Return' 'Xpto' 'LoremIpsum' 300 300 1 'TEST_MODE')
+  assert_equals_helper 'Expected menu with with all custom options' "$LINENO" "$expected" "$output"
 }
 
 function test_create_simple_checklist_rely_on_some_default_options()

--- a/tests/lib/dialog_ui_test.sh
+++ b/tests/lib/dialog_ui_test.sh
@@ -381,6 +381,41 @@ function test_create_form_screen_all_options()
   assert_equals_helper 'Expected form with default values' "$LINENO" "$expected_cmd" "$output"
 }
 
+function test_create_rangebox_screen_rely_on_some_default_options()
+{
+  local box_title="Select a 'value' from this range"
+  local message_box="This is \`a rangebox'."
+  local expected_cmd
+  local output
+
+  expected_cmd=" dialog --backtitle $'${KW_PATCH_HUB_TITLE}'"
+  expected_cmd+=" --title $'Select a \'value\' from this range' --clear --colors"
+  expected_cmd+=" --cancel-label $'Exit'"
+  expected_cmd+=" --rangebox $'This is \`a rangebox\'.'"
+  expected_cmd+=" '10' '60'"
+  expected_cmd+=" '0' '100' '50'"
+  output=$(create_rangebox_screen "$box_title" "$message_box" '' '' '' '' '' '' '' '' 'TEST_MODE')
+  assert_equals_helper 'Expected Rangebox with some default options' "$LINENO" "$expected_cmd" "$output"
+}
+
+function test_create_rangebox_screen_use_all_options()
+{
+  local box_title="Select a 'value' from this range"
+  local message_box="This is \`a rangebox'."
+  local expected_cmd
+  local output
+
+  expected_cmd=" dialog --backtitle $'${KW_PATCH_HUB_TITLE}'"
+  expected_cmd+=" --title $'Select a \'value\' from this range' --clear --colors"
+  expected_cmd+=" --cancel-label $'Cancel'"
+  expected_cmd+=" --extra-button --extra-label $'range' --help-button --help-label $'box'"
+  expected_cmd+=" --rangebox $'This is \`a rangebox\'.'"
+  expected_cmd+=" '2718' '31415'"
+  expected_cmd+=" '23' '42' '318'"
+  output=$(create_rangebox_screen "$box_title" "$message_box" 23 42 318 'range' 'Cancel' 'box' 2718 31415 'TEST_MODE')
+  assert_equals_helper 'Expected Rangebox with all custom options' "$LINENO" "$expected_cmd" "$output"
+}
+
 function test_build_dialog_command_preamble()
 {
   local output

--- a/tests/lib/dialog_ui_test.sh
+++ b/tests/lib/dialog_ui_test.sh
@@ -262,7 +262,47 @@ function test_create_help_screen()
   assert_equals_helper 'Wrong help screen for Directory Selection' "$LINENO" "$expected_cmd" "$output"
 }
 
-function test_create_choice_list_screen_rely_on_some_default_options()
+function test_create_choice_list_screen_with_indexed_array_rely_on_some_default_options()
+{
+  local box_title="Make 'a' choice!"
+  local message_box="Select \`one' of the below options."
+  # shellcheck disable=SC2190
+  local -a choices=('choice1' 'choice2' 'choice3' 'choice4')
+  local -a check_statuses=('' 1 '' '')
+  local expected_cmd
+  local output
+
+  expected_cmd=" dialog --backtitle $'${KW_PATCH_HUB_TITLE}'"
+  expected_cmd+=" --title $'Make \'a\' choice!' --clear --colors"
+  expected_cmd+=" --ok-label $'Ok' --cancel-label $'Cancel'"
+  expected_cmd+=" --radiolist $'Select \`one\' of the below options.'"
+  expected_cmd+=" '${EXPECTED_DEFAULT_HEIGHT}' '${EXPECTED_DEFAULT_WIDTH}' '0'"
+  expected_cmd+=" $'choice1' '' 'off' $'choice2' '' 'on' $'choice3' '' 'off' $'choice4' '' 'off'"
+  output=$(create_choice_list_screen "$box_title" "$message_box" 'choices' 'check_statuses' '' '' '' '' '' 'TEST_MODE')
+  assert_equals_helper 'Expected choice list with some default options' "$LINENO" "$expected_cmd" "$output"
+}
+
+function test_create_choice_list_screen_with_indexed_array_use_all_options()
+{
+  local box_title="Make 'a' choice!"
+  local message_box="Select \`one' of the below options."
+  # shellcheck disable=SC2190
+  local -a choices=('choice1' 'choice2' 'choice3' 'choice4')
+  local -a check_statuses=('' 1 '' '')
+  local expected_cmd
+  local output
+
+  expected_cmd=" dialog --backtitle $'${KW_PATCH_HUB_TITLE}'"
+  expected_cmd+=" --title $'Make \'a\' choice!' --clear --colors"
+  expected_cmd+=" --ok-label $'Next' --cancel-label $'Previous' --extra-button --extra-label $'Cancel'"
+  expected_cmd+=" --radiolist $'Select \`one\' of the below options.'"
+  expected_cmd+=" '17041998' '10300507' '0'"
+  expected_cmd+=" $'choice1' '' 'off' $'choice2' '' 'on' $'choice3' '' 'off' $'choice4' '' 'off'"
+  output=$(create_choice_list_screen "$box_title" "$message_box" 'choices' 'check_statuses' 'Next' 'Previous' 'Cancel' '17041998' '10300507' 'TEST_MODE')
+  assert_equals_helper 'Expected choice list with all custom options' "$LINENO" "$expected_cmd" "$output"
+}
+
+function test_create_choice_list_screen_with_associative_array_rely_on_some_default_options()
 {
   local box_title="Make 'a' choice!"
   local message_box="Select \`one' of the below options."
@@ -281,7 +321,7 @@ function test_create_choice_list_screen_rely_on_some_default_options()
   assert_equals_helper 'Expected choice list with some default options' "$LINENO" "$expected_cmd" "$output"
 }
 
-function test_create_choice_list_screen_use_all_options()
+function test_create_choice_list_screen_with_associative_array_use_all_options()
 {
   local box_title="Make 'a' choice!"
   local message_box="Select \`one' of the below options."

--- a/tests/lib/lore_test.sh
+++ b/tests/lib/lore_test.sh
@@ -592,7 +592,7 @@ function test_process_patchsets()
   assert_equals_helper 'Wrong patchset at index 1' "$LINENO" "$expected" "${list_of_mailinglist_patches[1]}"
 }
 
-function test_reset_current_lore_fetch_session()
+function test_reset_current_lore_fetch_session_valid_argument()
 {
   list_of_mailinglist_patches[0]=1
   list_of_mailinglist_patches[1]=1
@@ -601,10 +601,39 @@ function test_reset_current_lore_fetch_session()
   DAYS=16
   LAST_TIMESTAMP='2023-01-01T00:00:00Z'
 
-  reset_current_lore_fetch_session
+  reset_current_lore_fetch_session 2
   assert_equals_helper 'Should reset `list_of_mailinglist_patches`' "$LINENO" 0 "${#list_of_mailinglist_patches[@]}"
   assert_equals_helper 'Should reset `PATCHSETS_PROCESSED`' "$LINENO" 0 "$PATCHSETS_PROCESSED"
-  assert_equals_helper 'Should reset lower end of timeframe' "$LINENO" "$TIMEFRAME_SIZE_IN_DAYS" "$DAYS"
+  assert_equals_helper 'Should reset lower end of timeframe' "$LINENO" 2 "$DAYS"
+  assert_equals_helper 'Should reset upper end of timeframe' "$LINENO" '' "$LAST_TIMESTAMP"
+}
+
+function test_reset_current_lore_fetch_session_invalid_argument()
+{
+  list_of_mailinglist_patches[0]=1
+  list_of_mailinglist_patches[1]=1
+  list_of_mailinglist_patches[2]=1
+  PATCHSETS_PROCESSED=3
+  DAYS=16
+  LAST_TIMESTAMP='2023-01-01T00:00:00Z'
+
+  reset_current_lore_fetch_session ''
+  assert_equals_helper 'Should reset `list_of_mailinglist_patches`' "$LINENO" 0 "${#list_of_mailinglist_patches[@]}"
+  assert_equals_helper 'Should reset `PATCHSETS_PROCESSED`' "$LINENO" 0 "$PATCHSETS_PROCESSED"
+  assert_equals_helper 'Should reset lower end of timeframe' "$LINENO" 14 "$DAYS"
+  assert_equals_helper 'Should reset upper end of timeframe' "$LINENO" '' "$LAST_TIMESTAMP"
+
+  list_of_mailinglist_patches[0]=1
+  list_of_mailinglist_patches[1]=1
+  list_of_mailinglist_patches[2]=1
+  PATCHSETS_PROCESSED=3
+  DAYS=16
+  LAST_TIMESTAMP='2023-01-01T00:00:00Z'
+
+  reset_current_lore_fetch_session '12x00'
+  assert_equals_helper 'Should reset `list_of_mailinglist_patches`' "$LINENO" 0 "${#list_of_mailinglist_patches[@]}"
+  assert_equals_helper 'Should reset `PATCHSETS_PROCESSED`' "$LINENO" 0 "$PATCHSETS_PROCESSED"
+  assert_equals_helper 'Should reset lower end of timeframe' "$LINENO" 14 "$DAYS"
   assert_equals_helper 'Should reset upper end of timeframe' "$LINENO" '' "$LAST_TIMESTAMP"
 }
 
@@ -635,24 +664,26 @@ function test_format_patchsets()
 function test_get_page_starting_index()
 {
   local page
+  local patchsets_per_page
   local output
 
-  NUMBER_OF_PATCHSETS_PER_PAGE=42
   page=5
+  patchsets_per_page=42
 
-  output=$(get_page_starting_index "$page")
+  output=$(get_page_starting_index "$page" "$patchsets_per_page")
   assert_equals_helper 'Wrong starting index outputted' "$LINENO" 168 "$output"
 }
 
 function test_get_page_ending_index()
 {
   local page
+  local patchsets_per_page
   local output
 
-  NUMBER_OF_PATCHSETS_PER_PAGE=42
   page=5
+  patchsets_per_page=42
 
-  output=$(get_page_ending_index "$page")
+  output=$(get_page_ending_index "$page" "$patchsets_per_page")
   assert_equals_helper 'Wrong ending index outputted' "$LINENO" 209 "$output"
 }
 

--- a/tests/lib/lore_test.sh
+++ b/tests/lib/lore_test.sh
@@ -441,100 +441,51 @@ function test_save_new_lore_config()
   assert_equals_helper 'Wrong lore.config contents' "$LINENO" "$expected" "$output"
 }
 
-function test_is_in_lore_timestamp_format_with_invalid_format()
-{
-  local timestamp
-
-  timestamp='Aug 23, 2021 at 11:24pm'
-  is_in_lore_timestamp_format "$timestamp"
-  assert_equals_helper 'Invalid format should return 1' "$LINENO" 1 "$?"
-
-  timestamp='29-12-2023T12:12:12Z'
-  is_in_lore_timestamp_format "$timestamp"
-  assert_equals_helper 'Invalid format should return 1' "$LINENO" 1 "$?"
-
-  timestamp='2023-01-01 23:34:32'
-  is_in_lore_timestamp_format "$timestamp"
-  assert_equals_helper 'Invalid format should return 1' "$LINENO" 1 "$?"
-
-  timestamp='2023-09-17T11:01:07Z '
-  is_in_lore_timestamp_format "$timestamp"
-  assert_equals_helper 'Invalid format should return 1' "$LINENO" 1 "$?"
-
-  timestamp='2023-11-31T01:22:32Z'
-  is_in_lore_timestamp_format "$timestamp"
-  assert_equals_helper 'Invalid date should return 1' "$LINENO" 1 "$?"
-}
-
-function test_is_in_lore_timestamp_format_with_valid_format()
-{
-  local timestamp
-
-  timestamp='2023-12-31T12:12:12Z'
-  is_in_lore_timestamp_format "$timestamp"
-  assert_equals_helper 'Valid format and date should return 0' "$LINENO" 0 "$?"
-}
-
 function test_compose_lore_query_url_with_verification_invalid_cases()
 {
   local target_mailing_list
-  local lower_end_in_days_ago
-  local upper_end_in_timestamp
-  local output
-  local expected
-
-  target_mailing_list='amd-gfx'
-  lower_end_in_days_ago=''
-  upper_end_in_timestamp=''
-  compose_lore_query_url_with_verification "$target_mailing_list" "$lower_end_in_days_ago" "$upper_end_in_timestamp"
-  assert_equals_helper 'Empty `lower_end_in_days_ago` should return 22' "$LINENO" 22 "$?"
+  local min_index
 
   target_mailing_list=''
-  lower_end_in_days_ago='8'
-  upper_end_in_timestamp=''
-  compose_lore_query_url_with_verification "$target_mailing_list" "$lower_end_in_days_ago" "$upper_end_in_timestamp"
+  min_index='200'
+  compose_lore_query_url_with_verification "$target_mailing_list" "$min_index"
   assert_equals_helper 'Empty `target_mailing_list` should return 22' "$LINENO" 22 "$?"
 
   target_mailing_list='amd-gfx'
-  lower_end_in_days_ago='8332o14'
+  min_index=''
   upper_end_in_timestamp='2023-01-01T00:00:00Z'
-  compose_lore_query_url_with_verification "$target_mailing_list" "$lower_end_in_days_ago" "$upper_end_in_timestamp"
-  assert_equals_helper 'Invalid `lower_end_in_days_ago` (not an integer) value should return 22' "$LINENO" 22 "$?"
+  compose_lore_query_url_with_verification "$target_mailing_list" "$min_index"
+  assert_equals_helper 'Empty `min_index` value should return 22' "$LINENO" 22 "$?"
 
   target_mailing_list='amd-gfx'
-  lower_end_in_days_ago='8'
-  upper_end_in_timestamp='2023-13-01T00:00:00Z'
-  compose_lore_query_url_with_verification "$target_mailing_list" "$lower_end_in_days_ago" "$upper_end_in_timestamp"
-  assert_equals_helper 'Invalid `upper_end_in_timestamp` (invalid date) value should return 22' "$LINENO" 22 "$?"
+  min_index='20a0'
+  compose_lore_query_url_with_verification "$target_mailing_list" "$min_index"
+  assert_equals_helper 'Invalid `min_index` (not an integer) value should return 22' "$LINENO" 22 "$?"
 
   target_mailing_list='amd-gfx'
-  lower_end_in_days_ago='8'
-  upper_end_in_timestamp='2023/01/01T00:00:00Z'
-  compose_lore_query_url_with_verification "$target_mailing_list" "$lower_end_in_days_ago" "$upper_end_in_timestamp"
-  assert_equals_helper 'Invalid `upper_end_in_timestamp` (wrong timestamp format) value should return 22' "$LINENO" 22 "$?"
+  min_index='200 '
+  compose_lore_query_url_with_verification "$target_mailing_list" "$min_index"
+  assert_equals_helper 'Invalid `min_index` (not an integer) value should return 22' "$LINENO" 22 "$?"
 }
 
 function test_compose_lore_query_url_with_verification_valid_cases()
 {
   local target_mailing_list
-  local lower_end_in_days_ago
-  local upper_end_in_timestamp
+  local min_index
   local output
   local expected
 
   target_mailing_list='amd-gfx'
-  lower_end_in_days_ago='8'
-  upper_end_in_timestamp=''
-  expected='https://lore.kernel.org/amd-gfx/?q=rt:8.day.ago..+AND+NOT+s:Re&x=A'
-  output=$(compose_lore_query_url_with_verification "$target_mailing_list" "$lower_end_in_days_ago" "$upper_end_in_timestamp")
-  assert_equals_helper 'Empty `upper_end_in_timestamp` should return 0' "$LINENO" 0 "$?"
+  min_index='200'
+  expected='https://lore.kernel.org/amd-gfx/?q=rt:..+AND+NOT+s:Re&x=A&o=200'
+  output=$(compose_lore_query_url_with_verification "$target_mailing_list" "$min_index")
+  assert_equals_helper 'Valid arguments should return 0' "$LINENO" 0 "$?"
   assert_equals_helper 'Wrong query URL outputted' "$LINENO" "$expected" "$output"
 
   target_mailing_list='amd-gfx'
-  lower_end_in_days_ago='8'
-  upper_end_in_timestamp='2023-01-01T00:00:00Z'
-  expected='https://lore.kernel.org/amd-gfx/?q=rt:8.day.ago..2023-01-01T00:00:00Z+AND+NOT+s:Re&x=A'
-  output=$(compose_lore_query_url_with_verification "$target_mailing_list" "$lower_end_in_days_ago" "$upper_end_in_timestamp")
+  min_index='-200'
+  expected='https://lore.kernel.org/amd-gfx/?q=rt:..+AND+NOT+s:Re&x=A&o=-200'
+  output=$(compose_lore_query_url_with_verification "$target_mailing_list" "$min_index")
   assert_equals_helper 'Valid arguments should return 0' "$LINENO" 0 "$?"
   assert_equals_helper 'Wrong query URL outputted' "$LINENO" "$expected" "$output"
 }
@@ -592,49 +543,18 @@ function test_process_patchsets()
   assert_equals_helper 'Wrong patchset at index 1' "$LINENO" "$expected" "${list_of_mailinglist_patches[1]}"
 }
 
-function test_reset_current_lore_fetch_session_valid_argument()
+function test_reset_current_lore_fetch_session()
 {
   list_of_mailinglist_patches[0]=1
   list_of_mailinglist_patches[1]=1
   list_of_mailinglist_patches[2]=1
   PATCHSETS_PROCESSED=3
-  DAYS=16
-  LAST_TIMESTAMP='2023-01-01T00:00:00Z'
+  MIN_INDEX=200
 
   reset_current_lore_fetch_session 2
   assert_equals_helper 'Should reset `list_of_mailinglist_patches`' "$LINENO" 0 "${#list_of_mailinglist_patches[@]}"
   assert_equals_helper 'Should reset `PATCHSETS_PROCESSED`' "$LINENO" 0 "$PATCHSETS_PROCESSED"
-  assert_equals_helper 'Should reset lower end of timeframe' "$LINENO" 2 "$DAYS"
-  assert_equals_helper 'Should reset upper end of timeframe' "$LINENO" '' "$LAST_TIMESTAMP"
-}
-
-function test_reset_current_lore_fetch_session_invalid_argument()
-{
-  list_of_mailinglist_patches[0]=1
-  list_of_mailinglist_patches[1]=1
-  list_of_mailinglist_patches[2]=1
-  PATCHSETS_PROCESSED=3
-  DAYS=16
-  LAST_TIMESTAMP='2023-01-01T00:00:00Z'
-
-  reset_current_lore_fetch_session ''
-  assert_equals_helper 'Should reset `list_of_mailinglist_patches`' "$LINENO" 0 "${#list_of_mailinglist_patches[@]}"
-  assert_equals_helper 'Should reset `PATCHSETS_PROCESSED`' "$LINENO" 0 "$PATCHSETS_PROCESSED"
-  assert_equals_helper 'Should reset lower end of timeframe' "$LINENO" 14 "$DAYS"
-  assert_equals_helper 'Should reset upper end of timeframe' "$LINENO" '' "$LAST_TIMESTAMP"
-
-  list_of_mailinglist_patches[0]=1
-  list_of_mailinglist_patches[1]=1
-  list_of_mailinglist_patches[2]=1
-  PATCHSETS_PROCESSED=3
-  DAYS=16
-  LAST_TIMESTAMP='2023-01-01T00:00:00Z'
-
-  reset_current_lore_fetch_session '12x00'
-  assert_equals_helper 'Should reset `list_of_mailinglist_patches`' "$LINENO" 0 "${#list_of_mailinglist_patches[@]}"
-  assert_equals_helper 'Should reset `PATCHSETS_PROCESSED`' "$LINENO" 0 "$PATCHSETS_PROCESSED"
-  assert_equals_helper 'Should reset lower end of timeframe' "$LINENO" 14 "$DAYS"
-  assert_equals_helper 'Should reset upper end of timeframe' "$LINENO" '' "$LAST_TIMESTAMP"
+  assert_equals_helper 'Should reset `MIN_INDEX`' "$LINENO" 0 "$MIN_INDEX"
 }
 
 function test_format_patchsets()
@@ -667,11 +587,22 @@ function test_get_page_starting_index()
   local patchsets_per_page
   local output
 
+  # Mocking `list_of_mailinglist_patches` with 199 patchsets
+  unset list_of_mailinglist_patches
+  declare -gA list_of_mailinglist_patches
+  for i in $(seq 0 199); do
+    list_of_mailinglist_patches["$i"]=1
+  done
+
   page=5
   patchsets_per_page=42
-
   output=$(get_page_starting_index "$page" "$patchsets_per_page")
   assert_equals_helper 'Wrong starting index outputted' "$LINENO" 168 "$output"
+
+  page=5
+  patchsets_per_page=50
+  output=$(get_page_starting_index "$page" "$patchsets_per_page")
+  assert_equals_helper 'Wrong starting index outputted' "$LINENO" 199 "$output"
 }
 
 function test_get_page_ending_index()
@@ -680,11 +611,22 @@ function test_get_page_ending_index()
   local patchsets_per_page
   local output
 
-  page=5
-  patchsets_per_page=42
+  # Mocking `list_of_mailinglist_patches` with 199 patchsets
+  unset list_of_mailinglist_patches
+  declare -gA list_of_mailinglist_patches
+  for i in $(seq 0 199); do
+    list_of_mailinglist_patches["$i"]=1
+  done
 
+  page=3
+  patchsets_per_page=42
   output=$(get_page_ending_index "$page" "$patchsets_per_page")
-  assert_equals_helper 'Wrong ending index outputted' "$LINENO" 209 "$output"
+  assert_equals_helper 'Wrong ending index outputted' "$LINENO" 125 "$output"
+
+  page=5
+  patchsets_per_page=50
+  output=$(get_page_ending_index "$page" "$patchsets_per_page")
+  assert_equals_helper 'Wrong ending index outputted' "$LINENO" 199 "$output"
 }
 
 invoke_shunit

--- a/tests/lib/web_test.sh
+++ b/tests/lib/web_test.sh
@@ -6,6 +6,26 @@ include './tests/utils.sh'
 oneTimeSetUp()
 {
   export KW_CACHE_DIR='fake_cache'
+
+  cp --recursive "${SAMPLES_DIR}/web/." "$SHUNIT_TMPDIR"
+}
+
+function setUp()
+{
+  export ORIGINAL_PATH="$PWD"
+
+  cd "${SHUNIT_TMPDIR}" || {
+    fail "($LINENO): setUp(): It was not possible to move into ${SHUNIT_TMPDIR}"
+    return
+  }
+}
+
+function tearDown()
+{
+  cd "${ORIGINAL_PATH}" || {
+    fail "($LINENO): tearDown(): It was not possible to move into ${ORIGINAL_PATH}"
+    return
+  }
 }
 
 function test_download()
@@ -48,6 +68,50 @@ function test_replace_http_by_https()
   output=$(replace_http_by_https 'lore.kernel.org/')
   assert_equals_helper 'No http prefix' "($LINENO)" "$?" 1
   assert_equals_helper 'Expected https' "($LINENO)" "$output" "$expected"
+}
+
+function test_is_html_file_with_non_html_files()
+{
+  local file_path
+
+  file_path="${SHUNIT_TMPDIR}/inexistent.path"
+  is_html_file "$file_path"
+  assert_equals_helper 'Invalid file path should return 2' "$LINENO" 2 "$?"
+
+  file_path="${SHUNIT_TMPDIR}/textfile.txt"
+  touch "$file_path"
+  printf 'Hey, I am just a\nsimple\nplain text\nor, if you prefer,\na .txt' > "$file_path"
+  is_html_file "$file_path"
+  assert_equals_helper 'Non HTML file should return 1' "$LINENO" 1 "$?"
+}
+
+function test_is_html_file_with_html_files()
+{
+  local file_path
+
+  file_path="${SHUNIT_TMPDIR}/sample1.html"
+  is_html_file "$file_path"
+  assert_equals_helper 'Valid HTML file should return 0' "$LINENO" 0 "$?"
+
+  file_path="${SHUNIT_TMPDIR}/sample2.html"
+  is_html_file "$file_path"
+  assert_equals_helper 'Valid HTML file should return 0' "$LINENO" 0 "$?"
+
+  file_path="${SHUNIT_TMPDIR}/sample3.html"
+  is_html_file "$file_path"
+  assert_equals_helper 'Valid HTML file should return 0' "$LINENO" 0 "$?"
+
+  file_path="${SHUNIT_TMPDIR}/sample4.html"
+  is_html_file "$file_path"
+  assert_equals_helper 'Valid HTML file should return 0' "$LINENO" 0 "$?"
+
+  file_path="${SHUNIT_TMPDIR}/sample5.html"
+  is_html_file "$file_path"
+  assert_equals_helper 'Valid HTML file should return 0' "$LINENO" 0 "$?"
+
+  file_path="${SHUNIT_TMPDIR}/sample6.html"
+  is_html_file "$file_path"
+  assert_equals_helper 'Valid HTML file should return 0' "$LINENO" 0 "$?"
 }
 
 invoke_shunit

--- a/tests/samples/lore/query_result_sample.xml
+++ b/tests/samples/lore/query_result_sample.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="us-ascii"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+	xmlns:thr="http://purl.org/syndication/thread/1.0">
+	<title>rt:8.day.ago.. AND NOT s:Re - search results</title>
+	<link rel="alternate" type="text/html" href="http://lore.kernel.org/amd-gfx/?q=rt:8.day.ago..+AND+NOT+s:Re"/>
+	<link rel="self" href="http://lore.kernel.org/amd-gfx/?q=rt:8.day.ago..+AND+NOT+s:Re&amp;x=A"/>
+	<id>urn:uuid:1e2607f0-9e95-992c-5330-cac14ca56190</id>
+	<updated>2023-08-09T22:09:53Z</updated>
+	<entry>
+		<author>
+			<name>David Tadokoro</name>
+			<email>davidbtadokoro@usp.br</email>
+		</author>
+		<title>[PATCH] drm/amdkfd: Add missing tba_hi programming on aldebaran</title>
+		<updated>2023-08-09T21:27:00Z</updated>
+		<link href="http://lore.kernel.org/amd-gfx/20230809212615.137674-1-davidbtadokoro@usp.br/"/>
+		<id>urn:uuid:2f9fa3da-2057-86a4-aa20-9ad0239ff7a3</id>
+		<content type="xhtml">
+			<div xmlns="http://www.w3.org/1999/xhtml">
+				<pre style="white-space:pre-wrap">Previously asymptomatic because high 32 bits were zero.
+
+Fixes: 615222cfed20 (&#34;drm/amdkfd: Relocate TBA/TMA to opposite side of VM hole&#34;)
+Signed-off-by: David Tadokoro &lt;davidbtadokoro@usp.br&gt;
+---
+ drivers/gpu/drm/amd/amdkfd/kfd_packet_manager_v9.c | 1 +
+ 1 file <a href="http://lore.kernel.org/amd-gfx/20230809212615.137674-1-davidbtadokoro@usp.br/#related">changed</a>, 1 insertion(+)
+
+					<span class="head">diff --git a/drivers/gpu/drm/amd/amdkfd/kfd_packet_manager_v9.c b/drivers/gpu/drm/amd/amdkfd/kfd_packet_manager_v9.c
+index 8fda16e6fee6..8ce6f5200905 100644
+--- a/drivers/gpu/drm/amd/amdkfd/kfd_packet_manager_v9.c
++++ b/drivers/gpu/drm/amd/amdkfd/kfd_packet_manager_v9.c
+					</span>
+					<span class="hunk">@@ -121,6 +121,7 @@ static int pm_map_process_aldebaran(struct packet_manager *pm,
+					</span> 	packet-&gt;sh_mem_bases = qpd-&gt;sh_mem_bases;
+ 	if (qpd-&gt;tba_addr) {
+ 		packet-&gt;sq_shader_tba_lo = lower_32_bits(qpd-&gt;tba_addr &gt;&gt; 8);
+					<span class="add">+		packet-&gt;sq_shader_tba_hi = upper_32_bits(qpd-&gt;tba_addr &gt;&gt; 8);
+					</span> 		packet-&gt;sq_shader_tma_lo = lower_32_bits(qpd-&gt;tma_addr &gt;&gt; 8);
+ 		packet-&gt;sq_shader_tma_hi = upper_32_bits(qpd-&gt;tma_addr &gt;&gt; 8);
+ 	}
+-- 
+2.25.1
+
+				</pre>
+			</div>
+		</content>
+	</entry>
+	<entry>
+		<author>
+			<name>Rodrigo Siqueira</name>
+			<email>rodrigo.siqueira@amd.com</email>
+		</author>
+		<title type="html">[PATCH] Revert &#34;drm/amd/pm: resolve reboot exception for si oland&#34;</title>
+		<updated>2023-08-09T19:10:26Z</updated>
+		<link href="http://lore.kernel.org/amd-gfx/20230809190956.435068-2-rodrigo.siqueira@amd.com/"/>
+		<id>urn:uuid:66fe77b1-55ad-6670-73ee-54e933cf5f63</id>
+		<thr:in-reply-to ref="urn:uuid:b09294a9-df54-a8b1-cf19-6f58c2febdd3" href="http://lore.kernel.org/amd-gfx/20230809190956.435068-1-rodrigo.siqueira@amd.com/"/>
+		<content type="xhtml">
+			<div xmlns="http://www.w3.org/1999/xhtml">
+				<pre style="white-space:pre-wrap">This reverts commit e490d60a2f76bff636c68ce4fe34c1b6c34bbd86.
+
+This causes hangs on SI when DC is enabled.
+
+Link: <a href="https://gitlab.freedesktop.org/drm/amd/-/issues/2755">https://gitlab.freedesktop.org/drm/amd/-/issues/2755</a>
+Signed-off-by: Rodrigo Siqueira &lt;rodrigo.siqueira@amd.com&gt;
+---
+ drivers/gpu/drm/amd/pm/legacy-dpm/si_dpm.c | 29 ++++++++++++++++++++++
+ 1 file <a href="http://lore.kernel.org/amd-gfx/20230809190956.435068-2-rodrigo.siqueira@amd.com/#related">changed</a>, 29 insertions(+)
+
+					<span class="head">diff --git a/drivers/gpu/drm/amd/pm/legacy-dpm/si_dpm.c b/drivers/gpu/drm/amd/pm/legacy-dpm/si_dpm.c
+index 02e69ccff3ba..d6d9e3b1b2c0 100644
+--- a/drivers/gpu/drm/amd/pm/legacy-dpm/si_dpm.c
++++ b/drivers/gpu/drm/amd/pm/legacy-dpm/si_dpm.c
+					</span>
+					<span class="hunk">@@ -6925,6 +6925,23 @@ static int si_dpm_enable(struct amdgpu_device *adev)
+					</span> 	return 0;
+ }
+ 
+					<span class="add">+static int si_set_temperature_range(struct amdgpu_device *adev)
++{
++	int ret;
++
++	ret = si_thermal_enable_alert(adev, false);
++	if (ret)
++		return ret;
++	ret = si_thermal_set_temperature_range(adev, R600_TEMP_RANGE_MIN, R600_TEMP_RANGE_MAX);
++	if (ret)
++		return ret;
++	ret = si_thermal_enable_alert(adev, true);
++	if (ret)
++		return ret;
++
++	return ret;
++}
++
+					</span> static void si_dpm_disable(struct amdgpu_device *adev)
+ {
+ 	struct rv7xx_power_info *pi = rv770_get_pi(adev);
+					<span class="hunk">@@ -7609,6 +7626,18 @@ static int si_dpm_process_interrupt(struct amdgpu_device *adev,
+					</span> 
+ static int si_dpm_late_init(void *handle)
+ {
+					<span class="add">+	int ret;
++	struct amdgpu_device *adev = (struct amdgpu_device *)handle;
++
++	if (!adev-&gt;pm.dpm_enabled)
++		return 0;
++
++	ret = si_set_temperature_range(adev);
++	if (ret)
++		return ret;
++#if 0 //TODO ?
++	si_dpm_powergate_uvd(adev, true);
++#endif
+					</span> 	return 0;
+ }
+ 
+-- 
+2.41.0
+
+				</pre>
+			</div>
+		</content>
+	</entry>
+	<entry>
+		<author>
+			<name>Rodrigo Siqueira</name>
+			<email>rodrigo.siqueira@amd.com</email>
+		</author>
+		<title type="html">[PATCH] drm/amdgpu: don&#39;t allow userspace to create a doorbell BO</title>
+		<updated>2023-08-09T19:10:22Z</updated>
+		<link href="http://lore.kernel.org/amd-gfx/20230809190956.435068-1-rodrigo.siqueira@amd.com/"/>
+		<id>urn:uuid:b09294a9-df54-a8b1-cf19-6f58c2febdd3</id>
+		<content type="xhtml">
+			<div xmlns="http://www.w3.org/1999/xhtml">
+				<pre style="white-space:pre-wrap">We need the domains in amdgpu_drm.h for the kernel driver to manage
+the pool, but we don&#39;t want userspace using it until the code
+is ready.  So reject for now.
+
+Signed-off-by: Rodrigo Siqueira &lt;rodrigo.siqueira@amd.com&gt;
+---
+ drivers/gpu/drm/amd/amdgpu/amdgpu_gem.c | 4 ++++
+ 1 file <a href="http://lore.kernel.org/amd-gfx/20230809190956.435068-1-rodrigo.siqueira@amd.com/#related">changed</a>, 4 insertions(+)
+
+					<span class="head">diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_gem.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_gem.c
+index 693b1fd1191a..ca4d2d430e28 100644
+--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_gem.c
++++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_gem.c
+					</span>
+					<span class="hunk">@@ -289,6 +289,10 @@ int amdgpu_gem_create_ioctl(struct drm_device *dev, void *data,
+					</span> 	uint32_t handle, initial_domain;
+ 	int r;
+ 
+					<span class="add">+	/* reject DOORBELLs until userspace code to use it is available */
++	if (args-&gt;in.domains &#38; AMDGPU_GEM_DOMAIN_DOORBELL)
++		return -EINVAL;
++
+					</span> 	/* reject invalid gem flags */
+ 	if (flags &#38; ~(AMDGPU_GEM_CREATE_CPU_ACCESS_REQUIRED |
+ 		      AMDGPU_GEM_CREATE_NO_CPU_ACCESS |
+-- 
+2.41.0
+
+				</pre>
+			</div>
+		</content>
+	</entry>
+</feed>

--- a/tests/samples/web/sample1.html
+++ b/tests/samples/web/sample1.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Sample 1</title>
+  </head>
+  <body>
+    <p>Starting with 'doctype' in lower case</p>
+  </body>
+</html>

--- a/tests/samples/web/sample2.html
+++ b/tests/samples/web/sample2.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Sample 2</title>
+  </head>
+  <body>
+    <p>Starting with 'DOCTYPE' in upper case</p>
+  </body>
+</html>

--- a/tests/samples/web/sample3.html
+++ b/tests/samples/web/sample3.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>Sample 3</title>
+  </head>
+  <body>
+    <p>Starting with 'html' in lower case</p>
+  </body>
+</html>

--- a/tests/samples/web/sample4.html
+++ b/tests/samples/web/sample4.html
@@ -1,0 +1,8 @@
+<HTML>
+  <head>
+    <title>Sample 4</title>
+  </head>
+  <body>
+    <p>Starting with 'HTML' in upper case</p>
+  </body>
+</html>

--- a/tests/samples/web/sample5.html
+++ b/tests/samples/web/sample5.html
@@ -1,0 +1,3 @@
+  <head>
+    <title>Sample 5 only with head</title>
+  </head>

--- a/tests/samples/web/sample6.html
+++ b/tests/samples/web/sample6.html
@@ -1,0 +1,3 @@
+  <body>
+    <p>Sample 6 only with body</p>
+  </body>

--- a/tests/ui/patch_hub/latest_patchsets_from_mailing_list_test.sh
+++ b/tests/ui/patch_hub/latest_patchsets_from_mailing_list_test.sh
@@ -21,35 +21,4 @@ function tearDown()
   }
 }
 
-function test_show_latest_patchsets_from_mailing_list_title()
-{
-  declare current_mailing_list=''
-
-  # shellcheck disable=SC2317
-  function create_loading_screen_notification()
-  {
-    return
-  }
-  # shellcheck disable=SC2317
-  function get_patches_from_mailing_list()
-  {
-    return
-  }
-  # shellcheck disable=SC2317
-  function list_patches()
-  {
-    return
-  }
-
-  # Not returning from a (supposed) series detail screen should set "$current_mailing_list" global variable to "$1"
-  screen_sequence['RETURNING']=''
-  show_latest_patchsets_from_mailing_list 'amd-gfx'
-  assert_equals_helper 'Wrong "current_mailing_list" value' "$LINENO" 'amd-gfx' "$current_mailing_list"
-
-  # Returning from a (supposed) series detail screen should use the old "$current_mailing_list" value
-  screen_sequence['RETURNING']=1
-  show_latest_patchsets_from_mailing_list 'arbitrary-value'
-  assert_equals_helper 'Wrong "current_mailing_list" value' "$LINENO" 'amd-gfx' "$current_mailing_list"
-}
-
 invoke_shunit

--- a/tests/ui/patch_hub/latest_patchsets_from_mailing_list_test.sh
+++ b/tests/ui/patch_hub/latest_patchsets_from_mailing_list_test.sh
@@ -21,7 +21,7 @@ function tearDown()
   }
 }
 
-function test_show_new_patches_in_the_mailing_list_title()
+function test_show_latest_patchsets_from_mailing_list_title()
 {
   declare current_mailing_list=''
 
@@ -43,12 +43,12 @@ function test_show_new_patches_in_the_mailing_list_title()
 
   # Not returning from a (supposed) series detail screen should set "$current_mailing_list" global variable to "$1"
   screen_sequence['RETURNING']=''
-  show_new_patches_in_the_mailing_list 'amd-gfx'
+  show_latest_patchsets_from_mailing_list 'amd-gfx'
   assert_equals_helper 'Wrong "current_mailing_list" value' "$LINENO" 'amd-gfx' "$current_mailing_list"
 
   # Returning from a (supposed) series detail screen should use the old "$current_mailing_list" value
   screen_sequence['RETURNING']=1
-  show_new_patches_in_the_mailing_list 'arbitrary-value'
+  show_latest_patchsets_from_mailing_list 'arbitrary-value'
   assert_equals_helper 'Wrong "current_mailing_list" value' "$LINENO" 'amd-gfx' "$current_mailing_list"
 }
 

--- a/tests/ui/patch_hub/latest_patchsets_from_mailing_list_test.sh
+++ b/tests/ui/patch_hub/latest_patchsets_from_mailing_list_test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+include './src/ui/patch_hub/latest_patchsets_from_mailing_list.sh'
+include './tests/utils.sh'
+
+function setUp()
+{
+  export ORIGINAL_PATH="$PWD"
+
+  cd "${SHUNIT_TMPDIR}" || {
+    fail "($LINENO): setUp(): It was not possible to move into ${SHUNIT_TMPDIR}"
+    return
+  }
+}
+
+function tearDown()
+{
+  cd "${ORIGINAL_PATH}" || {
+    fail "($LINENO): tearDown(): It was not possible to move into ${ORIGINAL_PATH}"
+    return
+  }
+}
+
+function test_show_new_patches_in_the_mailing_list_title()
+{
+  declare current_mailing_list=''
+
+  # shellcheck disable=SC2317
+  function create_loading_screen_notification()
+  {
+    return
+  }
+  # shellcheck disable=SC2317
+  function get_patches_from_mailing_list()
+  {
+    return
+  }
+  # shellcheck disable=SC2317
+  function list_patches()
+  {
+    return
+  }
+
+  # Not returning from a (supposed) series detail screen should set "$current_mailing_list" global variable to "$1"
+  screen_sequence['RETURNING']=''
+  show_new_patches_in_the_mailing_list 'amd-gfx'
+  assert_equals_helper 'Wrong "current_mailing_list" value' "$LINENO" 'amd-gfx' "$current_mailing_list"
+
+  # Returning from a (supposed) series detail screen should use the old "$current_mailing_list" value
+  screen_sequence['RETURNING']=1
+  show_new_patches_in_the_mailing_list 'arbitrary-value'
+  assert_equals_helper 'Wrong "current_mailing_list" value' "$LINENO" 'amd-gfx' "$current_mailing_list"
+}
+
+invoke_shunit

--- a/tests/ui/patch_hub/patch_hub_core_test.sh
+++ b/tests/ui/patch_hub/patch_hub_core_test.sh
@@ -32,7 +32,7 @@ function test_dashboard_entry_menu_check_valid_options()
   # shellcheck disable=SC2317
   function create_menu_options()
   {
-    menu_return_string=1
+    menu_return_string=0
   }
 
   dashboard_entry_menu
@@ -42,7 +42,7 @@ function test_dashboard_entry_menu_check_valid_options()
   # shellcheck disable=SC2317
   function create_menu_options()
   {
-    menu_return_string=2
+    menu_return_string=1
   }
 
   dashboard_entry_menu
@@ -72,7 +72,7 @@ function test_list_patches_with_patches()
   # shellcheck disable=SC2317
   function create_menu_options()
   {
-    menu_return_string='3'
+    menu_return_string=2
   }
 
   patchsets_metadata_array=(

--- a/tests/ui/patch_hub/patch_hub_core_test.sh
+++ b/tests/ui/patch_hub/patch_hub_core_test.sh
@@ -119,35 +119,4 @@ function test_list_patches_without_patches()
   assert_equals_helper 'Expected screen' "$LINENO" "${screen_sequence['SHOW_SCREEN']}" 'dashboard'
 }
 
-function test_show_new_patches_in_the_mailing_list_title()
-{
-  declare current_mailing_list=''
-
-  # shellcheck disable=SC2317
-  function create_loading_screen_notification()
-  {
-    return
-  }
-  # shellcheck disable=SC2317
-  function get_patches_from_mailing_list()
-  {
-    return
-  }
-  # shellcheck disable=SC2317
-  function list_patches()
-  {
-    return
-  }
-
-  # Not returning from a (supposed) series detail screen should set "$current_mailing_list" global variable to "$1"
-  screen_sequence['RETURNING']=''
-  show_new_patches_in_the_mailing_list 'amd-gfx'
-  assert_equals_helper 'Wrong "current_mailing_list" value' "$LINENO" 'amd-gfx' "$current_mailing_list"
-
-  # Returning from a (supposed) series detail screen should use the old "$current_mailing_list" value
-  screen_sequence['RETURNING']=1
-  show_new_patches_in_the_mailing_list 'arbitrary-value'
-  assert_equals_helper 'Wrong "current_mailing_list" value' "$LINENO" 'amd-gfx' "$current_mailing_list"
-}
-
 invoke_shunit

--- a/tests/ui/patch_hub/patch_hub_core_test.sh
+++ b/tests/ui/patch_hub/patch_hub_core_test.sh
@@ -87,7 +87,7 @@ function test_list_patches_with_patches()
     'more_patches_raw_data'
   )
 
-  screen_sequence['SHOW_SCREEN']='show_new_patches_in_the_mailing_list'
+  screen_sequence['SHOW_SCREEN']='latest_patchsets_from_mailing_list'
   list_patches 'Message test' list_of_mailinglist_patches ''
   assert_equals_helper 'Wrong screen set' "$LINENO" 'patchset_details_and_actions' "${screen_sequence['SHOW_SCREEN']}"
   assert_equals_helper 'Wrong screen parameter' "$LINENO" 'more_patches_raw_data' "${screen_sequence['SHOW_SCREEN_PARAMETER']}"

--- a/tests/ui/patch_hub/settings_test.sh
+++ b/tests/ui/patch_hub/settings_test.sh
@@ -8,6 +8,9 @@ function setUp()
   screen_sequence['SHOW_SCREEN']=''
 
   export ORIGINAL_PATH="$PWD"
+  export lore_config_path="${SHUNIT_TMPDIR}/lore.config"
+
+  touch "$lore_config_path"
 
   cd "${SHUNIT_TMPDIR}" || {
     fail "($LINENO): setUp(): It was not possible to move into ${SHUNIT_TMPDIR}"
@@ -17,6 +20,8 @@ function setUp()
 
 function tearDown()
 {
+  rm "$lore_config_path"
+
   cd "${ORIGINAL_PATH}" || {
     fail "($LINENO): tearDown(): It was not possible to move into ${ORIGINAL_PATH}"
     return
@@ -36,6 +41,48 @@ function test_show_settings_screen()
 
   show_settings_screen
   assert_equals_helper 'Should set next screen to "lore_mailing_lists"' "$LINENO" 'lore_mailing_lists' "${screen_sequence['SHOW_SCREEN']}"
+}
+
+function test_change_patchsets_per_page_setting()
+{
+  local output
+  local expected
+
+  # shellcheck disable=SC2317
+  function create_choice_list_screen()
+  {
+    # 'Settings' sub-menu chosen
+    menu_return_string=60
+    return 0
+  }
+
+  printf 'patchsets_per_page=30' > "$lore_config_path"
+
+  change_patchsets_per_page_setting "$lore_config_path"
+  output=$(< "$lore_config_path")
+  expected='patchsets_per_page=60'
+  assert_equals_helper 'Wrong value in config file' "$LINENO" "$expected" "$output"
+}
+
+function test_change_lore_requests_timeframe_setting()
+{
+  local output
+  local expected
+
+  # shellcheck disable=SC2317
+  function create_choice_list_screen()
+  {
+    # 'Settings' sub-menu chosen
+    menu_return_string=180
+    return 0
+  }
+
+  printf 'lore_requests_timeframe=180' > "$lore_config_path"
+
+  change_lore_requests_timeframe_setting "$lore_config_path"
+  output=$(< "$lore_config_path")
+  expected='lore_requests_timeframe=180'
+  assert_equals_helper 'Wrong value in config file' "$LINENO" "$expected" "$output"
 }
 
 invoke_shunit

--- a/tests/ui/patch_hub/settings_test.sh
+++ b/tests/ui/patch_hub/settings_test.sh
@@ -31,7 +31,7 @@ function test_show_settings_screen()
   function create_menu_options()
   {
     # 'Settings' sub-menu chosen
-    menu_return_string=1
+    menu_return_string=0
   }
 
   show_settings_screen


### PR DESCRIPTION
This PR implement the most critical point in `kw patch-hub` development, which is the interaction with the Lore API to fetch the latest patchsets from a given mailing list.

It introduces a realiable way to navigate through the whole history of a mailing list.

It can also be used as a base for making more specific queries to lore archives.