### PR TITLE
Change dependencies installation messages

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -86,7 +86,7 @@ function check_dependencies()
 
   if [[ -n "$package_list" ]]; then
     if [[ "$FORCE" == 0 ]]; then
-      if [[ $(ask_yN "Can we install the following dependencies? ${package_list}") =~ '0' ]]; then
+      if [[ $(ask_yN "The following packages are required: ${package_list}"$'\nMay we install them?') =~ '0' ]]; then
         complain 'Aborting kw installation...'
         exit 125 # ECANCELED
       fi

--- a/setup.sh
+++ b/setup.sh
@@ -55,7 +55,6 @@ function check_dependencies()
   local cmd=''
   local distro
   local ret
-  local error_message=''
 
   distro=$(detect_distro '/')
 
@@ -102,11 +101,7 @@ function check_dependencies()
 
     # Installation failed...
     if [[ "$ret" -ne 0 ]]; then
-      error_message='[ERROR]: Dependency installation failure: '
-      [[ "$ret" -eq 1 ]] && error_message+='Lacked sudo privileges to install the packages:'
-      [[ "$ret" -ne 1 ]] && error_message+='Something went wrong when installing the packages:'
-      error_message+=$'\n'"$package_list"
-      complain "$error_message"
+      complain $'[ERROR] Dependencies installation has failed. Aborting kw installation...'
       exit "$ret"
     fi
 


### PR DESCRIPTION
This pull request enhances the messages printed when installing KW dependencies (usually executing `./setup --install`).

As referred in #949, error messages can become misleading when dependencies installation fails. This [pull request fixes this problem](https://github.com/GuilhermeMoreno/kworkflow/commit/f12b21c91c6c82c56cd4e94c69b071de4c3a4dbd) with a minimal solution.

Furthermore, it [introduces enhancements to the question prompt presented before starting the dependencies installation](https://github.com/kworkflow/kworkflow/commit/fee732ecb6fee9a432ff9c19546169f8e4d8e4db), both in terms of formatting and politeness. 