### PR TITLE
`kw config`: Add verbose mode and reset options_values before each test

### DIFF
--- a/documentation/man/features/config.rst
+++ b/documentation/man/features/config.rst
@@ -7,8 +7,8 @@ kw-config
 SYNOPSIS
 ========
 | *kw* (*g* | *config*)
-| *kw* (*g* | *config*) [(-g | \--global)] <config.option value>
-| *kw* (*g* | *config*) [(-l | \--local)] <config.option value>
+| *kw* (*g* | *config*) [\--verbose] [(-g | \--global)] <config.option value>
+| *kw* (*g* | *config*) [\--verbose] [(-l | \--local)] <config.option value>
 | *kw* (*g* | *config*) (-s | \--show) [<config_target>]...
 
 
@@ -36,7 +36,10 @@ OPTIONS
   configuration.
 
 -s, \--show:
-  Display current configurations
+  Display current configurations.
+
+\--verbose:
+  Display commands executed under the hood.
 
 EXAMPLES
 ========
@@ -57,3 +60,7 @@ If you want to display all configurations you could use::
 If you want to display deploy configurations you could use::
 
   kw config -s deploy
+
+In case of any issue, you can try to enable the verbose option::
+
+  kw config --verbose kworkflow.alert vs

--- a/src/_kw
+++ b/src/_kw
@@ -147,6 +147,7 @@ _kw_config()
   fi
 
   _arguments : \
+    '(--verbose)--verbose[enable verbose mode]' \
     '(-g --global -l --local -s --show)'{-g,--global}'[set global configuration]' \
     '(-l --local -g --global -s --show)'{-l,--local}'[set local configuration]' \
     '(-s --show -g --global -l --local)'{-s,--show}'[display current configurations]: :(vm kworkflow notification build deploy mail)' \

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -48,7 +48,7 @@ function _kw_autocomplete()
                                        --remove --fetch --output --optimize --remote'
   kw_options['k']="${kw_options['kernel-config-manager']}"
 
-  kw_options['config']='--local --global --show --help'
+  kw_options['config']='--local --global --show --help --verbose'
 
   kw_options['remote']='add remove rename --list --global --set-default --verbose'
 

--- a/tests/config_test.sh
+++ b/tests/config_test.sh
@@ -129,6 +129,26 @@ function test_set_config_with_a_path_as_value()
   assert_equals_helper 'Change llvm' "($LINENO)" "$output" 'qemu_path_image=/DATA/QEMU_VMS/virty.qcow2'
 }
 
+function test_set_config_with_verbose_mode()
+{
+  local option
+  local new_value
+  local config_path
+  local output
+  local expected
+
+  option="default_to_recipients"
+  new_value="test@email.com"
+  config_path="${KW_CONFIG_BASE_PATH}/mail.config"
+  expected+="sed --in-place --regexp-extended --follow-symlinks \"s<(default_to_recipients=).*<\1test@email.com<\" \"${config_path}\""
+  expected+=$'\n'
+  expected+="sed --in-place --regexp-extended --follow-symlinks \"s<\#\s*default_to_recipients<default_to_recipients<\" \"${config_path}\""
+
+  output="$(set_config_value "$option" "$new_value" "$config_path" "VERBOSE")"
+
+  assert_equals_helper 'Wrong verbose output' "$LINENO" "$expected" "$output"
+}
+
 function test_check_if_target_config_exist()
 {
   check_if_target_config_exist 'vm' 'vm.config'
@@ -140,29 +160,41 @@ function test_check_if_target_config_exist()
 
 function test_parse_config_options()
 {
-  unset options_values
-  declare -gA options_values
+  # shellcheck disable=SC2317
+  function reset_options_values()
+  {
+    unset options_values
+    declare -gA options_values
+  }
 
+  reset_options_values
   parse_config_options
   assert_equals_helper 'Expected local as a default scope' \
     "($LINENO)" 'local' "${options_values['SCOPE']}"
 
   # test default options
+  reset_options_values
   parse_config_options --global
-
   assert_equals_helper 'Set global scope' \
     "($LINENO)" 'global' "${options_values['SCOPE']}"
 
+  reset_options_values
   parse_config_options --local
   assert_equals_helper 'Set local scope' \
     "($LINENO)" 'local' "${options_values['SCOPE']}"
 
+  reset_options_values
   parse_config_options 'build.something=xpto'
   assert_equals_helper 'Expected <build.something=xpto>' \
     "($LINENO)" 'build.something=xpto ' "${options_values['PARAMETERS']}"
 
+  reset_options_values
   parse_config_options --invalid
   assertEquals "($LINENO)" 22 "$?"
+
+  reset_options_values
+  parse_config_options --verbose
+  assertEquals "($LINENO):" '1' "${options_values['VERBOSE']}"
 }
 
 function test_show_configurations_without_parameters()


### PR DESCRIPTION
Add support for the verbose parameter within `kw config`.
The verbose parameter gives details of the commands that are executed behind the scenes.

Task of issue #857 

Also refactor test_parse_config_options and fix options_values not being reset before each parse_config_options assertion.
