### PR TITLE
src: config: Fix set_config behaviour when using env

### DIFF
--- a/src/config.sh
+++ b/src/config.sh
@@ -194,8 +194,8 @@ function set_config_value()
   # work well if we deal with paths. Here we had to break the pattern a little
   # bit and use < instead of / after the s option to ensure that we accept
   # paths in the config option.$
-  sed -i -r "s<($option=).*<\1$value<" "$path"
-  sed -i -r "s<#\s*$option<$option<" "$path"
+  sed --in-place --regexp-extended --follow-symlinks "s<(${option}=).*<\1${value}<" "${path}"
+  sed --in-place --regexp-extended --follow-symlinks "s<#\s*${option}<${option}<" "$path"
 }
 
 function parse_config_options()

--- a/tests/config_test.sh
+++ b/tests/config_test.sh
@@ -81,6 +81,20 @@ function test_is_a_valid_config_invalid_parameters()
   assertEquals "($LINENO)" "$?" 95
 }
 
+function test_set_config_check_if_file_still_a_link_after_change()
+{
+  local output
+
+  # Create fake env
+  mkdir 'FAKE_ENV'
+  mv "${KW_CONFIG_BASE_PATH}/build.config" 'FAKE_ENV'
+  ln --symbolic --force "${KW_CONFIG_BASE_PATH}/FAKE_ENV/build.config" "${KW_CONFIG_BASE_PATH}/build.config"
+
+  set_config_value 'use_llvm' 'lala' "${KW_CONFIG_BASE_PATH}/build.config"
+  output=$(grep 'use_llvm' "${KW_CONFIG_BASE_PATH}/build.config")
+  assertTrue "($LINENO): Cache dir not created" '[[ -L  ${KW_CONFIG_BASE_PATH}/build.config ]]'
+}
+
 function test_set_config_value_changing_default_value()
 {
   local output


### PR DESCRIPTION
When using command like

    kw config build.arch x86_32

inside an env, kw destroys the symbolic link created by the env and creates a new file. As a result, when switching between envs the configuration does not persist. This commit fixes this issue by adding the follow-symlinks option in the sed command responsible for handling the config file.