### PR TITLE
src: help: Add system-wide paths

### DIFF
--- a/kw
+++ b/kw
@@ -4,14 +4,10 @@ KWORKFLOW=${KWORKFLOW:-'kw'}
 
 # Global paths
 
-# Kw shell files
-if [[ -f '/usr/bin/kw' ]]; then
-  KW_LIB_DIR='/usr/share/kw'
-else
-  KW_LIB_DIR="${KW_LIB_DIR:-"${HOME}/.local/lib"}/${KWORKFLOW}"
-fi
-
-KW_PLUGINS_DIR="${KW_PLUGINS_DIR:-"${KW_LIB_DIR}/plugins"}"
+# If kw gets installed in the system instead of the user's home, the main
+# binary will be available at /usr/bin. Let's use it to update the global
+# paths.
+KW_SYSTEM_WIDE_INSTALLATION='/usr/bin/kw'
 
 # Share files
 KW_SHARE_DIR="${XDG_DATA_HOME:-"${HOME}/.local/share"}/${KWORKFLOW}"
@@ -20,12 +16,25 @@ KW_MAN_DIR="${KW_SHARE_DIR}/man"
 KW_SOUND_DIR="${KW_SHARE_DIR}/sound"
 KW_DB_DIR="${KW_SHARE_DIR}/database"
 
+# Configuration files
+KW_ETC_DIR="${XDG_CONFIG_HOME:-"${HOME}/.config"}/${KWORKFLOW}"
+
+# Set system-wide path
+if [[ -f "$KW_SYSTEM_WIDE_INSTALLATION" ]]; then
+  KW_LIB_DIR='/usr/share/kw'
+  KW_SOUND_DIR='/usr/share/sounds/kw'
+  KW_DOC_DIR='/usr/share/doc/kw/html/'
+  KW_SOUND_DIR='/usr/share/sounds/kw'
+  KW_ETC_DIR='/etc/kw'
+else
+  KW_LIB_DIR="${KW_LIB_DIR:-"${HOME}/.local/lib"}/${KWORKFLOW}"
+fi
+
+KW_PLUGINS_DIR="${KW_PLUGINS_DIR:-"${KW_LIB_DIR}/plugins"}"
+
 # User specific data files (currently this collapses with the share dir,
 # but would not for a system-wide installation)
 KW_DATA_DIR="${XDG_DATA_HOME:-"${HOME}/.local/share"}/${KWORKFLOW}"
-
-# Configuration files
-KW_ETC_DIR="${XDG_CONFIG_HOME:-"${HOME}/.config"}/${KWORKFLOW}"
 
 # Cache folder
 KW_CACHE_DIR="${XDG_CACHE_HOME:-"${HOME}/.cache"}/${KWORKFLOW}"

--- a/src/help.sh
+++ b/src/help.sh
@@ -54,6 +54,11 @@ function kworkflow_man()
     feature="kw-${feature}"
   fi
 
+  if [[ -f "$KW_SYSTEM_WIDE_INSTALLATION" ]]; then
+    cmd_manager "$flag" "man ${feature}"
+    exit "$?"
+  fi
+
   if [[ -r "$doc/$feature.1" ]]; then
     cmd_manager "$flag" "man -l $doc/$feature.1"
     exit "$?"


### PR DESCRIPTION
While testing some of the kw package features, I noticed some features behave differently than expected due to wrong paths. This commit updates kw to use the correct paths if it is installed system-wide.