### PR TITLE
src: lib: dialog_ui: Make choice list more flexible

### DIFF
--- a/src/lib/dialog_ui.sh
+++ b/src/lib/dialog_ui.sh
@@ -362,6 +362,9 @@ function create_file_selection_screen()
 #   `<choice><choice_description>` pairs to be displayd
 # @_check_statuses: An array reference containing all the statuses of the checks
 #   (if they are on/off).
+# @ok_label: Override the default 'Ok' button label option (Default is 'Yes').
+# @cancel_label: Override the default 'Cancel' button label option (Default is 'Cancel')
+# @extra_label: Label for the 'Extra' button
 # @height: Menu height in lines size
 # @width: Menu width in column size
 # @flag How to display a command, the default value is
@@ -377,9 +380,12 @@ function create_choice_list_screen()
   local message_box="$2"
   local -n _choices="$3"
   local -n _check_statuses="$4"
-  local height="$5"
-  local width="$6"
-  local flag="$7"
+  local ok_label="$5"
+  local cancel_label="$6"
+  local extra_button_label="$7"
+  local height="$8"
+  local width="$9"
+  local flag="${10}"
   local choice_description
   local index=0
   local cmd
@@ -387,12 +393,24 @@ function create_choice_list_screen()
   flag=${flag:-'SILENT'}
   height=${height:-$DEFAULT_HEIGHT}
   width=${width:-$DEFAULT_WIDTH}
+  cancel_label=${cancel_label:-'Cancel'}
+  ok_label=${ok_label:-'Ok'}
 
   # Escape all single quotes to avoid breaking arguments
+  ok_label=$(str_escape_single_quotes "$ok_label")
+  cancel_label=$(str_escape_single_quotes "$cancel_label")
+  extra_button_label=$(str_escape_single_quotes "$extra_button_label")
   box_title=$(str_escape_single_quotes "$box_title")
   message_box=$(str_escape_single_quotes "$message_box")
 
   cmd=$(build_dialog_command_preamble "$box_title")
+  # Override OK, cancel, and add extra button if necessary.
+  cmd+=" --ok-label $'${ok_label}'"
+  cmd+=" --cancel-label $'${cancel_label}'"
+  if [[ -n "$extra_button_label" ]]; then
+    cmd+=" --extra-button --extra-label $'${extra_button_label}'"
+  fi
+
   # Add radiolist screen
   cmd+=" --radiolist $'${message_box}'"
   # Set height and width

--- a/tests/lib/dialog_ui_test.sh
+++ b/tests/lib/dialog_ui_test.sh
@@ -272,10 +272,11 @@ function test_create_choice_list_screen_rely_on_some_default_options()
 
   expected_cmd=" dialog --backtitle $'${KW_PATCH_HUB_TITLE}'"
   expected_cmd+=" --title $'Make \'a\' choice!' --clear --colors"
+  expected_cmd+=" --ok-label $'Ok' --cancel-label $'Cancel'"
   expected_cmd+=" --radiolist $'Select \`one\' of the below options.'"
   expected_cmd+=" '${EXPECTED_DEFAULT_HEIGHT}' '${EXPECTED_DEFAULT_WIDTH}' '0'"
   expected_cmd+=" $'choice1' $'${choices['choice1']}' 'off' $'choice2' $'${choices['choice2']}' 'on' $'choice3' $'${choices['choice3']}' 'off'"
-  output=$(create_choice_list_screen "$box_title" "$message_box" 'choices' 'check_statuses' '' '' 'TEST_MODE')
+  output=$(create_choice_list_screen "$box_title" "$message_box" 'choices' 'check_statuses' '' '' '' '' '' 'TEST_MODE')
   assert_equals_helper 'Expected choice list with some default options' "$LINENO" "$expected_cmd" "$output"
 }
 
@@ -290,10 +291,11 @@ function test_create_choice_list_screen_use_all_options()
 
   expected_cmd=" dialog --backtitle $'${KW_PATCH_HUB_TITLE}'"
   expected_cmd+=" --title $'Make \'a\' choice!' --clear --colors"
+  expected_cmd+=" --ok-label $'Next' --cancel-label $'Previous' --extra-button --extra-label $'Cancel'"
   expected_cmd+=" --radiolist $'Select \`one\' of the below options.'"
   expected_cmd+=" '17041998' '10300507' '0'"
   expected_cmd+=" $'choice1' $'${choices['choice1']}' 'off' $'choice2' $'${choices['choice2']}' 'on' $'choice3' $'${choices['choice3']}' 'off'"
-  output=$(create_choice_list_screen "$box_title" "$message_box" 'choices' 'check_statuses' '17041998' '10300507' 'TEST_MODE')
+  output=$(create_choice_list_screen "$box_title" "$message_box" 'choices' 'check_statuses' 'Next' 'Previous' 'Cancel' '17041998' '10300507' 'TEST_MODE')
   assert_equals_helper 'Expected choice list with all custom options' "$LINENO" "$expected_cmd" "$output"
 }
 


### PR DESCRIPTION
The choice list does not support extra buttons nor change the OK and Cancel labels. This commit expands this function to support extra buttons and rename the default ones.