### PR TITLE
kw: show notice message if kw runs in developer mode

### DIFF
--- a/kw
+++ b/kw
@@ -36,6 +36,19 @@ KW_STATE_DIR="${XDG_STATE_HOME:-"${HOME}/.local/state"}/${KWORKFLOW}"
 # ENV dir name
 ENV_DIR='envs'
 
+# Export external variables required by kworkflow
+export KWORKFLOW
+
+#INJECT_CODE_TRACING_SETUP
+
+# This is the one and only time a file will be sourced this way.
+# The include function (sourced from this file) should always be used for file sourcing.
+. "${KW_LIB_DIR}/lib/kw_include.sh" --source-only
+
+
+# Dev mode has to begin after sourcing lib/kw_include.sh
+# Otherwise, it is not possible to use helpers.
+
 ##BEGIN-DEV-MODE##
 KW_BIN="$(readlink -f "${BASH_SOURCE[0]}")"
 KW_BASE_DIR="$(dirname "${KW_BIN}")"
@@ -50,17 +63,27 @@ if [ -f "${KW_BASE_DIR}/src/lib/kwlib.sh" ]; then
   KW_ETC_DIR="${KW_BASE_DIR}/etc"
   KW_PLUGINS_DIR="${KW_LIB_DIR}/plugins"
   # KW_CACHE_DIR # use default cache folder
+
+  # include IO utilities
+  include "${KW_LIB_DIR}/lib/kwio.sh"
+
+  # Print a notice to the developers so he knows some envvars have been changed
+  # We redirect to stderror because this output would make tests fails if the developer is testing
+  say "[INFO]: Running kw in developer mode. Envvars set to the following:
+
+KW_CACHE_DIR =${KW_CACHE_DIR}
+KW_DATA_DIR=${KW_DATA_DIR}
+KW_DB_DIR=${KW_DB_DIR}
+KW_DOC_DIR=${KW_DOC_DIR}
+KW_ETC_DIR=${KW_ETC_DIR}
+KW_LIB_DIR=${KW_LIB_DIR}
+KW_MAN_DIR=${KW_MAN_DIR}
+KW_PLUGINS_DIR=${KW_PLUGINS_DIR}
+KW_SOUND_DIR=${KW_SOUND_DIR}
+" >&2
+
 fi
 ##END-DEV-MODE##
-
-# Export external variables required by kworkflow
-export KWORKFLOW
-
-#INJECT_CODE_TRACING_SETUP
-
-# This is the one and only time a file will be sourced this way.
-# The include function (sourced from this file) should always be used for file sourcing.
-. "${KW_LIB_DIR}/lib/kw_include.sh" --source-only
 
 include "${KW_LIB_DIR}/lib/signal_manager.sh"
 


### PR DESCRIPTION
When kw runs in developer mode, some env vars are changed to point the cache/data/db/doc/etc/lib/man directories to the repository in which the `kw` script is at.

This can cause confusion to developers, which may expect some files (such as database files, manual pages,  plugin files) to be somewhere else and may think kw has a bug (due to devmode) when it doesn't.

This PR basically shows a notice message to inform the developer that kw is running in developer mode and some envvars have been changed. The message is sent to stderror to prevent failing tests (because it would disrupt the output expected to the commands).

**OBS**: I made this commit because I myself ran into problems due to the variables being changed without my awareness.

Closes #956 