### PR TITLE
`patch-hub`: Add query based on string functionality

### DIFF
--- a/src/lib/dialog_ui.sh
+++ b/src/lib/dialog_ui.sh
@@ -27,6 +27,8 @@ function ui_setup()
 
   DEFAULT_WIDTH="$columns"
   DEFAULT_HEIGHT="$lines"
+  DEFAULT_SMALL_WIDTH="$((columns / 2))"
+  DEFAULT_SMALL_HEIGHT="$((lines / 3))"
 
   # Set sefault layout
   if [[ -n "$default_layout" ]]; then
@@ -673,6 +675,71 @@ function create_rangebox_screen()
   cmd+=" '${height}' '${width}'"
   # Set range and default value
   cmd+=" '${min_value}' '${max_value}' '${default_value}'"
+
+  [[ "$flag" == 'TEST_MODE' ]] && printf '%s' "$cmd" && return 0
+
+  run_dialog_command "$cmd" "$flag"
+}
+
+# Create an Inputbox to collect a string from the user. The string typed in the
+# Inputbox is returned in the variable `menu_return_string` if the user hits either
+# the 'Ok' button or the 'Extra' button. An empty string is also a valid input.
+#
+# @box_title: Title of the box
+# @message_box: The message to be displayed
+# @extra_label: Extra label. If not set, the 'Extra' button won't be displayed
+# @cancel_label: Cancel label. If not set, the default is 'Exit'
+# @help_label: Help label. If not set, the 'Help' button won't be displayed
+# @height: Menu height in lines size
+# @width: Menu width in column size
+# @flag How to display a command, the default value is
+#   "SILENT". For more options see `src/lib/kwlib.sh` function `cmd_manager`
+#
+# Return:
+# Returns 0 if the 'Ok' button is pressed, 1 if the 'Cancel' button is pressed,
+# 2 if the 'Help' button is pressed, and 3 if the 'Extra' button is pressed.
+# The `menu_return_string` will store the string in the Inputbox if the user hits
+# either the 'Ok' button or the 'Extra' button. An empty string is also a valid
+# input.
+function create_inputbox_screen()
+{
+  local box_title="$1"
+  local message_box="$2"
+  local extra_label="$3"
+  local cancel_label="$4"
+  local help_label="$5"
+  local height="$6"
+  local width="$7"
+  local flag="$8"
+  local cmd
+
+  cancel_label=${cancel_label:-'Exit'}
+  flag=${flag:-'SILENT'}
+  height=${height:-$DEFAULT_SMALL_HEIGHT}
+  width=${width:-$DEFAULT_SMALL_WIDTH}
+
+  # Escape all single quotes to avoid breaking arguments
+  box_title=$(str_escape_single_quotes "$box_title")
+  message_box=$(str_escape_single_quotes "$message_box")
+  cancel_label=$(str_escape_single_quotes "$cancel_label")
+  extra_label=$(str_escape_single_quotes "$extra_label")
+  help_label=$(str_escape_single_quotes "$help_label")
+
+  cmd=$(build_dialog_command_preamble "$box_title")
+  # Override 'Cancel' button label
+  cmd+=" --cancel-label $'${cancel_label}'"
+  # Add 'Extra' button
+  if [[ -n "${extra_label}" ]]; then
+    cmd+=" --extra-button --extra-label $'${extra_label}'"
+  fi
+  # Add 'Help' button
+  if [[ -n "${help_label}" ]]; then
+    cmd+=" --help-button --help-label $'${help_label}'"
+  fi
+  # Add Inputbox screen
+  cmd+=" --inputbox $'${message_box}'"
+  # Set height and width
+  cmd+=" '${height}' '${width}'"
 
   [[ "$flag" == 'TEST_MODE' ]] && printf '%s' "$cmd" && return 0
 

--- a/src/lib/web.sh
+++ b/src/lib/web.sh
@@ -76,3 +76,52 @@ function is_html_file()
   [[ "$?" == 0 ]] && return 0
   return 1
 }
