### PR TITLE
src: self_update: Adding verbose mode.

### DIFF
--- a/documentation/man/features/self-update.rst
+++ b/documentation/man/features/self-update.rst
@@ -6,8 +6,8 @@ kw-self-update
 
 SYNOPSIS
 ========
-| *kw* (*u* | *self-update*)
-| *kw* (*u* | *self-update*) [(-u | --unstable)]
+| *kw* (*u* | *self-update*) [\--verbose]
+| *kw* (*u* | *self-update*) [(-u | --unstable)] [\--verbose]
 | *kw* (*u* | *self-update*) [(-h | --help)]
 
 DESCRIPTION
@@ -28,6 +28,11 @@ OPTIONS
 
 \--help:
   Show this man page
+
+\--verbose:
+  Verbose mode is an option that causes the kw program to display debug messages to track
+  its progress. This functionality is very useful during the debugging process, allowing
+  you to identify possible errors more easily.
 
 EXAMPLES
 ========

--- a/src/_kw
+++ b/src/_kw
@@ -449,6 +449,7 @@ _kw_u() { _kw_self-update }
 _kw_self-update()
 {
   _arguments : \
+    '(--verbose)--verbose[enable verbose mode]' \
     '(-u --unstable)'{-u,--unstable}'[update kw based on the unstable branch]'
 }
 

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -38,7 +38,7 @@ function _kw_autocomplete()
   kw_options['ssh']='--remote --script --command --verbose --help'
   kw_options['s']="${kw_options['ssh']}"
 
-  kw_options['self-update']='--unstable --help'
+  kw_options['self-update']='--unstable --help --verbose'
   kw_options['u']="${kw_options['self-update']}"
 
   kw_options['maintainers']='--authors --update-patch'

--- a/src/self_update.sh
+++ b/src/self_update.sh
@@ -9,6 +9,9 @@ function self_update_main()
   local target_branch='master'
   local path_to_tmp_dir
   local ret
+  local flag
+
+  flag=${flag:-'SILENT'}
 
   parse_self_update_options "$@"
   if [[ "$?" != 0 ]]; then
@@ -16,6 +19,8 @@ function self_update_main()
     self_update_help
     return 22 # EINVAL
   fi
+
+  [[ -n "${options_values['VERBOSE']}" ]] && flag='VERBOSE'
 
   if [[ -n "${options_values['UNSTABLE']}" ]]; then
     target_branch='unstable'
@@ -28,7 +33,7 @@ function self_update_main()
   fi
 
   path_to_tmp_dir=$(mktemp --directory)
-  update_from_official_repo "${target_branch}" "${path_to_tmp_dir}"
+  update_from_official_repo "${target_branch}" "${path_to_tmp_dir}" "$flag"
 
   ret="$?"
   if [[ "$ret" != 0 ]]; then
@@ -122,7 +127,7 @@ function update_from_official_repo()
 
 function parse_self_update_options()
 {
-  local long_options='unstable,help'
+  local long_options='unstable,help,verbose'
   local short_options='u,h'
 
   options="$(kw_parse "$short_options" "$long_options" "$@")"
@@ -132,6 +137,9 @@ function parse_self_update_options()
       "$long_options" "$@")"
     return 22 # EINVAL
   fi
+
+  # Default values
+  options_values['VERBOSE']=''
 
   eval "set -- $options"
 
@@ -144,6 +152,10 @@ function parse_self_update_options()
       --help | -h)
         self_update_help "$1"
         exit
+        ;;
+      --verbose)
+        options_values['VERBOSE']=1
+        shift
         ;;
       --)
         shift

--- a/tests/self_update_test.sh
+++ b/tests/self_update_test.sh
@@ -66,6 +66,11 @@ function test_parse_self_update_options()
 
   unset options_values
   declare -gA options_values
+  parse_self_update_options '--verbose'
+  assertEquals "($LINENO) VERBOSE could not be set" 1 "${options_values['VERBOSE']}"
+
+  unset options_values
+  declare -gA options_values
   parse_self_update_options '-u'
   assertEquals "($LINENO) UNSTABLE could not be set" 1 "${options_values['UNSTABLE']}"
 


### PR DESCRIPTION
This commit adds support for the verbose parameter within `kw self-update`. The verbose parameter gives details of the commands that are executed behind the scenes.

Note: This is part of the issue: #857