### PR TITLE
`patch-hub`: Fix bug and refactor 'Registered Mailing Lists' screen

### DIFF
--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -59,8 +59,8 @@ function patch_hub_main_loop()
         show_lore_mailing_lists
         ret="$?"
         ;;
-      'registered_mailing_list')
-        registered_mailing_list
+      'registered_mailing_lists')
+        show_registered_mailing_lists
         ret="$?"
         ;;
       'show_new_patches_in_the_mailing_list')
@@ -108,7 +108,7 @@ function dashboard_entry_menu()
 
   case "$menu_return_string" in
     1) # Registered mailing list
-      screen_sequence['SHOW_SCREEN']='registered_mailing_list'
+      screen_sequence['SHOW_SCREEN']='registered_mailing_lists'
       ;;
     2) # Bookmarked patches
       screen_sequence['SHOW_SCREEN']='bookmarked_patches'
@@ -132,27 +132,30 @@ function show_bookmarked_patches()
   list_patches 'Bookmarked patches' bookmarked_series "${fallback_message}"
 }
 
-# Show all mailing list that the developer is registered
-function registered_mailing_list()
+# Show mailing lists available in lore.kernel.org that the user has registered.
+# A registered mailing list is one that was selected in the 'Register/Unregister
+# Mailing Lists'.
+function show_registered_mailing_lists()
 {
   local -a registered_mailing_lists
   local message_box
-  local selected_list
+  local selected_list_index
   local ret
 
   # Load registered mailing lists from config file into array
   IFS=',' read -r -a registered_mailing_lists <<< "${lore_config['lists']}"
 
-  message_box='Below you can see all the mailing lists that you are registered:'
+  message_box='Below, you can see the lore.kernel.org mailing lists that you have registered.'
+  message_box+='Select a mailing list to see the latest patchsets sent to it.'
 
-  create_menu_options 'Mailing lists' "$message_box" 'registered_mailing_lists' 1
+  create_menu_options 'Registered Mailing Lists' "$message_box" 'registered_mailing_lists' 1
   ret="$?"
 
-  selected_list=$((menu_return_string - 1)) # Normalize array index
+  selected_list_index=$((menu_return_string - 1)) # Normalize array index
   case "$ret" in
     0) # OK
       screen_sequence['SHOW_SCREEN']='show_new_patches_in_the_mailing_list'
-      screen_sequence['SHOW_SCREEN_PARAMETER']="${registered_mailing_lists[$selected_list]}"
+      screen_sequence['SHOW_SCREEN_PARAMETER']="${registered_mailing_lists[$selected_list_index]}"
       ;;
     1) # Exit
       handle_exit "$ret"

--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -19,7 +19,6 @@ include "${KW_LIB_DIR}/ui/patch_hub/settings.sh"
 include "${KW_LIB_DIR}/ui/patch_hub/patchset_details_and_actions.sh"
 
 # These are references to data structures used all around the state-machine.
-declare -ga registered_lists
 declare -ga patches_from_mailing_list
 declare -ga bookmarked_series
 declare -g current_mailing_list
@@ -42,17 +41,12 @@ function patch_hub_main_loop()
   # Load UI variables that define screen size, layout and others.
   ui_setup "${lore_config['dialog_layout']}"
 
-  # Load the registered lists from the file to the data structure
-  IFS=',' read -r -a registered_lists <<< "${lore_config['lists']}"
-
   # "Dashboard" is the default state
   screen_sequence['SHOW_SCREEN']='dashboard'
 
   # In case the user doesn't have any mailing list registered, the first
   # state should be "Register/Unregister Mailing Lists"
-  if [[ "${#registered_lists[@]}" == 0 ]]; then
-    screen_sequence['SHOW_SCREEN']='lore_mailing_lists'
-  fi
+  [[ -z "${lore_config['lists']}" ]] && screen_sequence['SHOW_SCREEN']='lore_mailing_lists'
 
   # Main loop of the state-machine
   while true; do

--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -141,20 +141,24 @@ function show_bookmarked_patches()
 # Show all mailing list that the developer is registered
 function registered_mailing_list()
 {
+  local -a registered_mailing_lists
   local message_box
   local selected_list
   local ret
 
+  # Load registered mailing lists from config file into array
+  IFS=',' read -r -a registered_mailing_lists <<< "${lore_config['lists']}"
+
   message_box='Below you can see all the mailing lists that you are registered:'
 
-  create_menu_options 'Mailing lists' "$message_box" 'registered_lists' 1
+  create_menu_options 'Mailing lists' "$message_box" 'registered_mailing_lists' 1
   ret="$?"
 
   selected_list=$((menu_return_string - 1)) # Normalize array index
   case "$ret" in
     0) # OK
       screen_sequence['SHOW_SCREEN']='show_new_patches_in_the_mailing_list'
-      screen_sequence['SHOW_SCREEN_PARAMETER']="${registered_lists[$selected_list]}"
+      screen_sequence['SHOW_SCREEN_PARAMETER']="${registered_mailing_lists[$selected_list]}"
       ;;
     1) # Exit
       handle_exit "$ret"

--- a/tests/ui/patch_hub/patch_hub_core_test.sh
+++ b/tests/ui/patch_hub/patch_hub_core_test.sh
@@ -36,7 +36,7 @@ function test_dashboard_entry_menu_check_valid_options()
   }
 
   dashboard_entry_menu
-  assert_equals_helper 'Expected register screen' "$LINENO" "${screen_sequence['SHOW_SCREEN']}" 'registered_mailing_list'
+  assert_equals_helper 'Expected register screen' "$LINENO" "${screen_sequence['SHOW_SCREEN']}" 'registered_mailing_lists'
 
   # Mock bookmarked
   # shellcheck disable=SC2317


### PR DESCRIPTION
This PR has 3 commits:

- **Commit 1**: Fix bug of feature freezing when first launching it and accessing 'Registered Mailing Lists'.
- **Commit 2 and 3**: Refactor 'Registered Mailing Lists' screen-handler function and screen name.

Chose to pack commit 1 with commit 2 and 3 together in a single PR as they build upon each other and are quite simple changes.