### PR TITLE
src: build: fix typo at warnings variable declaration

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -26,7 +26,7 @@ function build_kernel_main()
   local optimizations
   local cpu_scaling_factor
   local parallel_cores
-  local warning
+  local warnings
   local output_path
   local llvm
   local env_name


### PR DESCRIPTION
The local variable "warnings" at build_kernel_main() is declared as "warning", causing the scope to be global. In this context, fix the typo.

Closes: #920