### PR TITLE
`run_tests`: fix tests on non-english machines

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -107,7 +107,8 @@ if [[ "$#" -eq 0 ]]; then
   # Note: Usually we want to use double-quotes on bash variables, however,
   # in this case we want a set of parameters instead of a single one.
   strip_path $files_list
-  run_tests
+  # Note: LANGUAGE environment variable must be set in order to avoid error messages in other languages.
+  LANGUAGE=en_US.UTF_8 run_tests
 elif [[ "$1" == 'list' ]]; then
   index=0
   files_list=$(find ./tests/ -name '*_test.sh')
@@ -118,7 +119,7 @@ elif [[ "$1" == 'list' ]]; then
   done
 elif [[ "$1" == 'test' ]]; then
   strip_path "${@:2}"
-  run_tests
+  LANGUAGE=en_US.UTF_8 run_tests
 else
   show_help
 fi


### PR DESCRIPTION
On machines with non-english locales, some error messages generated are printed in that language. The tests assertions, thus, fail inappropriately. In this context, set LANGUAGE environment variable before running the tests.

Closes #916.