### PR TITLE
src: build: Fix cflags formatting issue 

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -127,7 +127,7 @@ function build_kernel_main()
   command="make ${optimizations} ${llvm}ARCH=${platform_ops}${warnings}"
 
   if [[ -n "$cflags" ]]; then
-    command+=" KCFLAGS=${cflags}"
+    command+=" KCFLAGS=\"${cflags}\""
   fi
   command+="${output_kbuild_flag}${output_path}"
 
@@ -293,7 +293,7 @@ function load_build_config()
 
 function parse_build_options()
 {
-  local long_options='help,info,menu,doc,ccache,cpu-scaling:,warnings::,save-log-to:,llvm,clean,full-cleanup,verbose,cflags'
+  local long_options='help,info,menu,doc,ccache,cpu-scaling:,warnings::,save-log-to:,llvm,clean,full-cleanup,verbose,cflags:'
   local short_options='h,i,n,d,S:,w::,s:,c,f'
   local doc_type
   local file_name_size

--- a/tests/build_test.sh
+++ b/tests/build_test.sh
@@ -946,6 +946,25 @@ function test_kernel_build_full_cleanup_inside_env()
   assertEquals "($LINENO)" "$expected_result" "$output"
 }
 
+function test_kernel_build_cflags()
+{
+  local expected_result
+  local output
+  local flag_name="-O3 -pipe -march=native"
+  build_config=()
+
+  parse_configuration "${SAMPLES_DIR}/build_no_log.config" build_config
+
+  output=$(build_kernel_main 'TEST_MODE' --cflags "${flag_name}" | tail -n +1 | head -2)
+
+  declare -a expected_cmd=(
+    "make -j ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- --silent olddefconfig"
+    "make -j${PARALLEL_CORES} ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- W=2 KCFLAGS=\"${flag_name}\""
+  )
+
+  compare_command_sequence '' "$LINENO" 'expected_cmd' "$output"
+}
+
 function test_kernel_build_cflags_inside_env()
 {
   local expected_result
@@ -962,7 +981,7 @@ function test_kernel_build_cflags_inside_env()
 
   declare -a expected_cmd=(
     "make -j ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- --silent olddefconfig O=${env_output}"
-    "make -j${PARALLEL_CORES} ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- W=2 KCFLAGS=${flag_name} O=${env_output}"
+    "make -j${PARALLEL_CORES} ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- W=2 KCFLAGS=\"${flag_name}\" O=${env_output}"
   )
 
   compare_command_sequence '' "$LINENO" 'expected_cmd' "$output"


### PR DESCRIPTION
This commit solves the issue where setting the string as cflags "-DAMD_PRIVATE_COLOR" was not functioning as expected. The code has been updated the code to properly escape the minus symbol in cflags, making it work as expected

Closes: #934