### PR TITLE
documentation: conf: Fix deprecated `navigation_with_keys` setting bug

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -97,7 +97,9 @@ html_favicon = 'favicon.ico'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    "navigation_with_keys": False
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
[What]

At the current moment, by running the command

`./setup.sh --docs`

we are met with the current error:

  Warning, treated as error:
  The default value for `navigation_with_keys` will change to `False` in
  the next release. If you wish to preserve the old behavior for your
  site, set `navigation_with_keys=True` in the `html_theme_options` dict
  in your `conf.py` file.Be aware that `navigation_with_keys = True` has
  negative accessibility
  implications:https://github.com/pydata/pydata-sphinx-theme/issues/1492

By accessing the link mentioned in the error message, it seems that the python-sphinx setting `navigation_with_keys` is, by default, set to `True` and this creates accessibility problems. Thus, the site compilation fails with the objective of warning users to make a conscious decision about the setting.

[Why]

Reading the thread from the link, it seems that it is better to set `navigation_with_keys` to `False`, as the kworkflow site doesn't look to take advantage of the setting, and we need to make a decision about it.

[How]

Change the `navigation_with_keys` setting to `False` in the `html_theme_options` Python dictionary of the `documentation/conf.py` file, as indicated by the error message.