### PR TITLE
src: ui: patch_hub: patch_hub_core: Fix 'Registered Mailing Lists' me…

### DIFF
--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -145,7 +145,7 @@ function show_registered_mailing_lists()
   # Load registered mailing lists from config file into array
   IFS=',' read -r -a registered_mailing_lists <<< "${lore_config['lists']}"
 
-  message_box='Below, you can see the lore.kernel.org mailing lists that you have registered.'
+  message_box='Below, you can see the lore.kernel.org mailing lists that you have registered.'$'\n'
   message_box+='Select a mailing list to see the latest patchsets sent to it.'
 
   create_menu_options 'Registered Mailing Lists' "$message_box" 'registered_mailing_lists' 1


### PR DESCRIPTION
…ssage box

This commit adds a newline to the message box of the 'Registered Mailing Lists' screen of the `kw patch-hub` feature. Without the newline, the message box had a part that was like
  '[...] that you have registered.Select a mailing list [...]',
instead of
  '[...] that you have registered.
   Select a mailing list [...]'.