### PR TITLE
Enhance 'kw config' command to distinguish global and local sources

### DIFF
--- a/src/config.sh
+++ b/src/config.sh
@@ -222,7 +222,7 @@ function parse_config_options()
   fi
 
   # Default values
-  options_values['SCOPE']='local'
+  options_values['SCOPE']=''
   options_values['PARAMETERS']=''
   options_values['IS_SHOW_CONFIGURATIONS']=''
   options_values['VERBOSE']=''
@@ -294,7 +294,6 @@ function show_configurations()
     read -ra configs <<< "${!config_file_list[@]}"
   fi
 
-  # For each config file
   for config in "${configs[@]}"; do
     # Check if it is a valid config
     if ! is_config_file_valid "$config"; then
@@ -305,23 +304,55 @@ function show_configurations()
     # Load corresponding config file
     eval "load_${config}_config"
 
-    # This part is heavily depedent of the names defined in kw_config_loader
     if [[ "$config" == 'kworkflow' ]]; then
-      declare -n config_array='configurations'
+      declare -n config_array_local="configurations_local"
+      declare -n config_array_global="configurations_global"
     else
-      declare -n config_array="${config}_config"
+      declare -n config_array_local="${config}_config_local"
+      declare -n config_array_global="${config}_config_global"
     fi
 
-    # For each possible option in a config file
     options_buffer=$(printf '%s' "${config_file_list[$config]}" | sed --null-data 's/\n/ /g')
     read -ra options <<< "${options_buffer}"
     for option in "${options[@]}"; do
-      value="${config_array[$option]}"
-      if [[ -z "$value" ]]; then
-        warning "${config}.${option}=N/A"
-      else
-        printf '%s\n' "${config}.${option}=${value}"
+
+      # if user specified global or local scope, we won't append scope prefixes
+      if [[ -n "${options_values['SCOPE']}" ]]; then
+        if [[ "${options_values['SCOPE']}" == 'local' ]]; then
+          value="${config_array_local[$option]}"
+        elif [[ "${options_values['SCOPE']}" == 'global' ]]; then
+          value="${config_array_global[$option]}"
+        fi
+
+        if [[ -n "$value" ]]; then
+          # value is defined globally or locally
+          printf '%s.%s=%s\n' "$config" "$option" "$value"
+        else
+          # undefined value
+          warning "${config}.${option}=N/A"
+        fi
+        continue
       fi
+
+      # Otherwise, we append an indicator prefix before the config.
+      # That way, the user knows if the config is defined locally or globally.
+
+      # config comes from local source
+      value="${config_array_local[$option]}"
+      if [[ -n "$value" ]]; then
+        printf '[LOCAL ] %s.%s=%s\n' "$config" "$option" "$value"
+        continue
+      fi
+
+      # config comes from global source
+      value="${config_array_global[$option]}"
+      if [[ -n "$value" ]]; then
+        printf '[GLOBAL] %s.%s=%s\n' "$config" "$option" "$value"
+        continue
+      fi
+
+      # config is undefined
+      warning "[      ] ${config}.${option}=N/A"
     done
   done
 

--- a/src/lib/kw_config_loader.sh
+++ b/src/lib/kw_config_loader.sh
@@ -20,24 +20,38 @@ TARGET="$VM_TARGET"
 
 # Default configuration
 declare -gA configurations
+declare -gA configurations_global
+declare -gA configurations_local
 
 # Build configuration
 declare -gA build_config
+declare -gA build_config_global
+declare -gA build_config_local
 
 # Deploy configuration
 declare -gA deploy_config
+declare -gA deploy_config_global
+declare -gA deploy_config_local
 
 # VM configuration
 declare -gA vm_config
+declare -gA vm_config_global
+declare -gA vm_config_local
 
 # Mail configuration
 declare -gA mail_config
+declare -gA mail_config_global
+declare -gA mail_config_local
 
 # Notification configuration
 declare -gA notification_config
+declare -gA notification_config_global
+declare -gA notification_config_local
 
 # Notification configuration
 declare -gA lore_config
+declare -gA lore_config_global
+declare -gA lore_config_local
 
 # Default target option from kworkflow.config
 declare -gA deploy_target_opt=(['local']=2 ['remote']=3)
@@ -338,6 +352,7 @@ function parse_configuration()
 {
   local config_path="$1"
   local config_array="${2:-configurations}"
+  local config_array_scope="$3"
   local value
 
   if [ ! -f "$config_path" ]; then
@@ -354,6 +369,9 @@ function parse_configuration()
       value="$(sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' <<< "$value")"
 
       eval "${config_array}"'["$varname"]="$value"'
+      if [[ -n "${config_array_scope}" ]]; then
+        eval "${config_array_scope}"'["$varname"]="$value"'
+      fi
     fi
   done < "$config_path"
 }
@@ -366,6 +384,8 @@ function load_configuration()
   local target_config="$1"
   local target_config_file
   local target_array='configurations'
+  local target_array_global=''
+  local target_array_local=''
   local -a config_dirs
   local config_dirs_size
   local IFS=:
@@ -393,8 +413,11 @@ function load_configuration()
       ;;
   esac
 
+  target_array_global="${target_array}_global"
+  target_array_local="${target_array}_local"
+
   target_config_file="${target_config}.config"
