### PR TITLE
kw: show notice message if kw runs in developer mode

### DIFF
--- a/kw
+++ b/kw
@@ -36,11 +36,13 @@ KW_STATE_DIR="${XDG_STATE_HOME:-"${HOME}/.local/state"}/${KWORKFLOW}"
 # ENV dir name
 ENV_DIR='envs'
 
-##BEGIN-DEV-MODE##
+##BEGIN-REPO-MODE##
 KW_BIN="$(readlink -f "${BASH_SOURCE[0]}")"
 KW_BASE_DIR="$(dirname "${KW_BIN}")"
+KW_REPO_MODE='n'
 if [ -f "${KW_BASE_DIR}/src/lib/kwlib.sh" ]; then
   # running from source directory
+  KW_REPO_MODE='y'
   KW_LIB_DIR="${KW_BASE_DIR}/src"
   # KW_DATA_DIR # use default data folder
   KW_DOC_DIR="${KW_BASE_DIR}/documentation"
@@ -51,7 +53,7 @@ if [ -f "${KW_BASE_DIR}/src/lib/kwlib.sh" ]; then
   KW_PLUGINS_DIR="${KW_LIB_DIR}/plugins"
   # KW_CACHE_DIR # use default cache folder
 fi
-##END-DEV-MODE##
+##END-REPO-MODE##
 
 # Export external variables required by kworkflow
 export KWORKFLOW
@@ -63,6 +65,25 @@ export KWORKFLOW
 . "${KW_LIB_DIR}/lib/kw_include.sh" --source-only
 
 include "${KW_LIB_DIR}/lib/signal_manager.sh"
+
+# print a notice message if on REPO mode
+if [[ "${KW_REPO_MODE}" == 'y' ]]; then
+  repo_mode_msg=''
+  repo_mode_msg+="${SEPARATOR}"$'\n'
+  repo_mode_msg+='[INFO]: Running kw in developer mode.'$'\n'$'\n'
+  repo_mode_msg+='KW environment variables are set to the following:'$'\n'$'\n'
+  repo_mode_msg+=$'\t'"KW_CACHE_DIR=${KW_CACHE_DIR}"$'\n'
+  repo_mode_msg+=$'\t'"KW_DATA_DIR=${KW_DATA_DIR}"$'\n'
+  repo_mode_msg+=$'\t'"KW_DB_DIR=${KW_DB_DIR}"$'\n'
+  repo_mode_msg+=$'\t'"KW_DOC_DIR=${KW_DOC_DIR}"$'\n'
+  repo_mode_msg+=$'\t'"KW_ETC_DIR=${KW_ETC_DIR}"$'\n'
+  repo_mode_msg+=$'\t'"KW_LIB_DIR=${KW_LIB_DIR}"$'\n'
+  repo_mode_msg+=$'\t'"KW_MAN_DIR=${KW_MAN_DIR}"$'\n'
+  repo_mode_msg+=$'\t'"KW_PLUGINS_DIR=${KW_PLUGINS_DIR}"$'\n'
+  repo_mode_msg+=$'\t'"KW_SOUND_DIR=${KW_SOUND_DIR}"$'\n'$'\n'
+  repo_mode_msg+="${SEPARATOR}"
+  say "${repo_mode_msg}"
+fi
 
 function kw()
 {


### PR DESCRIPTION
When kw runs in developer mode, some env vars are changed to point the cache/data/db/doc/etc/lib/man directories to the repository in which the kw script is at.

This can cause confusion to developers, which may expect some files (such as database files, manual pages, plugin files) to be somewhere else and may think kw has a bug (due to devmode) when it doesn't.

This PR basically shows a notice message to inform the developer that kw is running in developer mode and some envvars have been changed. The message is sent to stderror to prevent failing tests (because it would disrupt the output expected to the commands).

OBS: I made this commit because I myself ran into problems due to the variables being changed without my awareness.

Closes https://github.com/kworkflow/kworkflow/issues/956