### PR TITLE
Initially block LKML

### DIFF
--- a/etc/mail.config
+++ b/etc/mail.config
@@ -2,5 +2,7 @@
 send_opts=--annotate --cover-letter --no-chain-reply-to --thread
 
 # You can choose to block certain emails from being added to the recipients
-# list of your patches, separate values with commas
-#blocked_emails=
+# list of your patches, separate values with commas. Linux Kernel ML is
+# initially blocked to avoid mistakenly send more than 15 patches at once to
+# the vger mailing lists. Configure it according to your needs.
+blocked_emails=linux-kernel@vger.kernel.org


### PR DESCRIPTION
`kw mail` automatically adds LKML as a receipt of all patches since this is recommended by Kernel Doc, but Kernel Doc also requires to not send more than 15 patches at once to the vger mailing lists and states that the volume on that list has caused a number of developers to tune it out. To prevent users from being surprised by this automatic addition, initialize `mail.config` with LKML blocked. Users can restore the default behavior once they are more familiar with the `kw mail` feature and its options.

Closes #755 