### PR TITLE
src: device_info: Add verbose mode

### DIFF
--- a/documentation/man/features/device.rst
+++ b/documentation/man/features/device.rst
@@ -6,7 +6,7 @@ kw-device
 
 SYNOPSIS
 ========
-*kw device* [\--local | \--remote [<remote>:<port>]]
+*kw device* [\--local | \--remote [<remote>:<port>] [\--verbose]
 
 DESCRIPTION
 ===========
@@ -26,3 +26,8 @@ OPTIONS
 
 \--remote [<remote>:<port>]:
   Show hardware information from remote machine.
+
+\--verbose:
+  Verbose mode is an option that causes the kw program to display debug
+  messages to track its progress. This functionality is very useful during the
+  debugging process, allowing you to identify possible errors more easily.

--- a/src/_kw
+++ b/src/_kw
@@ -220,6 +220,7 @@ _kw_deploy()
 _kw_device()
 {
   _arguments : \
+    '(--verbose)--verbose[enable verbose mode]' \
     '(--remote --vm)--local[show hardware information from host machine]' \
     '(--local --vm)--remote[show hardware information from a remote machine]: :' \
     '(--remote --vm)--vm[show hardware information from a virtual machine]'

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -62,7 +62,7 @@ function _kw_autocomplete()
   kw_options['report']='--day --week --month --year --output --statistics --pomodoro --all --verbose'
   kw_options['r']="${kw_options['report']}"
 
-  kw_options['device']='--local --remote --vm'
+  kw_options['device']='--local --remote --vm --verbose'
 
   kw_options['backup']='--restore --force --verbose --help'
 


### PR DESCRIPTION
This commit enables the verbose option for the device info; unfortunately, to make these changes happen, I had to find a balance between updating legacy code and adding a new one. In particular, I had to create a new verbose function only for this feature because most of the code processes strings, and the verbose option should display them in the logs. Additionally, I decided to drop many tests that validate the command sequence, which, for the specific case of device_info, is not helpful because the potential of the errors are in the command result and test it is the correct approach.

Related-to:  #857