+
+# This function recieves a string and converts it to contain only characters that
+# are legal to be used within a URL (https://en.wikipedia.org/wiki/Percent-encoding).
+# Only illegal chars are percent-encoded. A percent-encoding of an ASCII char is
+# its ASCII number in hexadecimal format prefixed by a percent '%'. If the char is
+# non-ASCII, each byte of its byte sequence in UTF-8 is treated as an ASCII char
+# and converted accordingly.
+
+# Note: A full URL shouldn't be passed as argument, as the function will probably
+# break it (e.g., it will convert all foward slashes in the string).
+#
+# @string: String to be encoded
+#
+# Return:
+# The function outputs the encoded string and returns 0 in any case. An empty `string`
+# value is a valid argument.
+#
+# CREDITS:
+# This function was adapted to follow kw's coding style, and the primary reference
+# for it is https://github.com/dylanaraps/pure-bash-bible#percent-encode-a-string,
+# from the book 'pure bash bible', which is licensed under the MIT license. Also,
+# credits to meleu (https://github.com/meleu) who wrote a blogpost that can be
+# checked at https://meleu.sh/urlencode, from which this function was first found.
+function url_encode()
+{
+  local string="$1"
+  local LC_ALL
+  local char
+  local encoded_string
+
+  # We create a local `LC_ALL` to not pollute the user settings.
+  # The 'C' is to capture only the 26 ASCII chars from a to z in [a-z] (analogous for [A-Z]).
+  LC_ALL='C'
+
+  # In this loop, we are iterating through each char and encoding it when necessary
+  for ((i = 0; i < ${#string}; i++)); do
+    char="${string:i:1}"
+    if [[ "$char" =~ [a-zA-Z0-9.~_-] ]]; then
+      encoded_string+="$char"
+    else
+      # %% - Literal '%'
+      # %02X - Two digit hexadecimal with 0 preceding, if necessary
+      # "'$char" - ASCII number of "$char"
+      encoded_string+=$(printf '%%%02X' "'$char")
+    fi
+  done
+
+  printf '%s' "$encoded_string"
+}

--- a/src/ui/patch_hub/latest_patchsets_from_mailing_list.sh
+++ b/src/ui/patch_hub/latest_patchsets_from_mailing_list.sh
@@ -7,6 +7,7 @@ declare -ga formatted_patchsets_list
 # These patchsets are ordered by their recieved time in the lore.kernel.org servers.
 function show_latest_patchsets_from_mailing_list()
 {
+  local additional_filters="$1"
   local starting_index
   local ending_index
   local box_title
@@ -14,10 +15,15 @@ function show_latest_patchsets_from_mailing_list()
 
   create_loading_screen_notification "Loading patchsets from ${current_mailing_list} list"
   # Query patches from mailing list, this info will be saved at `list_of_mailinglist_patches[@]`.
-  fetch_latest_patchsets_from "$current_mailing_list" "$PAGE" "${lore_config['patchsets_per_page']}"
+  fetch_latest_patchsets_from "$current_mailing_list" "$PAGE" "${lore_config['patchsets_per_page']}" "$additional_filters"
   if [[ "$?" != 0 ]]; then
     create_message_box 'Error' "Couldn't fetch patchsets from ${current_mailing_list} list."
-    screen_sequence['SHOW_SCREEN']='registered_mailing_lists'
+    if [[ -n "$additional_filters" ]]; then
+      screen_sequence['SHOW_SCREEN']='dashboard'
+      screen_sequence['SHOW_SCREEN_PARAMETER']=''
+    else
+      screen_sequence['SHOW_SCREEN']='registered_mailing_lists'
+    fi
     return
   fi
 
@@ -51,7 +57,11 @@ function show_latest_patchsets_from_mailing_list()
         reset_current_lore_fetch_session
         PAGE=1
         formatted_patchsets_list=()
-        screen_sequence['SHOW_SCREEN']='registered_mailing_lists'
+        if [[ -n "$additional_filters" ]]; then
+          screen_sequence['SHOW_SCREEN']='dashboard'
+        else
+          screen_sequence['SHOW_SCREEN']='registered_mailing_lists'
+        fi
       fi
       ;;
   esac

--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -18,6 +18,7 @@ include "${KW_LIB_DIR}/ui/patch_hub/lore_mailing_lists.sh"
 include "${KW_LIB_DIR}/ui/patch_hub/settings.sh"
 include "${KW_LIB_DIR}/ui/patch_hub/patchset_details_and_actions.sh"
 include "${KW_LIB_DIR}/ui/patch_hub/latest_patchsets_from_mailing_list.sh"
+include "${KW_LIB_DIR}/ui/patch_hub/search_string_in_lore.sh"
 
 # These are references to data structures used all around the state-machine.
 declare -ga bookmarked_series
@@ -63,11 +64,15 @@ function patch_hub_main_loop()
         ret="$?"
         ;;
       'latest_patchsets_from_mailing_list')
-        show_latest_patchsets_from_mailing_list
+        show_latest_patchsets_from_mailing_list "${screen_sequence['SHOW_SCREEN_PARAMETER']}"
         ret="$?"
         ;;
       'bookmarked_patches')
         show_bookmarked_patches
+        ret="$?"
+        ;;
+      'search_string_in_lore')
+        show_search_string_in_lore
         ret="$?"
         ;;
       'settings')
