### PR TITLE
Remove duplicated config entries

### DIFF
--- a/src/config.sh
+++ b/src/config.sh
@@ -12,8 +12,7 @@ declare -gA config_file_list=(
   ['mail']='send_opts blocked_emails default_to_recipients default_cc_recipients'
   ['deploy']='kw_files_remote_path deploy_temporary_files_path
               deploy_default_compression dtb_copy_pattern default_deploy_target
-              reboot_after_deploy strip_modules_debug_option
-              default_deploy_target reboot_after_deploy'
+              reboot_after_deploy strip_modules_debug_option'
   ['notification']='alert sound_alert_command visual_alert_command'
   ['kworkflow']='ssh_user ssh_ip ssh_port ssh_configfile hostname
                  disable_statistics_data_track gui_on gui_off send_opts


### PR DESCRIPTION
Very basic stuff: just remove duplicated entries in config array.



Though trivial, I think it is more relevant than it seems: while I was working on some features for the config module, there were several times while I saw duplicated lines in `config`'s output, leading me to think I had introduced some sort of bug and wasting time trying to find it. Hopefully, other devs won't be fooled by it.