### PR TITLE
src: deploy: fix preparation of remote directory

### DIFF
--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -574,6 +574,8 @@ function prepare_remote_dir()
     cmd_manager "$flag" "$cmd"
   fi
 
+  # Removes temporary directory if already existent
+  cmd_remotely "rm --preserve-root=all --recursive --force -- $KW_DEPLOY_TMP_FILE" "$flag"
   # Create temporary folder
   cmd_remotely "mkdir -p $KW_DEPLOY_TMP_FILE" "$flag"
 }

--- a/tests/unit/deploy_test.sh
+++ b/tests/unit/deploy_test.sh
@@ -889,6 +889,7 @@ function test_prepare_remote_dir()
   # Test 1: Normal remote prepare
   declare -a expected_cmd=(
     "$debian_sync_files_cmd"
+    "$CONFIG_SSH $CONFIG_REMOTE sudo \"rm --preserve-root=all --recursive --force -- $KW_DEPLOY_TMP_FILE\""
     "$CONFIG_SSH $CONFIG_REMOTE sudo \"mkdir -p $KW_DEPLOY_TMP_FILE\""
   )
 
@@ -901,6 +902,7 @@ function test_prepare_remote_dir()
   arch_sync_files_cmd="$rsync_quiet $scripts_path/$to_copy $CONFIG_REMOTE:$REMOTE_KW_DEPLOY $STD_RSYNC_FLAG --archive"
   declare -a expected_cmd=(
     "$arch_sync_files_cmd"
+    "$CONFIG_SSH $CONFIG_REMOTE sudo \"rm --preserve-root=all --recursive --force -- $KW_DEPLOY_TMP_FILE\""
     "$CONFIG_SSH $CONFIG_REMOTE sudo \"mkdir -p $KW_DEPLOY_TMP_FILE\""
     "$CONFIG_RSYNC $KW_ETC_DIR/template_mkinitcpio.preset $CONFIG_REMOTE:$REMOTE_KW_DEPLOY $STD_RSYNC_FLAG"
   )
@@ -919,6 +921,7 @@ function test_prepare_remote_dir()
     "$UPDATE_KW_REMOTE_MSG"
     "$CONFIG_SSH $CONFIG_REMOTE sudo \"mkdir -p $REMOTE_KW_DEPLOY\""
     "scp -q $scripts_path/$to_copy $CONFIG_REMOTE:$REMOTE_KW_DEPLOY"
+    "$CONFIG_SSH $CONFIG_REMOTE sudo \"rm --preserve-root=all --recursive --force -- $KW_DEPLOY_TMP_FILE\""
     "$CONFIG_SSH $CONFIG_REMOTE sudo \"mkdir -p $KW_DEPLOY_TMP_FILE\""
   )
 


### PR DESCRIPTION
If the temporary directory already existed, it would not be cleaned up. This could cause issues if multiples deploys were made without rebooting the target. In this context, the code now removes the temporary directory and creates it again.

Fixes kworkflow/kworkflow#990.
