### PR TITLE
src: report: Add verbose mode

### DIFF
--- a/documentation/man/features/report.rst
+++ b/documentation/man/features/report.rst
@@ -6,10 +6,10 @@ kw-report
 
 SYNOPSIS
 ========
-| *kw* (*r* | *report*) [\--year [<year>]] [\--output <file-path>]
-| *kw* (*r* | *report*) [\--month [<year>/<month>]] [\--output <file-path>]
-| *kw* (*r* | *report*) [\--week [<year>/<month>/<day>]] [\--output <file-path>]
-| *kw* (*r* | *report*) [\--day [<year>/<month>/<day>]] [\--output <file-path>]
+| *kw* (*r* | *report*) [\--year [<year>]] [\--output <file-path> ] [\--verbose]
+| *kw* (*r* | *report*) [\--month [<year>/<month>]] [\--output <file-path>] [\--verbose]
+| *kw* (*r* | *report*) [\--week [<year>/<month>/<day>]] [\--output <file-path>] [\--verbose]
+| *kw* (*r* | *report*) [\--day [<year>/<month>/<day>]] [\--output <file-path>] [\--verbose]
 
 DESCRIPTION
 ===========
@@ -71,6 +71,9 @@ OPTIONS
 
 \--output <file-path>:
   Save the output of the report to *<file-path>*.
+
+\--verbose:
+  Display commands executed under the hood.
 
 EXAMPLES
 ========

--- a/src/_kw
+++ b/src/_kw
@@ -449,6 +449,7 @@ _kw_r() { _kw_report }
 _kw_report()
 {
   _arguments : \
+    '(--verbose)--verbose[enable verbose mode]' \
     '(--month --week --day)--year=-[exhibits a yearly summary]:: : ' \
     '(--year --week --day)--month=-[exhibits a monthly summary]:: : ' \
     '(--year --month --day)--week=-[exhibits a weekly summary]:: : ' \

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -59,7 +59,7 @@ function _kw_autocomplete()
   kw_options['pomodoro']='--set-timer --check-timer --show-tags --tag --description --help'
   kw_options['p']="${kw_options['pomodoro']}"
 
-  kw_options['report']='--day --week --month --year --output --statistics --pomodoro --all'
+  kw_options['report']='--day --week --month --year --output --statistics --pomodoro --all --verbose'
   kw_options['r']="${kw_options['report']}"
 
   kw_options['device']='--local --remote --vm'

--- a/tests/report_test.sh
+++ b/tests/report_test.sh
@@ -79,6 +79,9 @@ function test_parse_report_options()
   expected_result=$(get_today_info '+%Y')
   assert_equals_helper 'Get this year info' "$LINENO" "${options_values['YEAR']}" "$expected_result"
 
+  parse_report_options '--verbose'
+  assert_equals_helper 'Show a detailed output' "$LINENO" "${options_values['VERBOSE']}" '1'
+
   # Values with parameters
   ## Days
   ref_date='1999/03/03'
@@ -502,6 +505,7 @@ function test_save_data_to()
 {
   local output
   local expected
+  local expected_cmd
   local ret
   local yellow
   local green
@@ -555,7 +559,6 @@ function test_save_data_to()
   ret="$?"
   assert_equals_helper 'We expect a directory path to be valid' "$LINENO" 0 "$ret"
 
-  # Verifying that the correct message is displayed.
   expected="The report output was saved in: ${SHUNIT_TMPDIR}/report_output"
   assert_equals_helper 'We expect a valid message' "$LINENO" "$expected" "$output"
 


### PR DESCRIPTION
Add support for the verbose parameter within `kw report`. The verbose parameter gives details of the commands that are executed behind the scenes.

Note: This is part of the issue: #857