### PR TITLE
src: kernel_install: add pacman-key init to arch pre-setup

### DIFF
--- a/src/plugins/kernel_install/arch.sh
+++ b/src/plugins/kernel_install/arch.sh
@@ -47,6 +47,10 @@ function distro_pre_setup()
   cmd="${cmd_prefix}systemctl restart pacman-init.service"
   cmd_manager "$flag" "$cmd"
 
+  # As documented at https://wiki.archlinux.org/title/Pacman/Package_signing
+  cmd="${cmd_prefix}pacman-key --init"
+  cmd_manager "$flag" "$cmd"
+
   # Initialize keyring
   cmd="${cmd_prefix}pacman-key --populate"
   cmd_manager "$flag" "$cmd"

--- a/tests/deploy_test.sh
+++ b/tests/deploy_test.sh
@@ -266,6 +266,7 @@ function test_prepare_distro_for_deploy_ext4()
     '' # Extra space for the \n
     'sudo -E mv /etc/skel/.screenrc /tmp'
     'sudo -E systemctl restart pacman-init.service'
+    'sudo -E pacman-key --init'
     'sudo -E pacman-key --populate'
     'yes | sudo -E pacman -Syu'
     'yes | pacman -Syu rsync screen pv bzip2 lzip lzop zstd xz os-prober rng-tools'
@@ -319,6 +320,7 @@ function test_prepare_distro_for_deploy_btrfs()
     'btrfs property get / ro | grep "ro=false" --silent'
     'sudo -E mv /etc/skel/.screenrc /tmp'
     'sudo -E systemctl restart pacman-init.service'
+    'sudo -E pacman-key --init'
     'sudo -E pacman-key --populate'
     'yes | sudo -E pacman -Syu'
     'yes | pacman -Syu rsync screen pv bzip2 lzip lzop zstd xz os-prober rng-tools'


### PR DESCRIPTION
Initizalizing keyring fits pacman setup guideline at: https://wiki.archlinux.org/title/Pacman/Package_signing

Add the missing steps to steamOS dev environment configuration.

Note: a previous step of restarting pacman-init service fails on steamOS, since there is no pacman-init service there. I'm not sure about other arch-base OSes and it's harmless on steamOS, so I didn't remove it. I don't have another arch-based system, better double-check with someone that has it. 