-  parse_configuration "${KW_ETC_DIR}/${target_config_file}" "$target_array"
+  parse_configuration "${KW_ETC_DIR}/${target_config_file}" "$target_array" "$target_array_global"
 
   # XDG_CONFIG_DIRS is a colon-separated list of directories for config
   # files to be searched, in order of preference. Since this function
@@ -405,10 +428,10 @@ function load_configuration()
   # /etc/xdg.
   config_dirs_size="${#config_dirs[@]}"
   for ((i = config_dirs_size - 1; i >= 0; i--)); do
-    parse_configuration "${config_dirs["$i"]}/${KWORKFLOW}/${target_config_file}" "$target_array"
+    parse_configuration "${config_dirs["$i"]}/${KWORKFLOW}/${target_config_file}" "$target_array" "$target_array_global"
   done
 
-  parse_configuration "${XDG_CONFIG_HOME:-"${HOME}/.config"}/${KWORKFLOW}/${target_config_file}" "$target_array"
+  parse_configuration "${XDG_CONFIG_HOME:-"${HOME}/.config"}/${KWORKFLOW}/${target_config_file}" "$target_array" "$target_array_global"
 
   # Old users may have kworkflow.config at $PWD
   if [[ -f "$PWD/$CONFIG_FILENAME" ]]; then
@@ -418,12 +441,12 @@ function load_configuration()
       mkdir -p "$PWD/$KW_DIR/"
       mv "$PWD/$CONFIG_FILENAME" "$PWD/$KW_DIR/$CONFIG_FILENAME"
     else
-      parse_configuration "${PWD}/${CONFIG_FILENAME}" "$target_array"
+      parse_configuration "${PWD}/${CONFIG_FILENAME}" "$target_array" "$target_array_local"
     fi
   fi
 
   if [[ -f "${PWD}/${KW_DIR}/${target_config_file}" ]]; then
-    parse_configuration "${PWD}/${KW_DIR}/${target_config_file}" "$target_array"
+    parse_configuration "${PWD}/${KW_DIR}/${target_config_file}" "$target_array" "$target_array_local"
   fi
 }
 

--- a/tests/unit/config_test.sh
+++ b/tests/unit/config_test.sh
@@ -36,6 +36,13 @@ function tearDown()
   rm -rf "${KW_CONFIG_BASE_PATH}"
 }
 
+# Show configurations WITHOUT the prefixes [GLOBAL]/[LOCAL].
+# The tests do not expect the output to have source indicators prefixes.
+function show_raw_configurations()
+{
+  show_configurations "$@" | sed 's;\[[A-Z ]\+\] ;;'
+}
+
 function test_is_config_file_valid()
 {
   is_config_file_valid 'invalid'
@@ -161,8 +168,8 @@ function test_parse_config_options()
 
   reset_options_values
   parse_config_options
-  assert_equals_helper 'Expected local as a default scope' \
-    "($LINENO)" 'local' "${options_values['SCOPE']}"
+  assert_equals_helper 'Expected empty string as a default scope' \
+    "($LINENO)" '' "${options_values['SCOPE']}"
 
   # test default options
   reset_options_values
@@ -200,7 +207,7 @@ function test_show_configurations_without_parameters()
     return
   }
 
-  output=$(show_configurations)
+  output=$(show_raw_configurations)
 
   assert_line_match "$LINENO" 'vm.virtualizer=libvirt' "$output"
   assert_line_match "$LINENO" 'vm.mount_point=/home/lala' "$output"
@@ -258,7 +265,7 @@ function test_show_configurations_with_parameters()
     return
   }
 
-  output=$(show_configurations 'vm notification')
+  output=$(show_raw_configurations 'vm notification')
 
   assert_line_match "$LINENO" 'vm.virtualizer=libvirt' "$output"
   assert_line_match "$LINENO" 'vm.mount_point=/home/lala' "$output"


### PR DESCRIPTION
Closes #894.

Here is a sample output:

```
$ kw config --show               
[GLOBAL]
vm.virtualizer=N/A
vm.mount_point=N/A
...
build.arch=x86_64
...
deploy.strip_modules_debug_option=yes
deploy.default_deploy_target=remote
...
mail.send_opts=--annotate --cover-letter --no-chain-reply-to --thread
mail.blocked_emails=linux-kernel@vger.kernel.org
...
[LOCAL]
vm.virtualizer=N/A
vm.mount_point=N/A
vm.qemu_hw_options=N/A
...
build.doc_type=N/A
build.cpu_scaling_factor=75
...
deploy.reboot_after_deploy=n
deploy.strip_modules_debug_option=N/A
...
mail.default_cc_recipients=N/A

$ kw config --show build    
[GLOBAL]
build.arch=x86_64
build.kernel_img_name=bzImage
build.cross_compile=N/A
build.menu_config=nconfig
build.doc_type=htmldocs
build.cpu_scaling_factor=100
...
[LOCAL]
build.arch=N/A
build.kernel_img_name=N/A
...
build.cpu_scaling_factor=75
...

$ kw config --show --local build
build.arch=N/A
build.kernel_img_name=N/A
...
build.cpu_scaling_factor=75
...

$ kw config --show --global build 
build.arch=x86_64
build.kernel_img_name=bzImage
build.cross_compile=N/A
build.menu_config=nconfig
build.doc_type=htmldocs
build.cpu_scaling_factor=100
...
```

Of course, `...` means supressed output.