### PR TITLE
Add option to install KW systemwide

### DIFF
--- a/kw
+++ b/kw
@@ -23,8 +23,8 @@ KW_ETC_DIR="${XDG_CONFIG_HOME:-"${HOME}/.config"}/${KWORKFLOW}"
 if [[ -f "$KW_SYSTEM_WIDE_INSTALLATION" ]]; then
   KW_LIB_DIR='/usr/share/kw'
   KW_SOUND_DIR='/usr/share/sounds/kw'
-  KW_DOC_DIR='/usr/share/doc/kw/html/'
-  KW_SOUND_DIR='/usr/share/sounds/kw'
+  KW_DOC_DIR='/usr/share/doc/kw/html'
+  KW_MAN_DIR='/usr/share/man/man1'
   KW_ETC_DIR='/etc/kw'
 else
   KW_LIB_DIR="${KW_LIB_DIR:-"${HOME}/.local/lib"}/${KWORKFLOW}"

--- a/setup.sh
+++ b/setup.sh
@@ -522,8 +522,23 @@ function use_system_wide_installation_directories()
   ETCDIR="/etc/${app_name}"
 }
 
+# Ask for confirmation if KW seems to be already installed.
+function confirm_reinstallation()
+{
+  if [[ -x "${KWBINPATH}" && "${FORCE}" == 0 ]]; then
+    warning 'KW seems to be already installed!'
+    if [[ $(ask_yN 'Do you want to proceed anyway?') =~ '0' ]]; then
+      info 'Aborting kw installation...'
+      exit 0
+    fi
+  fi
+}
+
 function install_kw()
 {
+  # confirm before attempting to reinstall if that is the case.
+  confirm_reinstallation
+
   # Check Dependencies
   if [[ "$SKIPCHECKS" == 0 ]]; then
     say 'Checking dependencies ...'

--- a/src/help.sh
+++ b/src/help.sh
@@ -54,17 +54,17 @@ function kworkflow_man()
     feature="kw-${feature}"
   fi
 
+  if [[ -r "${doc}/${feature}.1" ]]; then
+    cmd_manager "$flag" "man -l ${doc}/${feature}.1"
+    exit "$?"
+  fi
+
   if [[ -f "$KW_SYSTEM_WIDE_INSTALLATION" ]]; then
     cmd_manager "$flag" "man ${feature}"
     exit "$?"
   fi
 
-  if [[ -r "$doc/$feature.1" ]]; then
-    cmd_manager "$flag" "man -l $doc/$feature.1"
-    exit "$?"
-  fi
-
-  complain "Couldn't find the man page for $feature!"
+  complain "Couldn't find the man page for ${feature}!"
   exit 2 # ENOENT
 }
 


### PR DESCRIPTION
Add `--system` flag in `setup.sh` for systemwide installation.

This enhancement brings the following benefits:

1. System wide installation allows several users to run kw.
2. System wide installation does not require modifying PATH, such as in .bashrc.
3. It can be useful when testing because some testing environments (such as docker or podman containers) do NOT have $HOME/.local/bin in their $PATH and do NOT read .bashrc files by default, which requires manually changing PATH.

Closes #985