@@ -94,7 +99,12 @@ function dashboard_entry_menu()
   local message_box
   local ret
 
-  menu_list_string_array=('Registered mailing list' 'Bookmarked patches' 'Settings')
+  menu_list_string_array=(
+    'Registered mailing list'
+    'Bookmarked patches'
+    'Search in Lore'
+    'Settings'
+  )
 
   message_box=''
 
@@ -112,7 +122,10 @@ function dashboard_entry_menu()
     1) # Bookmarked patches
       screen_sequence['SHOW_SCREEN']='bookmarked_patches'
       ;;
-    2) # Settings
+    2) # Search in Lore
+      screen_sequence['SHOW_SCREEN']='search_string_in_lore'
+      ;;
+    3) # Settings
       screen_sequence['SHOW_SCREEN']='settings'
       ;;
   esac
@@ -152,6 +165,7 @@ function show_registered_mailing_lists()
   case "$ret" in
     0) # OK
       screen_sequence['SHOW_SCREEN']='latest_patchsets_from_mailing_list'
+      screen_sequence['SHOW_SCREEN_PARAMETER']=''
       current_mailing_list="${registered_mailing_lists["$menu_return_string"]}"
       ;;
     1) # Exit

--- a/src/ui/patch_hub/search_string_in_lore.sh
+++ b/src/ui/patch_hub/search_string_in_lore.sh
@@ -1,0 +1,48 @@
+include "${KW_LIB_DIR}/ui/patch_hub/patch_hub_core.sh"
+
+# This function displays an input box that allows the user to search a string in
+# the lore archives.
+function show_search_string_in_lore()
+{
+  local -a list_of_options_array
+  local message_box
+  local ret
+
+  message_box='This string will be searched in the entirety of the lore archives.'
+
+  create_inputbox_screen 'Input string to be searched' "$message_box" 'Return'
+  ret="$?"
+
+  case "$ret" in
+    0) # OK
+      search_string_in_lore "$menu_return_string"
+      ;;
+    1) # Exit
+      handle_exit "$ret"
+      ;;
+    3) # Return
+      screen_sequence['SHOW_SCREEN']='dashboard'
+      screen_sequence['SHOW_SCREEN_PARAMETER']=''
+      ;;
+  esac
+}
+
+# This function handles the search of a string in lore. It does this by passing
+# the string as a query filter for the `latest_patchsets_from_mailing_list` screen.
+#
+# @string: String to be searched in lore.
+function search_string_in_lore()
+{
+  local string="$1"
+
+  if [[ -z "$string" ]]; then
+    create_message_box 'Error' 'Inputted string should not be empty.'
+    return
+  fi
+
+  # Set mailing list to 'all' to search on all lore archives
+  current_mailing_list='all'
+
+  screen_sequence['SHOW_SCREEN']='latest_patchsets_from_mailing_list'
+  screen_sequence['SHOW_SCREEN_PARAMETER']="$(url_encode "$string")"
+}

