### PR TITLE
integration_tests: Containerfile: Podman integration testing

### DIFF
--- a/.github/workflows/kcov.yml
+++ b/.github/workflows/kcov.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           kcov --include-path=src,kw \
           --exclude-pattern=src/bash_autocomplete.sh,src/help.sh \
-          kcov_out/ ./run_tests.sh
+          kcov_out/ ./run_tests.sh --unit
 
       - name: Upload coverage do codecov
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -30,4 +30,4 @@ jobs:
 
       - name: Unit tests
         run: |
-          ./run_tests.sh
+          ./run_tests.sh --unit

--- a/documentation/content/tests.rst
+++ b/documentation/content/tests.rst
@@ -9,6 +9,11 @@ Kw's tests rely on `shunit2`. The `run_tests.sh` script automatically detects
 can have shunit2 source code in `tests/` (you can clone it from
 https://github.com/kward/shunit2).
 
+In order to run the integration tests, it is necessary to install Podman and  to
+configure it to run in `rootless` mode. Podman  is  available  via  the  default
+package manager of popular distros, such as Arch, Debian, Fedora and those based
+on them.
+
 If you want to run all the tests, try::
 
   ./run_tests.sh
@@ -20,6 +25,37 @@ List all available test files::
 Or run individual tests with::
 
   ./run_tests.sh test TESTFILE1 ...
+
+To limit the scope of the tests, pass the flag `--unit` or `--integration` as
+the first argument to any of the examples above. So, the syntax is::
+
+  ./run_tests.sh [scope] [command] [args]
+
+Where `[scope]` can be `--unit` or `--integration`. The placeholder  `[command]`
+can be either `list`, `test` or simply omited in order to run  all  tests.  Here
+are some examples:
+
+  ./run_tests.sh --unit                       # run all unit tests
+  ./run_tests.sh --unit list                  # list all unit tests
+  ./run_tests.sh --unit test device           # test device unit test
+  ./run_tests.sh --integration                # run all integration tests
+  ./run_tests.sh --integration list           # list all integration tests
+  ./run_tests.sh --integration test device    # test device integration test
+  ./run_tests.sh                              # run all tests
+  ./run_tests.sh list                         # list all tests
+  ./run_tests.sh test device                  # run all device tests
+
+The integration tests can take over 10 minutes to run in the first time  because
+podman is building the container images to be used in the tests, which  requires
+installing kw's dependencies in the supported distros.  After  the  images  have
+been built and cached, running the integration tests  should  take  only  a  few
+seconds each time.
+
+Then, the local kw repo is copied to the containers and installed  again,  which
+takes very few seconds. For optimization purposes,  the  containers  are  reused
+accross tests. If you add a new commit or checkout to another branch, such  that
+HEAD points to another commit, the containers  will  be  destroyed  and  created
+again in order to install the current local version of kw.
 
 Kw is already prepared to run tests, build the documentation and check the
 installation in the github workflow.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,6 +2,7 @@
 
 . ./src/lib/kw_include.sh --source-only
 include './tests/unit/utils.sh'
+include './tests/integration/utils.sh'
 include './src/lib/kwio.sh'
 
 function show_help()
@@ -11,6 +12,8 @@ function show_help()
     "Example: $0 test kw_test" \
     '' \
     'OPTIONS' \
+    '  -i, --integration' \
+    '         Limit tests to integration tests' \
     '  -u, --unit' \
     '         Limit tests to unit tests' \
     '' \
@@ -66,16 +69,33 @@ function run_tests()
   local -i notfound=0
   local -i fail=0
   local test_failure_list=''
+  local test_dir
+  local integration_tests_setup=0 # have we setup the environment for integration tests?
 
   for current_test in "${TESTS[@]}"; do
     target=$(find "$TESTS_DIR" -name "${current_test}*.sh" | grep --extended-regexp --invert-match 'samples/.*|/shunit2/')
     if [[ -f "$target" ]]; then
+
+      # if we are running integration tests, we will set up the environment for
+      # them here. That is because all integration tests share the same setup:
+      # at least the container environment must be up. It is much more efficient
+      # to run the setup just once for all tests than to run it for every test.
+      # This approach also avoids code duplication in the files.
+      test_dir=$(dirname "${target}")
+      if [[ "$test_dir" =~ '/integration' && "$integration_tests_setup" == 0 ]]; then
+        integration_tests_setup=1
+        say 'Preparing environment for integration tests...'
+        setup_container_environment
+        printf '\n'
+      fi
+
       say "Running test [${current_test}]"
       say "$SEPARATOR"
       (
         init_env
         "$target"
       )
+
       if [[ "$?" -eq 0 ]]; then
         success+=1
       else
@@ -91,6 +111,17 @@ function run_tests()
       notfound+=1
     fi
   done
+
+  # instead of tearing down the container environment after each integration test,
+  # we will tear it down only after all tests have ran. This optimizes significant
+  # amount of time for the integration tests.
+  if [[ "${integration_tests_setup}" == 1 ]]; then
+    printf '\n' # add new line after the last "OK"
+    say 'Tearing down environment used in integration tests...'
+    teardown_container_environment
+    printf '\n'
+  fi
+
   report_results "$total" "$success" "$notfound" "$fail" "$test_failure_list"
 }
 
