### PR TITLE
src: kw_remote.sh: Remove dashes from `kw remote --list` command

### DIFF
--- a/documentation/man/features/remote.rst
+++ b/documentation/man/features/remote.rst
@@ -8,9 +8,9 @@ SYNOPSIS
 ========
 | *kw remote* [-v | \--verbose]
 | *kw remote* [--global] add <name> <user>@<remote>[:<port>]
+| *kw remote* [--global] list
 | *kw remote* [--global] remove <name>
 | *kw remote* [--global] rename <old-name> <new-name>
-| *kw remote* [--global] \--list
 | *kw remote* [--global] (-s | \--set-default)=<name>
 
 DESCRIPTION
@@ -27,15 +27,15 @@ add <name> <remote-address>:
   `remote` can be an IP or a name server and `:<port>` is optional (default port
   is 22).
 
+list:
+  List all available remotes.
+
 remove <name>:
   Remove the remote named <name>.
 
 rename <old-name> <new-name>:
   Rename the remote named <old-name> to <new-name>. If you try a name already
   in use, kw will fail with a message.
-
-\--list:
-  List all available remotes.
 
 \--global:
   Force use global config file instead of the local one.
@@ -68,7 +68,7 @@ If you want to rename::
 
 You can also list all your available remotes via::
 
- kw remote --list
+  kw remote list
 
 If you want to set the default remote::
 

--- a/src/_kw
+++ b/src/_kw
@@ -420,14 +420,14 @@ _kw_remote()
 {
   local -a remote_commands=(
     'add:add a named remote to kw management'
+    'list:list all available remotes'
     'remove:remove an existing remote from kw management'
     'rename:rename an existing remote'
   )
 
   _arguments : \
     '(-v --verbose)'{-v,--verbose}'[be a little more verbose and show remote url after name]' \
-    '(-s --set-default)--list[list all available remotes]' \
-    '(-s --set-default --list)'{-s-,--set-default=-}'[set default remote to an existing one]: : ' \
+    '(-s --set-default)'{-s-,--set-default=-}'[set default remote to an existing one]: : ' \
 
   if [[ "$CURRENT" -lt 3 ]]; then
     _describe -t remote-commands 'remote command' remote_commands

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -50,7 +50,7 @@ function _kw_autocomplete()
 
   kw_options['config']='--local --global --show --help'
 
-  kw_options['remote']='add remove rename --list --global --set-default --verbose'
+  kw_options['remote']='add list remove rename --global --set-default --verbose'
 
   kw_options['explore']='--log --grep --all --only-header --only-source --exactly --verbose'
   kw_options['e']="${kw_options['explore']}"

--- a/src/kw_remote.sh
+++ b/src/kw_remote.sh
@@ -363,16 +363,16 @@ function parse_remote_options()
         options_values['ADD']=1
         shift
         ;;
+      list)
+        options_values['LIST']=1
+        shift
+        ;;
       remove)
         options_values['REMOVE']=1
         shift
         ;;
       rename)
         options_values['RENAME']=1
-        shift
-        ;;
-      --list)
-        options_values['LIST']=1
         shift
         ;;
       --global)
@@ -411,7 +411,7 @@ function parse_remote_options()
     -z "${options_values['RENAME']}" && -z "${options_values['LIST']}" &&
     -z "${options_values['DEFAULT_REMOTE']}" ]]; then
     options_values['ERROR']='"kw remote" should be proceeded by valid option'$'\n'
-    options_values['ERROR']+='Usage: kw remote (add | remove | rename | --list | --set-default) <params>[...]'
+    options_values['ERROR']+='Usage: kw remote (add | list | remove | rename | --set-default) <params>[...]'
     return 22 # EINVAL
   fi
 }
@@ -426,9 +426,9 @@ function remote_help()
   printf '%s\n' 'kw remote:' \
     '  remote - handle remote options' \
     '  remote add [--global] <name> <USER@IP:PORT> [--set-default] - Add new remote' \
+    '  remote list [--global] - List remotes' \
     '  remote remove [--global] <name> - Remove remote' \
     '  remote rename [--global] <old> <new> - Rename remote' \
     '  remote [--global] --set-default=<remonte-name> - Set default remote' \
-    '  remote [--global] --list - List remotes' \
     '  remote [--global] (--verbose | -v) - be verbose'
 }


### PR DESCRIPTION
The dashes inside the command `kw remote --list` are confusing since some of the others `kw remote` options don't require them. For example, there aren't dashes in `kw remote add`, `kw remote remove` and `kw remote rename`.

So, change `kw remote --list` command to `kw remote list` to make it more clear and intuitive.

Solves: #995