### PR TITLE
src: pomodoro: Add verbose mode

### DIFF
--- a/documentation/man/features/pomodoro.rst
+++ b/documentation/man/features/pomodoro.rst
@@ -6,9 +6,9 @@ kw-pomodoro
 
 SYNOPSIS
 ========
-| *kw* (*p* | *pomodoro*) (-t | \--set-timer) <time>(h | m | s) [(-g | \--tag) <tag> [(-d | \--description) <desc>]]
-| *kw* (*p* | *pomodoro*) (-c | \--check-timer)
-| *kw* (*p* | *pomodoro*) (-s | \--show-tags)
+| *kw* (*p* | *pomodoro*) (-t | \--set-timer) <time>(h | m | s) [(-g | \--tag) <tag> [(-d | \--description) <desc>] [\--verbose]]
+| *kw* (*p* | *pomodoro*) (-c | \--check-timer) [\--verbose]
+| *kw* (*p* | *pomodoro*) (-s | \--show-tags) [\--verbose]
 
 DESCRIPTION
 ===========
@@ -54,6 +54,9 @@ OPTIONS
 
 -s, \--show-tags:
   This option shows all the registered tags.
+
+\--verbose:
+  Display commands executed under the hood.
 
 EXAMPLES
 ========

--- a/src/_kw
+++ b/src/_kw
@@ -420,6 +420,7 @@ _kw_pomodoro()
   fi
 
   _arguments : \
+    '(--verbose)--verbose[enable verbose mode]' \
     '(-t --set-timer -c --check-timer -s --show-tags)'{-t,--set-timer}'[set the timer for the Pomodoro timebox]: : ' \
     '(-c --check-timer -t --set-timer -s --show-tags)'{-c,--check-timer}'[shows information of each active Pomodoro timebox]' \
     '(-s --show-tags -c --check-timer -t --set-timer)'{-s,--show-tags}'[shows registered tags]' \

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -56,7 +56,7 @@ function _kw_autocomplete()
   kw_options['explore']='--log --grep --all --only-header --only-source --exactly --verbose'
   kw_options['e']="${kw_options['explore']}"
 
-  kw_options['pomodoro']='--set-timer --check-timer --show-tags --tag --description --help'
+  kw_options['pomodoro']='--set-timer --check-timer --show-tags --tag --description --help --verbose'
   kw_options['p']="${kw_options['pomodoro']}"
 
   kw_options['report']='--day --week --month --year --output --statistics --pomodoro --all'

--- a/tests/pomodoro_test.sh
+++ b/tests/pomodoro_test.sh
@@ -172,6 +172,9 @@ function test_parse_pomodoro()
   apostrophe="Let's try something with apostrophe (I'm, you're, we're)"
   parse_pomodoro '--set-timer' '1234s' '--tag' 'apostrophe' '--description' "$apostrophe"
   assert_equals_helper 'Wrong description' "$LINENO" "${options_values['DESCRIPTION']}" "$apostrophe"
+
+  parse_pomodoro '--verbose'
+  assert_equals_helper 'Show a detailed output' "$LINENO" "${options_values['VERBOSE']}" '1'
 }
 
 function test_register_data_for_report()
@@ -218,31 +221,31 @@ function test_register_tag()
     'tag 2'
   )
 
-  register_tag 'tag 1'
-  register_tag 'tag 2'
+  register_tag 'TEST_MODE' 'tag 1'
+  register_tag 'TEST_MODE' 'tag 2'
   output=$(sqlite3 "${KW_DATA_DIR}/kw.db" -batch "SELECT name FROM tag ;")
 
   compare_command_sequence '' "$LINENO" 'expected_content' "$output"
 
   # Try to register the same tag
-  register_tag 'tag 2'
+  register_tag 'TEST_MODE' 'tag 2'
   compare_command_sequence '' "$LINENO" 'expected_content' "$output"
 
   # Try to register an empty tag
-  register_tag ''
+  register_tag 'TEST_MODE' ''
   compare_command_sequence '' "$LINENO" 'expected_content' "$output"
 }
 
 function test_is_tag_already_registered()
 {
-  is_tag_already_registered 'Tag 0'
+  is_tag_already_registered 'TEST_MODE' 'Tag 0'
   assertNotEquals "$LINENO: We should not get a success" "$?" 0
 
-  is_tag_already_registered ''
+  is_tag_already_registered 'TEST_MODE' ''
   assertNotEquals "$LINENO: We should not get a success" "$?" 0
 
   sqlite3 "${KW_DATA_DIR}/kw.db" -batch "INSERT INTO tag ('name') VALUES ('Tag 0') ;"
-  is_tag_already_registered 'Tag 0'
+  is_tag_already_registered 'TEST_MODE' 'Tag 0'
   assertEquals "$LINENO: We expect to find Tag 0" "$?" 0
 }
 
@@ -258,10 +261,10 @@ function test_get_tag_name()
   expected='Some tag'
   assert_equals_helper 'Should return same value if it is not a number' "$LINENO" "$expected" "$output"
 
-  register_tag 'tag 1'
-  register_tag 'tag 2'
-  register_tag 'tag 3'
-  register_tag 'tag 4'
+  register_tag 'TEST_MODE' 'tag 1'
+  register_tag 'TEST_MODE' 'tag 2'
+  register_tag 'TEST_MODE' 'tag 3'
+  register_tag 'TEST_MODE' 'tag 4'
 
   for i in {1..4}; do
     output=$(get_tag_name "$i")


### PR DESCRIPTION
Add support for the verbose parameter within `kw pomodoro`. The verbose parameter gives details of the commands that are executed behind the scenes.

Note: This is part of the issue: #857