@@ -108,6 +139,9 @@ function strip_path()
 declare TESTS_DIR=./tests
 if [[ "$1" == '--unit' || "$1" == '-u' ]]; then
   TESTS_DIR=./tests/unit
+  shift
+elif [[ "$1" == '--integration' || "$1" == '-i' ]]; then
+  TESTS_DIR=./tests/integration
   shift
 fi
 

--- a/tests/integration/config_test.sh
+++ b/tests/integration/config_test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+include './tests/unit/utils.sh'
+include './tests/integration/utils.sh'
+
+function oneTimeSetUp()
+{
+  local distro
+
+  # copy config files to the containers
+  for distro in "${DISTROS[@]}"; do
+    container_copy "kw-${distro}" "${SAMPLES_DIR}/config" '/tmp/.kw'
+  done
+}
+
+# The current workaround is this: we are using specially crafted config files
+# that overwrite all global options in the same order displayed by kw.
+function local_config_test_helper()
+{
+  local config="$1"
+  local config_file
+  local container
+  local distro
+  local expected_output
+
+  # make sure config is defined
+  if [[ -z "${config}" ]]; then
+    fail "(${LINENO}): 'config' is not defined."
+  fi
+
+  # the path to the config file
+  config_file="${SAMPLES_DIR}/config/${config}.config"
+
+  # the expected output is the same for all distros
+  expected_output=$(sort --dictionary-order "${config_file}")
+
+  for distro in "${DISTROS[@]}"; do
+    container="kw-${distro}"
+
+    # get the output inside the container
+    output=$(container_exec --workdir '/tmp' "${container}" "kw config --show --local ${config}")
+
+    if [[ "$?" -ne 0 ]]; then
+      fail "(${LINENO}) kw failed to show local variables in ${distro}"
+    fi
+
+    # remove prefix and N/A values from the output and sort them, before comparing
+    output=$(grep --invert-match 'N/A' <<< "${output}" | sed "s/^${config}.//" | sort --dictionary-order)
+
+    assertEquals "(${LINENO}): kw config failed for ${distro}" "${expected_output}" "${output}"
+  done
+}
+
+function test_build_config()
+{
+  local_config_test_helper 'build'
+}
+
+function test_deploy_config()
+{
+  local_config_test_helper 'deploy'
+}
+
+function test_mail_config()
+{
+  local_config_test_helper 'mail'
+}
+
+function test_notification_config()
+{
+  local_config_test_helper 'notification'
+}
+
+function test_vm_config()
+{
+  local_config_test_helper 'vm'
+}
+
+invoke_shunit

