### PR TITLE
setup.sh: stop kw installation if dependencies cannot be installed.

### DIFF
--- a/.github/workflows/test_setup_and_docs.yml
+++ b/.github/workflows/test_setup_and_docs.yml
@@ -12,6 +12,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      # This is here just because git-email cannot be installed in the 
+      # Github CI otherwise.
+      - name: Add git-core PPA for git-email
+        run: |
+          sudo add-apt-repository ppa:git-core/ppa -y
+
       - name: Update the system
         run: |
           sudo apt update -y


### PR DESCRIPTION
We perform a check to see if the installation of the dependencies was successful, which exits the program if not.

For example, the user may lack sudo privileges or answer NO when asked to install the dependencies.

Closes: #596