--- a/tests/lib/dialog_ui_test.sh
+++ b/tests/lib/dialog_ui_test.sh
@@ -14,6 +14,8 @@ function setUp()
 
   EXPECTED_DEFAULT_WIDTH=$(eval tput"${TPUTTERM}" cols)
   EXPECTED_DEFAULT_HEIGHT=$(eval tput"${TPUTTERM}" lines)
+  EXPECTED_DEFAULT_SMALL_WIDTH="$((EXPECTED_DEFAULT_WIDTH / 2))"
+  EXPECTED_DEFAULT_SMALL_HEIGHT="$((EXPECTED_DEFAULT_HEIGHT / 3))"
 
   mkdir -p "$TMP_DIR"
   mkdir -p "$KW_ETC_DIR"
@@ -454,6 +456,39 @@ function test_create_rangebox_screen_use_all_options()
   expected_cmd+=" '23' '42' '318'"
   output=$(create_rangebox_screen "$box_title" "$message_box" 23 42 318 'range' 'Cancel' 'box' 2718 31415 'TEST_MODE')
   assert_equals_helper 'Expected Rangebox with all custom options' "$LINENO" "$expected_cmd" "$output"
+}
+
+function test_create_inputbox_screen_rely_on_some_default_options()
+{
+  local box_title="Type a 'string' here!"
+  local message_box="This is \`a inputbox'."
+  local expected_cmd
+  local output
+
+  expected_cmd=" dialog --backtitle $'${KW_PATCH_HUB_TITLE}'"
+  expected_cmd+=" --title $'Type a \'string\' here!' --clear --colors"
+  expected_cmd+=" --cancel-label $'Exit'"
+  expected_cmd+=" --inputbox $'This is \`a inputbox\'.'"
+  expected_cmd+=" '${EXPECTED_DEFAULT_SMALL_HEIGHT}' '${EXPECTED_DEFAULT_SMALL_WIDTH}'"
+  output=$(create_inputbox_screen "$box_title" "$message_box" '' '' '' '' '' 'TEST_MODE')
+  assert_equals_helper 'Expected Inputbox with some default options' "$LINENO" "$expected_cmd" "$output"
+}
+
+function test_create_inputbox_screen_use_all_options()
+{
+  local box_title="Type a 'string' here!"
+  local message_box="This is \`a inputbox'."
+  local expected_cmd
+  local output
+
+  expected_cmd=" dialog --backtitle $'${KW_PATCH_HUB_TITLE}'"
+  expected_cmd+=" --title $'Type a \'string\' here!' --clear --colors"
+  expected_cmd+=" --cancel-label $'Cancel'"
+  expected_cmd+=" --extra-button --extra-label $'range' --help-button --help-label $'box'"
+  expected_cmd+=" --inputbox $'This is \`a inputbox\'.'"
+  expected_cmd+=" '11223348' '8498129'"
+  output=$(create_inputbox_screen "$box_title" "$message_box" 'range' 'Cancel' 'box' 11223348 8498129 'TEST_MODE')
+  assert_equals_helper 'Expected Inputbox with all custom options' "$LINENO" "$expected_cmd" "$output"
 }
 
 function test_build_dialog_command_preamble()

