### PR TITLE
src: lib: lore: Change /tmp/ to /dev/shm dir

### DIFF
--- a/src/lib/kwlib.sh
+++ b/src/lib/kwlib.sh
@@ -4,6 +4,7 @@ include "${KW_LIB_DIR}/lib/kw_db.sh"
 include "${KW_LIB_DIR}/lib/kw_time_and_date.sh"
 
 ENV_DIR='envs'
+KW_SHARED_MEMORY_DEFAULT_DIR='/dev/shm'
 
 # Array with compression programs accepted by tar
 declare -ga compression_programs=('gzip' 'bzip2' 'lzip' 'lzma' 'lzop' 'zstd'
@@ -124,6 +125,24 @@ function show_verbose()
   local cmd="$2"
 
   [[ "$flag" == 'VERBOSE' ]] && say "$cmd"
+}
+
+# This function create the shared memory directory, if
+# @KW_SHARED_MEMORY_DEFAULT_DIR is not available, create it on '/tmp/' instead
+#
+# @KW_SHARED_MEMORY_DEFAULT_DIR is a global variable that sets the target
+# '/dev/shm' directory
+#
+# Returns:
+# Returns the path for the new directory
+function create_shared_memory_dir()
+{
+  if [[ -d "$KW_SHARED_MEMORY_DEFAULT_DIR" && -w "$KW_SHARED_MEMORY_DEFAULT_DIR" ]]; then
+    printf '%s' "$(mktemp --tmpdir="$KW_SHARED_MEMORY_DEFAULT_DIR" --directory)"
+    return
+  fi
+
+  printf '%s' "$(mktemp --directory)"
 }
 
 # Checks if a directory is a kernel tree root

--- a/src/lib/lore.sh
+++ b/src/lib/lore.sh
@@ -433,7 +433,8 @@ function process_patchsets()
   local pids
   local i
 
-  shared_dir_for_parallelism=$(mktemp --directory)
+  shared_dir_for_parallelism=$(create_shared_memory_dir)
+
   starting_index="$PATCHSETS_PROCESSED"
   count=0
   i=0

--- a/tests/unit/lib/kwlib_test.sh
+++ b/tests/unit/lib/kwlib_test.sh
@@ -95,6 +95,22 @@ function teardownGitRepository()
   fi
 }
 
+function setupKwSharedMemoryDefaultDir()
+{
+  KW_SHARED_MEMORY_DEFAULT_DIR="${SHUNIT_TMPDIR}/test/tmp_dir"
+  mkdir --parents "$KW_SHARED_MEMORY_DEFAULT_DIR"
+}
+
+function teardownSharedMemoryDefaultDir()
+{
+  is_safe_path_to_remove "$KW_SHARED_MEMORY_DEFAULT_DIR"
+  if [[ "$?" == 0 ]]; then
+    rm --recursive "$KW_SHARED_MEMORY_DEFAULT_DIR"
+  else
+    fail 'It was not possible to remove TMP_DIR in the specified directory'
+  fi
+}
+
 function test_is_kernel_root()
 {
   is_kernel_root "$SHUNIT_TMPDIR"
@@ -963,6 +979,28 @@ function test_show_verbose()
 
   output=$(show_verbose 'VERBOSE' "$cmd")
   assert_equals_helper 'Expected value of command' "$LINENO" "$cmd" "$output"
+}
+
+function test_check_if_create_shared_memory_dir_creates_dir_in_kw_shared_memory_default_dir()
+{
+  local output
+
+  setupKwSharedMemoryDefaultDir
+
+  output=$(create_shared_memory_dir)
+  assertTrue "${LINENO}: Did not create directory at ${output}" "[[ -d ${output} ]]"
+  assertTrue "${LINENO}: Did not create directory at KW_SHARED_MEMORY_DEFAULT_DIR" '[[ $output =~ $KW_SHARED_MEMORY_DEFAULT_DIR ]]'
+
+  teardownSharedMemoryDefaultDir
+}
+
+function test_check_if_create_shared_memory_dir_creates_dir_in_default_mktemp_dir()
+{
+  local output
+
+  output=$(create_shared_memory_dir)
+  assertTrue "${LINENO}: Did not create directory at ${output}" "[[ -d ${output} ]]"
+  assertTrue "${LINENO}: Did not create directory at /tmp/ dir" '[[ $output =~ /tmp/ ]]'
 }
 
 invoke_shunit


### PR DESCRIPTION
To enable parallel processing of the patches, kw used the slower option, /tmp/ directory, instead of /dev/shm/ directory.

 In this case, to speed up the process, change the directory to /dev/shm.

This PR resolves #902 