--- a/tests/integration/device_test.sh
+++ b/tests/integration/device_test.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+include './tests/unit/utils.sh'
+include './tests/integration/utils.sh'
+include './src/device_info.sh'
+
+# test if `kw device --local` in the container matches the host
+function device_info_test_helper()
+{
+  local distro="${1}"
+  local container
+  local buffer
+  local filter
+  local filter_regex
+  local fs_type
+  local fs_size
+  local output
+  local expected_output
+
+  # buffer with all information.
+  container="kw-${distro}"
+  buffer=$(container_exec "${container}" 'kw device --local')
+
+  # some fields must be ignored because they surely won't match.
+  filter=(
+    'Root filesystem' 'Size' 'Mounted on'                        # storage fields
+    'Distribution' 'Distribution version' 'Desktop environments' # desktop fields
+  )
+
+  # add | separator to each filter item.
+  filter_regex=$(sed 's/ /|/g' <<< "${filter[@]}")
+
+  # the actual perl regex.
+  filter_regex="(${filter_regex}):"
+
+  # get the output, after applying filter.
+  output=$(printf '%s' "${buffer}" | grep --invert-match --perl-regexp "${filter_regex}")
+
+  # get the expected output from the host machine, also filtering information.
+  expected_output=$(device_main --local | grep --invert-match --perl-regexp "${filter_regex}")
+
+  # TODO: remove this block of code after issue #1000 has been solved.
+  #
+  # deviceinfo shows GPU information for Arch, but not for Debian and Fedora due
+  # some libraries being present in Arch by default,  but  not  in  the  others.
+  # Therefore, if this information is not present, we must filter it out.
+  grep 'GPU:' <<< "${output}" > /dev/null
+  if [[ "$?" -ne 0 ]]; then
+    # we resort to SED because GREP can't filter out lines after context IF we
+    # use invert match. First, we tell sed to stop printing lines after matching
+    # the pattern GPU then delete the line containing that pattern.
+    expected_output=$(sed '/GPU:/q' <<< "${expected_output}" | sed '/GPU:/d')
+  fi
+
+  assertEquals "(${LINENO}): kw device failed for ${distro}" "${output}" "${expected_output}"
+
+  # check storage information
+  fs_type=$(container_inspect --format '{{.Driver}}' "${container}")
+  fs_size=$(container_inspect --format '{{.GraphDriver.Data.WorkDir}}' "${container}" |
+    xargs df -h | tail --lines 1 | awk '{ print $2 }')
+
+  assert_substring_match 'Wrong filesystem type.' "${LINENO}" "${buffer}" "Root filesystem: ${fs_type}"
+  assert_substring_match 'Wrong filesystem size.' "${LINENO}" "${buffer}" "Size: ${fs_size}"
+  assert_substring_match 'Wrong mounting point.' "${LINENO}" "${buffer}" "Mounted on: /"
+}
+
+function test_device_archlinux()
+{
+  device_info_test_helper 'archlinux'
+}
+
+function test_device_debian()
+{
+  device_info_test_helper 'debian'
+}
+
+function test_device_fedora()
+{
+  device_info_test_helper 'fedora'
+}
+
+invoke_shunit

--- a/tests/integration/kw_version_test.sh
+++ b/tests/integration/kw_version_test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+include './src/lib/kwio.sh'
+include './tests/unit/utils.sh'
+include './tests/integration/utils.sh'
+
+declare -g expected_output
+
+function oneTimeSetUp()
+{
+  local kw_git_dir
+  local kw_dir
+  local head_hash
+  local branch_name
+  local base_version
+
+  # git directory path
+  kw_dir="${KWROOT_DIR}"
+  kw_git_dir="${kw_dir}/.git"
+
+  # In order to check correctness of `kw --version`, we collect some information
+  # from the git repo:
+  #
+  # - Base version (alpha, beta, or other)
+  # - Branch name
+  # - Commit sha
+  #
+  # Because the local KW repo is copied to the container, we run  the  following
+  # commands directly on the host instead of running in the container.
+  head_hash=$(git --git-dir "${kw_git_dir}" rev-parse --short HEAD)
+  branch_name=$(git --git-dir "${kw_git_dir}" rev-parse --short --abbrev-ref HEAD)
+  base_version=$(head --lines 1 "${kw_dir}/src/VERSION")
+
+  # using the gathered information, we build the expected output
+  expected_output=$(printf '%s\nBranch: %s\nCommit: %s' "$base_version" "$branch_name" "$head_hash")
+}
+
+function kw_version_test_helper()
+{
+  local distro="$1"
+  local container
+  local output
+
+  # collect the kw version in the container
+  container="kw-${distro}"
+  output=$(container_exec "${container}" 'kw --version')
+
+  assertEquals "(${LINENO}): kw version failed for ${distro}" "$expected_output" "$output"
+}
+
+function test_kw_version_on_archlinux()
+{
+  kw_version_test_helper 'archlinux'
+}
+
+function test_kw_version_on_debian()
+{
+  kw_version_test_helper 'debian'
+}
+
+function test_kw_version_on_fedora()
+{
+  kw_version_test_helper 'fedora'
+}
+
+invoke_shunit