--- a/tests/lib/lore_test.sh
+++ b/tests/lib/lore_test.sh
@@ -471,21 +471,30 @@ function test_compose_lore_query_url_with_verification_invalid_cases()
 function test_compose_lore_query_url_with_verification_valid_cases()
 {
   local target_mailing_list
+  local additional_filters
   local min_index
   local output
   local expected
 
   target_mailing_list='amd-gfx'
   min_index='200'
-  expected='https://lore.kernel.org/amd-gfx/?q=rt:..+AND+NOT+s:Re&x=A&o=200'
+  expected='https://lore.kernel.org/amd-gfx/?x=A&o=200&q=rt:..+AND+NOT+s:Re'
   output=$(compose_lore_query_url_with_verification "$target_mailing_list" "$min_index")
   assert_equals_helper 'Valid arguments should return 0' "$LINENO" 0 "$?"
   assert_equals_helper 'Wrong query URL outputted' "$LINENO" "$expected" "$output"
 
   target_mailing_list='amd-gfx'
   min_index='-200'
-  expected='https://lore.kernel.org/amd-gfx/?q=rt:..+AND+NOT+s:Re&x=A&o=-200'
+  expected='https://lore.kernel.org/amd-gfx/?x=A&o=-200&q=rt:..+AND+NOT+s:Re'
   output=$(compose_lore_query_url_with_verification "$target_mailing_list" "$min_index")
+  assert_equals_helper 'Valid arguments should return 0' "$LINENO" 0 "$?"
+  assert_equals_helper 'Wrong query URL outputted' "$LINENO" "$expected" "$output"
+
+  target_mailing_list='amd-gfx'
+  min_index='200'
+  additional_filters='s:drm%2Famdgpu+AND+NOT+f:David%20Tadokoro'
+  expected='https://lore.kernel.org/amd-gfx/?x=A&o=200&q=rt:..+AND+NOT+s:Re+AND+s:drm%2Famdgpu+AND+NOT+f:David%20Tadokoro'
+  output=$(compose_lore_query_url_with_verification "$target_mailing_list" "$min_index" "$additional_filters")
   assert_equals_helper 'Valid arguments should return 0' "$LINENO" 0 "$?"
   assert_equals_helper 'Wrong query URL outputted' "$LINENO" "$expected" "$output"
 }

--- a/tests/lib/web_test.sh
+++ b/tests/lib/web_test.sh
@@ -114,4 +114,38 @@ function test_is_html_file_with_html_files()
   assert_equals_helper 'Valid HTML file should return 0' "$LINENO" 0 "$?"
 }
 
