### PR TITLE
src: env: Block env switch if the kernel tree is not clean

### DIFF
--- a/etc/strings/env.txt
+++ b/etc/strings/env.txt
@@ -1,0 +1,7 @@
+[use_failure_explanation]:
+If you are trying to use kw env, you must ensure that your kernel tree is
+clean; in other words, it should not have any file that results from a
+compilation, and it should not have the .config file.
+
+If you have already created the env, you can safely run kw build --full-cleanup
+and run kw env --use <ENV_NAME>.

--- a/tests/kw_env_test.sh
+++ b/tests/kw_env_test.sh
@@ -20,6 +20,9 @@ setUp()
   # Create fake .kw folder
   mk_fake_kw_folder "$TEST_PATH"
 
+  # Copy strings
+  cp "${ORIGINAL_PATH}/etc/strings/env.txt" "$TEST_PATH"
+
   # Create a dummy kernel .config file
   cp "$STD_CONFIG_FILE" ./
 }
@@ -193,6 +196,36 @@ function test_use_target_env_invalid_env()
   options_values['USE']='lala'
   output=$(use_target_env)
   assertEquals "($LINENO) Env does not exists" "$?" 22
+}
+
+function test_validate_env_before_switch_invalid_case_with_config()
+{
+  # In this case we don't care about the user output for the test, for this
+  # reaon, move to dev/null
+  validate_env_before_switch > /dev/null
+  assertEquals "(${LINENO}) it should not allow switch to a new env due to .config file." "$?" 22
+}
+
+function test_validate_env_before_switch_invalid_case_with_object_file()
+{
+  # Remove the .cofig file
+  mv '.config' 'config'
+
+  # Create a fake object file
+  mkdir -p 'drivers/gpu/drm/'
+  touch 'drivers/gpu/drm/drm_atomic.o'
+
+  validate_env_before_switch > /dev/null
+  assertEquals "(${LINENO}) it should not allow switch to a new env due to object files." "$?" 22
+}
+
+function test_validate_env_before_switch_no_config_and_no_object_files()
+{
+  # Remove the .cofig file
+  mv '.config' 'config'
+
+  validate_env_before_switch > /dev/null
+  assertEquals "(${LINENO}) it should allow switch to a new env due to object files." "$?" 0
 }
 
 function test_parse_env_options()


### PR DESCRIPTION
One of the requirements of using kw env is imposed by how the O= option works, which requires that the kernel tree is clean to work properly. Currently, the command kw env --use only allows users to switch if the env is clean, which can lead to build failures and consequently mislead users. This commit addresses this issue by adding a check phase before the user tries to switch to a new env; if the kernel tree is not clean, kw fails the operation with an informative message.

Closes: #705