--- a/tests/integration/podman/Containerfile_archlinux
+++ b/tests/integration/podman/Containerfile_archlinux
@@ -1,0 +1,7 @@
+FROM docker.io/library/archlinux
+
+RUN pacman -Syu --noconfirm git
+
+COPY ./clone_and_install_kw.sh .
+
+RUN bash ./clone_and_install_kw.sh

--- a/tests/integration/podman/Containerfile_debian
+++ b/tests/integration/podman/Containerfile_debian
@@ -1,0 +1,7 @@
+FROM docker.io/library/debian
+
+RUN apt update -y && apt upgrade -y && apt install git -y
+
+COPY ./clone_and_install_kw.sh .
+
+RUN bash ./clone_and_install_kw.sh

--- a/tests/integration/podman/Containerfile_fedora
+++ b/tests/integration/podman/Containerfile_fedora
@@ -1,0 +1,7 @@
+FROM docker.io/library/fedora
+
+RUN dnf install -y git
+
+COPY ./clone_and_install_kw.sh .
+
+RUN bash ./clone_and_install_kw.sh

--- a/tests/integration/podman/clone_and_install_kw.sh
+++ b/tests/integration/podman/clone_and_install_kw.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# The primary purpose of this file is to install kw's dependencies in the  image
+# we will built. This will save up time when installing the local copy of KW  in
+# the running container.
+#
+# We clone kw and install the unstable branch in order for the base image of the
+# container to have all required dependencies. Later, the local KW repo will  be
+# copied to the container and installed, but the dependencies won't have  to  be
+# installed again, which saves a lot of time.
+
+kw_dir='/tmp/kw'
+
+git clone https://github.com/kworkflow/kworkflow "${kw_dir}"
+cd "$kw_dir" || exit 1
+git checkout unstable
+./setup.sh --install --force --skip-docs

--- a/tests/integration/samples/config/build.config
+++ b/tests/integration/samples/config/build.config
@@ -1,0 +1,5 @@
+arch=arm
+kernel_img_name=linux
+menu_config=nconfig
+doc_type=latexdocs
+cpu_scaling_factor=75

--- a/tests/integration/samples/config/deploy.config
+++ b/tests/integration/samples/config/deploy.config
@@ -1,0 +1,7 @@
+kw_files_remote_path=/opt/kw
+deploy_temporary_files_path=/tmp/kw
+deploy_default_compression=gzip
+dtb_copy_pattern=dtb*
+default_deploy_target=local
+reboot_after_deploy=yes
+strip_modules_debug_option=no

--- a/tests/integration/samples/config/kworkflow.config
+++ b/tests/integration/samples/config/kworkflow.config
@@ -1,0 +1,10 @@
+ssh_user=root
+ssh_ip=localhost
+ssh_port=2222
+alert=y
+sound_alert_command=
+visual_alert_command=
+disable_statistics_data_track=yes
+send_opts=
+checkpatch_opts=
+get_maintainer_opts=

--- a/tests/integration/samples/config/mail.config
+++ b/tests/integration/samples/config/mail.config
@@ -1,0 +1,4 @@
+send_opts=1
+blocked_emails=2
+default_to_recipients=3
+default_cc_recipients=4

--- a/tests/integration/samples/config/notification.config
+++ b/tests/integration/samples/config/notification.config
@@ -1,0 +1,3 @@
+alert=n
+sound_alert_command=sound_cmd
+visual_alert_command=alert_cmd

