### PR TITLE
src: mail: Add 'additional_emails' configuration

### DIFF
--- a/documentation/man/features/mail.rst
+++ b/documentation/man/features/mail.rst
@@ -32,6 +32,11 @@ the union of the recipients of each patch as the recipients of the cover-letter.
   *kworkflow.config* file.
 
 .. note::
+  You can add To\: and CC\: recipients to be included by default using the
+  *default_to_recipients* and *default_cc_recipients* configurations, respectively,
+  in the *mail.config* file.
+
+.. note::
   Any option recognized by ``git send-email`` can be passed directly to it if
   placed after the double dash (``--``) argument.
 

--- a/etc/mail.config
+++ b/etc/mail.config
@@ -6,3 +6,8 @@ send_opts=--annotate --cover-letter --no-chain-reply-to --thread
 # initially blocked to avoid mistakenly send more than 15 patches at once to
 # the vger mailing lists. Configure it according to your needs.
 blocked_emails=linux-kernel@vger.kernel.org
+
+# You can add emails to always be included as recipients. Emails should be
+# separated by comma. There is a separate config for the To: and CC: recipients.
+default_to_recipients=
+default_cc_recipients=

--- a/src/_kw
+++ b/src/_kw
@@ -133,7 +133,8 @@ _kw_config()
       build.cpu_scaling_factor build.enable_ccache build.warning_level build.use_llvm
       deploy.kw_files_remote_path deploy.deploy_temporary_files_path deploy.deploy_default_compression
       deploy.dtb_copy_pattern deploy.default_deploy_target deploy.reboot_after_deploy
-      deploy.strip_modules_debug_option mail.send_opts mail.blocked_emails
+      deploy.strip_modules_debug_option mail.send_opts mail.blocked_emails mail.default_cc_recipients
+      mail.default_to_recipients
     )'
 
     _multi_parts . "$configs"

--- a/src/config.sh
+++ b/src/config.sh
@@ -9,7 +9,7 @@ declare -gA config_file_list=(
           qemu_path_image'
   ['build']='arch kernel_img_name cross_compile menu_config doc_type
              cpu_scaling_factor enable_ccache warning_level use_llvm cflags'
-  ['mail']='send_opts blocked_emails'
+  ['mail']='send_opts blocked_emails default_to_recipients default_cc_recipients'
   ['deploy']='kw_files_remote_path deploy_temporary_files_path
               deploy_default_compression dtb_copy_pattern default_deploy_target
               reboot_after_deploy strip_modules_debug_option

--- a/src/lib/kw_config_loader.sh
+++ b/src/lib/kw_config_loader.sh
@@ -244,6 +244,8 @@ function show_mail_variables()
   local -Ar mail=(
     [send_opts]='Options to be used when sending a patch'
     [blocked_emails]='Blocked e-mail addresses'
+    [default_to_recipients]='E-mail addresses to always be included as To: recipients'
+    [default_cc_recipients]='E-mail addresses to always be included as CC: recipients'
   )
 
   printf '%s\n' "  kw mail options:"

--- a/tests/config_test.sh
+++ b/tests/config_test.sh
@@ -180,6 +180,8 @@ function test_show_configurations_without_parameters()
 
   assert_line_match "$LINENO" 'mail.send_opts=--annotate --cover-letter --no-chain-reply-to --thread' "$output"
   assert_line_match "$LINENO" 'mail.blocked_emails=test@email.com' "$output"
+  assert_line_match "$LINENO" 'mail.default_to_recipients=defaultto1@email.com,defaultto2@email.com' "$output"
+  assert_line_match "$LINENO" 'mail.default_cc_recipients=defaultcc1@email.com,defaultcc2@email.com,defaultcc3@email.com' "$output"
 
   assert_line_match "$LINENO" 'deploy.default_deploy_target=remote' "$output"
   assert_line_match "$LINENO" 'deploy.reboot_after_deploy=no' "$output"

--- a/tests/mail_test.sh
+++ b/tests/mail_test.sh
@@ -1085,4 +1085,33 @@ function test_mail_list()
   }
 }
 
+function test_add_recipients()
+{
+  local initial_recipients
+  local additional_recipients
+  local output
+  local expected
+
+  initial_recipients=''
+  additional_recipients=''
+  output=$(add_recipients "$initial_recipients" "$additional_recipients")
+  expected=''
+  assert_equals_helper 'No recipients should output nothing' "$LINENO" "$expected" "$output"
+
+  initial_recipients='recipient1@email.com'$'\n'
+  initial_recipients+='recipient2@email.com'$'\n'
+  initial_recipients+='recipient3@email.com'$'\n'
+  initial_recipients+='recipient4@email.com'
+  output=$(add_recipients "$initial_recipients" "$additional_recipients")
+  expected="$initial_recipients"
+  assert_equals_helper 'No additional recipients should output initial recipients' "$LINENO" "$expected" "$output"
+
+  additional_recipients='additional1@email.com,additional2@email.com'
+  output=$(add_recipients "$initial_recipients" "$additional_recipients")
+  expected="$initial_recipients"$'\n'
+  expected+='additional1@email.com'$'\n'
+  expected+='additional2@email.com'
+  assert_equals_helper 'Wrong output' "$LINENO" "$expected" "$output"
+}
+
 invoke_shunit

--- a/tests/samples/mail.config
+++ b/tests/samples/mail.config
@@ -1,2 +1,4 @@
 send_opts=--annotate --cover-letter --no-chain-reply-to --thread
 blocked_emails=test@email.com
+default_to_recipients=defaultto1@email.com,defaultto2@email.com
+default_cc_recipients=defaultcc1@email.com,defaultcc2@email.com,defaultcc3@email.com


### PR DESCRIPTION
`kw mail` already has a configuration to automatically block emails as recipients named 'blocked_emails'. An opposite configuration, to automatically add emails as recipients doesn't exist, though.

In this context, add the configuration 'additional_emails' to `kw mail` to automatically add pre-determined recipients.