### PR TITLE
src: help.sh: show correct version on repo mode

### DIFF
--- a/kw
+++ b/kw
@@ -91,7 +91,12 @@ if [[ "${KW_REPO_MODE}" == 'y' ]]; then
   repo_mode_msg+=$'\t'"KW_PLUGINS_DIR=${KW_PLUGINS_DIR}"$'\n'
   repo_mode_msg+=$'\t'"KW_SOUND_DIR=${KW_SOUND_DIR}"$'\n'$'\n'
   repo_mode_msg+="${SEPARATOR}"
-  say "${repo_mode_msg}"
+
+  # Message is redirected to stderr such that it can be easily ignored if needed.
+  # Otherwise, it could mess up the output expected by  integration  tests  which
+  # are runnning kw in repo-mode and the tests would fail (we may eventually want
+  # such tests because in repo-mode we can execute kw without installing it).
+  say "${repo_mode_msg}" >&2
 fi
 
 function kw()

--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,7 @@ KW_LIB_DIR='src'
 include "${KW_LIB_DIR}/lib/kwio.sh"
 include "${KW_LIB_DIR}/lib/kwlib.sh"
 include "${KW_LIB_DIR}/lib/kw_db.sh"
+include "${KW_LIB_DIR}/help.sh"
 
 SILENT=1
 VERBOSE=0
@@ -487,19 +488,7 @@ function safe_remove()
 
 function update_version()
 {
-  local head_hash
-  local branch_name
-  local base_version
-
-  head_hash=$(git rev-parse --short HEAD)
-  branch_name=$(git rev-parse --short --abbrev-ref HEAD)
-  base_version=$(head -n 1 "$libdir/VERSION")
-
-  cat > "$libdir/VERSION" << EOF
-$base_version
-Branch: $branch_name
-Commit: $head_hash
-EOF
+  kworkflow_version_from_repo > "${libdir}/VERSION"
 }
 
 function install_home()

--- a/src/help.sh
+++ b/src/help.sh
@@ -68,9 +68,30 @@ function kworkflow_man()
   exit 2 # ENOENT
 }
 
+function kworkflow_version_from_repo()
+{
+  local head_hash
+  local branch_name
+  local base_version
+  local git_dir
+
+  # get version info from the git repo
+  git_dir=$(realpath "${KW_LIB_DIR}/../.git")
+  head_hash=$(git -C "${git_dir}" rev-parse --short HEAD)
+  branch_name=$(git -C "${git_dir}" rev-parse --short --abbrev-ref HEAD)
+  base_version=$(head --lines 1 "${KW_LIB_DIR}/VERSION")
+
+  printf '%s\nBranch: %s\nCommit: %s\n' "${base_version}" "${branch_name}" "${head_hash}"
+}
+
 function kworkflow_version()
 {
-  local version_path="$KW_LIB_DIR/VERSION"
+  local version_path="${KW_LIB_DIR}/VERSION"
 
-  cat "$version_path"
+  if [[ "${KW_REPO_MODE}" == 'y' ]]; then
+    kworkflow_version_from_repo
+    return
+  fi
+
+  printf '%s' "$(< "$version_path")"
 }

--- a/tests/unit/help_test.sh
+++ b/tests/unit/help_test.sh
@@ -32,6 +32,25 @@ function test_kworkflow_man()
   assertEquals "($LINENO) We expected an error message." "$expect" "$output"
 }
 
+function test_kworkflow_version()
+{
+  local KW_LIB_DIR
+  local output
+  local expected_output
+
+  # the mocked version for KW
+  expected_output=$(printf 'beta\nBranch: bazz\nCommit: ffddee\n')
+
+  # this value mocks a fake location for the version file, which is the file used
+  # by KW to get information about the current version.
+  KW_LIB_DIR="${SHUNIT_TMPDIR}"
+  printf '%s' "${expected_output}" > "${KW_LIB_DIR}/VERSION"
+
+  # check output
+  output=$(kworkflow_version)
+  assert_equals_helper "Got wrong kw version." "$LINE" "${expected_output}" "${output}"
+}
+
 function test_kworkflow_version_in_repomode()
 {
   local branch_name

--- a/tests/unit/help_test.sh
+++ b/tests/unit/help_test.sh
@@ -32,4 +32,57 @@ function test_kworkflow_man()
   assertEquals "($LINENO) We expected an error message." "$expect" "$output"
 }
 
+function test_kworkflow_version_in_repomode()
+{
+  local branch_name
+  local head_hash
+  local version_name
+  local output
+  local original_path
+  local path_to_git_repository
+  local KW_REPO_MODE
+  local KW_LIB_DIR
+
+  # Initialize variables.
+  original_path="$PWD"
+  version_name='omega'
+  branch_name='foo'
+  path_to_git_repository="${SHUNIT_TMPDIR}/git_repo"
+  KW_LIB_DIR="${path_to_git_repository}/src"
+
+  # shellcheck disable=SC2034
+  KW_REPO_MODE='y' # used to trigger repo-mode behavior
+
+  # create the git repository
+  mkdir --parents "${path_to_git_repository}" "${KW_LIB_DIR}"
+
+  # cd into the repo, so we can run git commands there.
+  # This is necessary because our helper `mk_fake_git` assumes the current
+  # working directory is the directory in which we want to run git commands.
+  cd "${path_to_git_repository}" || fail 'Failed to switch to git dir.'
+
+  # print kw's version name
+  printf '%s' "${version_name}" > "${KW_LIB_DIR}/VERSION"
+
+  # Make fake git commits from the created branch.
+  mk_fake_git
+
+  # Create and switch to a new branch
+  git switch --quiet --create "${branch_name}"
+
+  # Get commit hash.
+  head_hash=$(git rev-parse --short HEAD)
+
+  # Get kw version.
+  output=$(kworkflow_version)
+
+  # Compare results.
+  assert_substring_match "Wrong version name" "(${LINENO})" "${version_name}" "${output}"
+  assert_substring_match "Wrong commit" "(${LINENO})" "Commit: ${head_hash}" "${output}"
+  assert_substring_match "Wrong branch" "(${LINENO})" "Branch: ${branch_name}" "${output}"
+
+  # Go back to previous dir.
+  cd "$original_path" || fail 'Failed to switch back to original directory.'
+}
+
 invoke_shunit


### PR DESCRIPTION
When running on repo-mode, KW  did  not  show  up  the  correct  version because it was simply running `cat` on a  file.  This  works  in  normal installations because the `kw` installed version is copied to  a  static file during the installation. In repo-mode such information is  dynamic, not static. In this case, it is necessary to run other commands.

Closes #986