--- a/tests/integration/samples/config/vm.config
+++ b/tests/integration/samples/config/vm.config
@@ -1,0 +1,5 @@
+virtualizer=qemu-system-x86_64
+mount_point=/mount
+qemu_hw_options=-enable-k-d -m 4096
+qemu_net_options=-nic user,hostfwd=tcp::2222-:22
+qemu_path_image=/usr/share/qemu/virty.qcow2

--- a/tests/integration/utils.sh
+++ b/tests/integration/utils.sh
@@ -202,3 +202,14 @@ container_copy()
     fail "(${LINENO}): Failed to copy host files to the container."
   fi
 }
+
+# inspect the container
+container_inspect()
+{
+  # shellcheck disable=SC2068
+  podman container inspect $@
+
+  if [[ "$?" -ne 0 ]]; then
+    fail "(${LINENO}): Failed to inspect the container."
+  fi
+}

--- a/tests/integration/utils.sh
+++ b/tests/integration/utils.sh
@@ -188,3 +188,17 @@ function container_exec()
     fail "(${LINENO}): Failed to execute the command in the container."
   fi
 }
+
+# copy local file to container
+container_copy()
+{
+  local container="$1"
+  local src="$2"
+  local dst="$3"
+
+  podman container cp "${src}" "${container}":"${dst}"
+
+  if [[ "$?" -ne 0 ]]; then
+    fail "(${LINENO}): Failed to copy host files to the container."
+  fi
+}

