### PR TITLE
Fix missing git credentials in tests

### DIFF
--- a/tests/lib/kwlib_test.sh
+++ b/tests/lib/kwlib_test.sh
@@ -83,6 +83,8 @@ function setupGitRepository()
   declare -gr PATH_TO_GIT_REPOSITORY="${SHUNIT_TMPDIR}/git_repository"
   mkdir -p "$PATH_TO_GIT_REPOSITORY"
   git -C "$PATH_TO_GIT_REPOSITORY" init --initial-branch='master' --quiet
+  git -C "$PATH_TO_GIT_REPOSITORY" config user.name kw
+  git -C "$PATH_TO_GIT_REPOSITORY" config user.email kw@kw
 }
 
 function teardownGitRepository()

--- a/tests/maintainers_test.sh
+++ b/tests/maintainers_test.sh
@@ -61,6 +61,8 @@ function oneTimeSetUp()
   touch fs/some_file
   git init --quiet
   git add fs/some_file
+  git config user.name kw
+  git config user.email kw@kw
   git commit --quiet -m "Test message"
   cd "$original_dir" || {
     fail "($LINENO) It was not possible to move back from temp directory"


### PR DESCRIPTION
The test suite `kwklib_test` required the git credentials `user.name` and `user.email`, but these were not defined when creating ephemeral git repositories for the tests. Rather, the tests relied on global git credentials, which if not set would cause the test to fail because it is not possible to make git commits without the mentioned credentials. This PR adds local git credentials when creating temporary git repos. That way, the test suite will pass even if no global git credentials are defined.