### PR TITLE
`patch-hub`: Update handler function of `dashboard` state

### DIFF
--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -109,9 +109,10 @@ function show_dashboard()
 
   create_menu_options 'Dashboard' "$message_box" 'menu_list_string_array'
   ret="$?"
+
+  # Exit
   if [[ "$ret" != 0 ]]; then
-    complain 'Something went wrong when kw tried to display the Dashboad screen.'
-    return "$ret"
+    handle_exit "$ret"
   fi
 
   case "$menu_return_string" in

--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -52,7 +52,7 @@ function patch_hub_main_loop()
   while true; do
     case "${screen_sequence['SHOW_SCREEN']}" in
       'dashboard')
-        dashboard_entry_menu
+        show_dashboard
         ret="$?"
         ;;
       'lore_mailing_lists')
@@ -89,10 +89,9 @@ function patch_hub_main_loop()
   done
 }
 
-# Build the bookmark screen. Developers may want to save some patch for
-# verification later, and the bookmark page address this requirement by
-# providing a list of patches saved by the developers.
-function dashboard_entry_menu()
+# Show Dashboard of patch-hub feature. This is the default starting state and main
+# menu of the feature.
+function show_dashboard()
 {
   local message_box
   local -a menu_list_string_array

--- a/tests/ui/patch_hub/patch_hub_core_test.sh
+++ b/tests/ui/patch_hub/patch_hub_core_test.sh
@@ -26,7 +26,7 @@ function tearDown()
   }
 }
 
-function test_show_dashboard_check_valid_options()
+function test_show_dashboard()
 {
   # Mock Register list
   # shellcheck disable=SC2317
@@ -47,21 +47,6 @@ function test_show_dashboard_check_valid_options()
 
   show_dashboard
   assert_equals_helper 'Expected register screen' "$LINENO" "${screen_sequence['SHOW_SCREEN']}" 'bookmarked_patches'
-}
-
-function test_show_dashboard_check_failed()
-{
-  local output
-
-  # Mock failed scenario
-  # shellcheck disable=SC2317
-  function create_menu_options()
-  {
-    return 22
-  }
-
-  output=$(show_dashboard)
-  assert_equals_helper 'Expected failure' "$LINENO" "$?" 22
 }
 
 function test_list_patches_with_patches()

--- a/tests/ui/patch_hub/patch_hub_core_test.sh
+++ b/tests/ui/patch_hub/patch_hub_core_test.sh
@@ -26,7 +26,7 @@ function tearDown()
   }
 }
 
-function test_dashboard_entry_menu_check_valid_options()
+function test_show_dashboard_check_valid_options()
 {
   # Mock Register list
   # shellcheck disable=SC2317
@@ -35,7 +35,7 @@ function test_dashboard_entry_menu_check_valid_options()
     menu_return_string=0
   }
 
-  dashboard_entry_menu
+  show_dashboard
   assert_equals_helper 'Expected register screen' "$LINENO" "${screen_sequence['SHOW_SCREEN']}" 'registered_mailing_lists'
 
   # Mock bookmarked
@@ -45,11 +45,11 @@ function test_dashboard_entry_menu_check_valid_options()
     menu_return_string=1
   }
 
-  dashboard_entry_menu
+  show_dashboard
   assert_equals_helper 'Expected register screen' "$LINENO" "${screen_sequence['SHOW_SCREEN']}" 'bookmarked_patches'
 }
 
-function test_dashboard_entry_menu_check_failed()
+function test_show_dashboard_check_failed()
 {
   local output
 
@@ -60,7 +60,7 @@ function test_dashboard_entry_menu_check_failed()
     return 22
   }
 
-  output=$(dashboard_entry_menu)
+  output=$(show_dashboard)
   assert_equals_helper 'Expected failure' "$LINENO" "$?" 22
 }
 


### PR DESCRIPTION
The function `dashboard_entry_menu` was one of the first functions that handles a state in the FSM, and it is outdated, as the function name does not follow the pattern of `show_<name_of_state>`, and prints a message in the standard output that won't be displayed to the user.

This PR introduces two commits to address both issues.