### PR TITLE
`patch-hub`: Move function `handle_exit` and update documentation

### DIFF
--- a/src/lib/dialog_ui.sh
+++ b/src/lib/dialog_ui.sh
@@ -911,22 +911,6 @@ function run_dialog_command()
   return "$ret"
 }
 
-# This function is responsible for handling the dialog exit.
-#
-# @exit_status: Exit code
-function handle_exit()
-{
-  local exit_status="$1"
-
-  # Handling stop
-  case "$exit_status" in
-    1 | 22 | 255) # Exit
-      clear
-      exit 0
-      ;;
-  esac
-}
-
 function prettify_string()
 {
   local fixed_text="$1"

--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -236,7 +236,10 @@ function list_patches()
   esac
 }
 
-# This function is responsible for handling the dialog exit.
+# This function is responsible for exitting the current shell if necessary.
+# It is supposed to be called inside `patch_hub_main_loop`, once it enters
+# the infinite while loop that starts the execution of the FSM of the patch-hub
+# feature.
 #
 # @exit_status: Exit code
 function handle_exit()

--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -236,4 +236,20 @@ function list_patches()
   esac
 }
 
+# This function is responsible for handling the dialog exit.
+#
+# @exit_status: Exit code
+function handle_exit()
+{
+  local exit_status="$1"
+
+  # Handling stop
+  case "$exit_status" in
+    1 | 22 | 255) # Exit
+      clear
+      exit 0
+      ;;
+  esac
+}
+
 load_lore_config


### PR DESCRIPTION
The function `handle_exit` used by `patch-hub` Controller component to stop the execution of the FSM is:

1. Implemented in a out-of-place way, inside `src/lib/dialog_ui.sh`. It fits better inside the file `src/ui/patch_hub/patch_hub_core.sh`;
2. Has a misleading documentation stating it is used to handle the exit of Dialog (View component).

This PR introduces two commits that try to address these issues.