--- a/tests/integration/utils.sh
+++ b/tests/integration/utils.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+
+include './src/lib/kwio.sh'
+
+declare -g CONTAINER_DIR # has the container files to build the container images
+declare -g SAMPLES_DIR   # has sample files used accross the integration tests
+declare -g KWROOT_DIR    # local kw dir to be copied to and installed in the containers
+declare -g DISTROS       # distributions we will run the integration tests
+
+# ensure path to directories is absolute
+script_dir=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
+CONTAINER_DIR="${script_dir}/podman"
+SAMPLES_DIR="${script_dir}/samples"
+KWROOT_DIR=$(realpath "${script_dir}/../..")
+
+# supported distros
+DISTROS=(
+  'archlinux'
+  'debian'
+  'fedora'
+)
+
+# Builds a container image for the given distro
+#
+# @param $1 The OS distribution of the target container image.
+# @return $? The status code of the command ran to build the image.
+function build_distro_image()
+{
+  local distro="${1}"
+  local file="${CONTAINER_DIR}/Containerfile_${distro}"
+
+  podman image build --file "$file" --tag "kw-${distro}" > /dev/null 2>&1
+
+  # Check if the command failed
+  if [[ "$?" -ne 0 ]]; then
+    fail "(${LINENO}): Error building the image for distribution ${distro}"
+    return "$?"
+  fi
+}
+
+# Builds container images and create containers used accross the tests.
+#
+# @param $1 log level to print info, debug or error
+function setup_container_environment()
+{
+  local container_img
+  local container_name
+  local distro            # current distro
+  local distros_ok        # array of distros whose setup succeed
+  local i                 # current step of the setup
+  local n                 # total number of steps
+  local working_directory # working directory in the container
+
+  # initialize some values
+  distros_ok=()
+  i=0
+  n=$((${#DISTROS[@]} * 2))
+  working_directory='/tmp/kw'
+
+  for distro in "${DISTROS[@]}"; do
+
+    # Only build the image if it does not exists. That's because trying to build
+    # the podman image takes a second or two even if it exists and is cached.
+    podman image exists "kw-${distro}"
+    if [[ "$?" -ne 0 ]]; then
+      # progress message:
+      i=$((i + 1))
+      say "[${i}/${n}] Building container image for ${distro}."
+
+      # Build the image or fail.
+      build_distro_image "$distro"
+      if [[ "$?" -ne 0 ]]; then
+        complain "failed to setup container environment for distro ${distro}"
+
+        # print we will skip creating the container image
+        i=$((i + 1))
+        say "[${i}/${n}] Skip creating ${distro} container."
+
+        # continue the setup for other distros.
+        continue
+      fi
+    else
+      # progress message:
+      i=$((i + 1))
+      say "[${i}/${n}] Using cached container image for ${distro}."
+    fi
+
+    # The name of the container and the container image are equal here,  but  it
+    # is useful to make a distinction that in some places we should use the image
+    # name and in others the container name (they are equal in value but are not
+    # equivalent in meaning).
+    container_img="kw-${distro}"
+    container_name="${container_img}"
+
+    # If container exists, we tear it down and create a new one in order
+    # ensure KW installation reflects the latest local changes.
+    podman container exists "${container_name}"
+    if [[ "$?" -eq 0 ]]; then
+      teardown_single_container "${container_name}"
+    fi
+
+    # progress message:
+    i=$((i + 1))
+    say "[${i}/${n}] Creating ${distro} container."
+
+    # containers are isolated environments designed to run a  process.  After  the
+    # process ends, the container is destroyed. In order execute multiple commands
+    # in the container, we need to keep the container,  which  means  the  primary
+    # process must not terminate. Therefore, we run a never-ending command as  the
+    # primary process,  so  that  we  can  execute  multiple  commands  (secondary
+    # processes) and get the output of each of them separately.
+    container_run \
+      --workdir "${working_directory}" \
+      --volume "${KWROOT_DIR}":"${working_directory}" \
+      --env PATH='/root/.local/bin:/usr/bin' \
+      --name "${container_name}" \
+      --detach \
+      "${container_img}" sleep infinity > /dev/null
+
+    if [[ "$?" -ne 0 ]]; then
+      fail "(${LINENO}): Failed to run the container ${container_name}"
+    fi
+
+    # install kw again
+    container_exec "${container_name}" \
+      ./setup.sh --install --force --skip-checks --skip-docs > /dev/null 2>&1
+
+    if [[ "$?" -ne 0 ]]; then
+      fail "(${LINENO}): Failed to install kw in the container ${container_name}"
+    else
+      # add distro to array of distros that worked.
+      distros_ok+=("$distro")
+    fi
+  done
+
+  # Update DISTRO so it only has distros whose setup succeed.
+  # Thus, the integration tests can run even if some distros failed to set up.
+  DISTROS=("${distros_ok[@]}")
+}
+
+# destroy a single container
+function teardown_single_container()
+{
+  local container="$1"
+
+  podman container exists "${container}"
+
+  if [[ "$?" -eq 0 ]]; then
+    # destroy the container, waiting 0 seconds to send SIGKILL
+    podman container rm --force --time 0 "${container}" > /dev/null 2>&1
+  fi
+}
+
+# destroy all containers used in the tests
+teardown_container_environment()
+{
+  local distro
+  local i=0                # current step of tear down
+  local n="${#DISTROS[@]}" # total number of steps of tear down
+
+  for distro in "${DISTROS[@]}"; do
+    # progress message
+    i=$((i + 1))
+    say "[${i}/${n}] Removing ${distro} container."
+
+    teardown_single_container "kw-${distro}"
+  done
+}
+
+# run a container
+function container_run()
+{
+  # shellcheck disable=SC2068
+  podman container run $@
+
+  if [[ "$?" -ne 0 ]]; then
+    fail "(${LINENO}): Failed to run the container."
+  fi
+}
+
+# execute a given command in the container
+function container_exec()
+{
+  # shellcheck disable=SC2068
+  podman container exec $@ 2> /dev/null
+
+  if [[ "$?" -ne 0 ]]; then
+    fail "(${LINENO}): Failed to execute the command in the container."
+  fi
+}


### PR DESCRIPTION
This PR implements an initial file structure to start developing integration tests for kw.

It is using Podman to provide a debian container with kw installed in the PATH and the kernel repository cloned inside.

The purpose of this commit is to provide an interface inside the folder `integration_tests` to set up and manipulate the containers to write integration tests.

We can still improve this by a lot, but we'd like to hear some feedback to know how to keep going on. Feel free to comment on anything we've made.

What we intend to do next is:

- Keep tests inside /integration_tests/tests/ folder
- Create a script `run_integration_tests.sh` similar to the one provided in [this PR](https://github.com/kworkflow/kworkflow/pull/946), to automatically run all test files from a path.
- Write a simple integration test for kw config manager