+function test_url_encode()
+{
+  local output
+  local expected
+
+  output=$(url_encode '')
+  expected=''
+  assert_equals_helper 'Should output an empty string' "$LINENO" "$expected" "$output"
+
+  output=$(url_encode 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
+  expected='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+  assert_equals_helper 'Should not alter valid ASCII letters' "$LINENO" "$expected" "$output"
+
+  output=$(url_encode '0123456789')
+  expected='0123456789'
+  assert_equals_helper 'Should not alter valid ASCII numbers' "$LINENO" "$expected" "$output"
+
+  output=$(url_encode '.~_-')
+  expected='.~_-'
+  assert_equals_helper 'Should not alter valid ASCII special characters' "$LINENO" "$expected" "$output"
+
+  output=$(url_encode ' !"#$%&'"'"'()*+,/:;<=>?@[\]^`{|}')
+  expected='%20%21%22%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3C%3D%3E%3F%40%5B%5C%5D%5E%60%7B%7C%7D'
+  assert_equals_helper 'Should percent-encode all invalid ASCII chars' "$LINENO" "$expected" "$output"
+
+  output=$(url_encode '■éøπ…≤µ∂˚')
+  expected='%E2%96%A0%C3%A9%C3%B8%CF%80%E2%80%A6%E2%89%A4%C2%B5%E2%88%82%CB%9A'
+  assert_equals_helper 'Should correctly percent-encode non-ASCII chars' "$LINENO" "$expected" "$output"
+
+  output=$(url_encode 'string to éncodî')
+  expected='string%20to%20%C3%A9ncod%C3%AE'
+  assert_equals_helper 'Wrong encoding of string' "$LINENO" "$expected" "$output"
+}
+
 invoke_shunit

--- a/tests/ui/patch_hub/search_string_in_lore_test.sh
+++ b/tests/ui/patch_hub/search_string_in_lore_test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+include './src/ui/patch_hub/search_string_in_lore.sh'
+include './tests/utils.sh'
+
+function setUp()
+{
+  export ORIGINAL_PATH="$PWD"
+
+  cd "${SHUNIT_TMPDIR}" || {
+    fail "($LINENO): setUp(): It was not possible to move into ${SHUNIT_TMPDIR}"
+    return
+  }
+}
+
+function tearDown()
+{
+  cd "${ORIGINAL_PATH}" || {
+    fail "($LINENO): tearDown(): It was not possible to move into ${ORIGINAL_PATH}"
+    return
+  }
+}
+
+function test_show_search_string_in_lore()
+{
+  local output
+  local expected
+
+  # shellcheck disable=SC2317
+  function create_inputbox_screen()
+  {
+    menu_return_string=''
+    return 0
+  }
+
+  # shellcheck disable=SC2317
+  function create_message_box()
+  {
+    printf '%s %s' "$1" "$2"
+    return 0
+  }
+
+  output=$(show_search_string_in_lore)
+  expected='Error Inputted string should not be empty.'
+  assert_equals_helper 'An empty string should output an error message' "$LINENO" "$expected" "$output"
+  assert_equals_helper 'Wrong screen set' "$LINENO" '' "${screen_sequence['SHOW_SCREEN']}"
+  assert_equals_helper 'Wrong screen parameter' "$LINENO" '' "${screen_sequence['SHOW_SCREEN_PARAMETER']}"
+
+  # shellcheck disable=SC2317
+  function create_inputbox_screen()
+  {
+    menu_return_string='query-string'
+    return 0
+  }
+
+  show_search_string_in_lore
+  assert_equals_helper 'Wrong screen set' "$LINENO" 'latest_patchsets_from_mailing_list' "${screen_sequence['SHOW_SCREEN']}"
+  assert_equals_helper 'Wrong screen parameter' "$LINENO" 'query-string' "${screen_sequence['SHOW_SCREEN_PARAMETER']}"
+  assert_equals_helper 'Wrong current list' "$LINENO" 'all' "$current_mailing_list"
+
+  # shellcheck disable=SC2317
+  function create_inputbox_screen()
+  {
+    return 3
+  }
+
+  screen_sequence['SHOW_SCREEN_PARAMETER']='query-string'
+  show_search_string_in_lore
+  assert_equals_helper 'Wrong screen set' "$LINENO" 'dashboard' "${screen_sequence['SHOW_SCREEN']}"
+  assert_equals_helper 'Wrong screen parameter' "$LINENO" '' "${screen_sequence['SHOW_SCREEN_PARAMETER']}"
+  assert_equals_helper 'Wrong current list' "$LINENO" 'all' "$current_mailing_list"
+}
+
+function test_search_string_in_lore()
+{
+  local output
+  local expected
+
+  # shellcheck disable=SC2317
+  function create_message_box()
+  {
+    printf '%s %s' "$1" "$2"
+    return 0
+  }
+
+  output=$(search_string_in_lore '')
+  expected='Error Inputted string should not be empty.'
+  assert_equals_helper 'An empty string should output an error message' "$LINENO" "$expected" "$output"
+
+  search_string_in_lore 'query-string'
+  assert_equals_helper 'Wrong screen set' "$LINENO" 'latest_patchsets_from_mailing_list' "${screen_sequence['SHOW_SCREEN']}"
+  assert_equals_helper 'Wrong screen parameter' "$LINENO" 'query-string' "${screen_sequence['SHOW_SCREEN_PARAMETER']}"
+  assert_equals_helper 'Wrong current list' "$LINENO" 'all' "$current_mailing_list"
+
+  search_string_in_lore 'Robson Cruzoé'
+  assert_equals_helper 'Wrong screen set' "$LINENO" 'latest_patchsets_from_mailing_list' "${screen_sequence['SHOW_SCREEN']}"
+  assert_equals_helper 'Wrong screen parameter' "$LINENO" 'Robson%20Cruzo%C3%A9' "${screen_sequence['SHOW_SCREEN_PARAMETER']}"
+  assert_equals_helper 'Wrong current list' "$LINENO" 'all' "$current_mailing_list"
+}
+
+invoke_shunit


### PR DESCRIPTION
This PR adds queries based on a string to `kw patch-hub`. Lore API provides a great number of filters to match strings against specific fields of the message, like 'Subject', 'To', 'Body', and even the whole message.

The PR adds queries for strings that are match against the whole message. The query is made in the 'Search String in Lore' menu inside 'Dashboard' through an input box.

Closes: #800 