### PR TITLE
src: add shellbang to all bash scripts

### DIFF
--- a/src/backup.sh
+++ b/src/backup.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This file deals with backing up and restoring kw data files stored under the
 # the KW_DATA_DIR directory. These files are configs, pomodoro reports and
 # kw usage statistics.

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 function _kw_autocomplete()
 {
   declare -A kw_options

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/lib/kwlib.sh"
 include "${KW_LIB_DIR}/lib/kwio.sh"
 include "${KW_LIB_DIR}/lib/kw_config_loader.sh"

--- a/src/codestyle.sh
+++ b/src/codestyle.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Checkpatch is a useful tool provided by Linux, and the main goal of the code
 # in this file is to handle this script in a way to make this tool easier for
 # users.

--- a/src/config.sh
+++ b/src/config.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/lib/kwlib.sh"
 include "${KW_LIB_DIR}/lib/kwio.sh"
 

--- a/src/debug.sh
+++ b/src/debug.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Kw provides a set of mechanisms for making it easy to use some of the kernels
 # debug options such as events and ftrace. This file comprises a rich set of
 # functions to deal with this activity.

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # The `deploy.sh` file centralizes functions related to kernel installation.
 # With kworkflow, we want to handle three scenarios:

--- a/src/device_info.sh
+++ b/src/device_info.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This file deals with functions related to hardware information
 
 include "${KW_LIB_DIR}/lib/kw_string.sh"

--- a/src/diff.sh
+++ b/src/diff.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/lib/kwlib.sh"
 include "${KW_LIB_DIR}/lib/kwio.sh"
 

--- a/src/explore.sh
+++ b/src/explore.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This file is the core of the explore feature. The idea behind the explore
 # command it unifies the way that we search for things in the project, by
 # things, you can understand from files to messages in git log.

--- a/src/help.sh
+++ b/src/help.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/lib/kwio.sh"
 include "${KW_LIB_DIR}/lib/kwlib.sh"
 

--- a/src/init.sh
+++ b/src/init.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # The init.sh keep all the operations related to the `kworkflow.config`
 # initialization. The initialization feature it is inspired on `git init`.
 

--- a/src/kernel_config_manager.sh
+++ b/src/kernel_config_manager.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/lib/kwlib.sh"
 include "${KW_LIB_DIR}/lib/kwio.sh"
 include "${KW_LIB_DIR}/lib/kw_db.sh"

--- a/src/kw_env.sh
+++ b/src/kw_env.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/lib/kwlib.sh"
 include "${KW_LIB_DIR}/lib/kwio.sh"
 include "${KW_LIB_DIR}/lib/kw_string.sh"

--- a/src/kw_remote.sh
+++ b/src/kw_remote.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/lib/kwlib.sh"
 include "${KW_LIB_DIR}/lib/remote.sh"
 

--- a/src/kw_ssh.sh
+++ b/src/kw_ssh.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/lib/remote.sh"
 include "${KW_LIB_DIR}/lib/kwlib.sh"
 

--- a/src/lib/dialog_ui.sh
+++ b/src/lib/dialog_ui.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # In this file, you will find the implementation of multiple abstract functions
 # to build the interface between kw and lore. Notice that here we manage the
 # dialog tool.

--- a/src/lib/kw_config_loader.sh
+++ b/src/lib/kw_config_loader.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/lib/kwio.sh"
 include "${KW_LIB_DIR}/lib/kwlib.sh"
 

--- a/src/lib/kw_db.sh
+++ b/src/lib/kw_db.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This file handles the interactions with the kw database
 
 include "${KW_LIB_DIR}/lib/kwio.sh"

--- a/src/lib/kw_include.sh
+++ b/src/lib/kw_include.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #Used for file sourcing.
 #This function should used for file sourcing instead of `. file.sh --source-only`
 #

--- a/src/lib/kw_string.sh
+++ b/src/lib/kw_string.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # @@ Expect a string
 #
 # Return:

--- a/src/lib/kw_time_and_date.sh
+++ b/src/lib/kw_time_and_date.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/lib/kw_string.sh"
 include "${KW_LIB_DIR}/lib/kwio.sh"
 

--- a/src/lib/kwio.sh
+++ b/src/lib/kwio.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # NOTE: src/lib/kw_config_loader.sh must be included before this file
 declare -gr BLUECOLOR='\033[1;34;49m%s\033[m'
 declare -gr REDCOLOR='\033[1;31;49m%s\033[m'

--- a/src/lib/kwlib.sh
+++ b/src/lib/kwlib.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # NOTE: src/lib/kw_config_loader.sh must be included before this file
 include "${KW_LIB_DIR}/lib/kw_string.sh"
 include "${KW_LIB_DIR}/lib/kw_db.sh"

--- a/src/lib/lore.sh
+++ b/src/lib/lore.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This file is the library that handles the "back end" of interacting with the
 # kernel lore archives. it handles fecthing, listing and downloading of patches
 # sent to the public mailing lists.

--- a/src/lib/remote.sh
+++ b/src/lib/remote.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # NOTE: It is recommended that src/lib/kw_config_loader.sh be included before this
 # file
 include "${KW_LIB_DIR}/lib/kw_config_loader.sh"

--- a/src/lib/signal_manager.sh
+++ b/src/lib/signal_manager.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/lib/kwio.sh"
 
 function get_valid_signals()

--- a/src/lib/statistics.sh
+++ b/src/lib/statistics.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # kw keeps track of some data operation in daily use, and this file intends to
 # process all data based on the user request. Here you going to find functions
 # responsible for aggregate and calculate values such as average and total.

--- a/src/lib/web.sh
+++ b/src/lib/web.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This file handles any web access
 
 include "${KW_LIB_DIR}/lib/kwio.sh"

--- a/src/mail.sh
+++ b/src/mail.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This file handles all the interactions with git send-email. Currently it
 # provides functions to configure the options used by git send-email.
 # It's also able to verify if the configurations required to use git send-email

--- a/src/maintainers.sh
+++ b/src/maintainers.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/lib/kw_config_loader.sh"
 include "${KW_LIB_DIR}/lib/kwlib.sh"
 

--- a/src/patch_hub.sh
+++ b/src/patch_hub.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # The `patch_hub.sh` file is the entrypoint for the `patch-hub`
 # feature that follows kw codestyle. As the feature is screen-driven, it is implemented
 # as a state-machine in files stored at the `src/ui/patch_hub` directory.

--- a/src/plugins/kernel_install/arch.sh
+++ b/src/plugins/kernel_install/arch.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Kworkflow treats this script as a plugin for installing a new Kernel or
 # module on ArchLinux. It is essential to highlight that this file follows an
 # API that can be seen in the "deploy.sh" file, if you make any change here,

--- a/src/plugins/kernel_install/bootloader_utils.sh
+++ b/src/plugins/kernel_install/bootloader_utils.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 declare -gar GRUB=(
   'boot/grub/grub.conf'
   'boot/grub/grub.cfg'

--- a/src/plugins/kernel_install/debian.sh
+++ b/src/plugins/kernel_install/debian.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Kworkflow treats this script as a plugin for installing a new Kernel or
 # module in a target system. It is essential to highlight that this file
 # follows an API that can be seen in the "deploy.sh" file, if you make any

--- a/src/plugins/kernel_install/fedora.sh
+++ b/src/plugins/kernel_install/fedora.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Kworkflow treats this script as a plugin for installing a new Kernel or
 # module in a target system. It is essential to highlight that this file
 # follows an API that can be seen in the "deploy.sh" file, if you make any

--- a/src/plugins/kernel_install/grub.sh
+++ b/src/plugins/kernel_install/grub.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This file is specific to the GRUB bootloader, and since it is part of kw, it
 # follows the bootloader API. In other words, we have one entry point
 # functions: run_bootloader_update: Update GRUB in a local and remote machine.

--- a/src/plugins/kernel_install/remote_deploy.sh
+++ b/src/plugins/kernel_install/remote_deploy.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This script will be executed via ssh, because of this, I can't see any good
 # reason (until now) for making things complicated here.
 #

--- a/src/plugins/kernel_install/rpi_bootloader.sh
+++ b/src/plugins/kernel_install/rpi_bootloader.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This file is specific to the raspberry pi bootloader, and since it is part
 # of kw, it follows the bootloader API. In other words, we have two entry
 # point functions:

--- a/src/plugins/kernel_install/utils.sh
+++ b/src/plugins/kernel_install/utils.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 declare -g INSTALLED_KERNELS_PATH="$REMOTE_KW_DEPLOY/INSTALLED_KERNELS"
 declare -g AB_ROOTFS_PARTITION='/dev/disk/by-partsets/self/rootfs'
 declare -g LIB_MODULES_PATH='/lib/modules'

--- a/src/plugins/kw_mail/to_cc_cmd.sh
+++ b/src/plugins/kw_mail/to_cc_cmd.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This file reads the files generated containing the recipients for any given
 # patch, this is supposed to be used by `git send-email` in the `--to-cmd` and
 # `--cc-cmd` arguments after the appropriate files have been created using the

--- a/src/plugins/subsystems/drm/drm.sh
+++ b/src/plugins/subsystems/drm/drm.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 . "${KW_LIB_DIR}/lib/kw_config_loader.sh" --source-only
 . "${KW_LIB_DIR}/lib/remote.sh" --source-only
 . "${KW_LIB_DIR}/lib/kwlib.sh" --source-only

--- a/src/pomodoro.sh
+++ b/src/pomodoro.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/lib/kw_config_loader.sh"
 include "${KW_LIB_DIR}/lib/kwlib.sh"
 include "${KW_LIB_DIR}/lib/kw_db.sh"

--- a/src/report.sh
+++ b/src/report.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # kw keeps track of some data operations; at the moment kw tracks
 # Pomodoro sessions (kw pomodoro) and overall statistics. This file
 # intends to keep all procedures related to data fetching, processing,

--- a/src/self_update.sh
+++ b/src/self_update.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/lib/kwlib.sh"
 include "${KW_LIB_DIR}/lib/kwio.sh"
 include "${KW_LIB_DIR}/help.sh"

--- a/src/ui/patch_hub/latest_patchsets_from_mailing_list.sh
+++ b/src/ui/patch_hub/latest_patchsets_from_mailing_list.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/ui/patch_hub/patch_hub_core.sh"
 
 declare -g PAGE=1

--- a/src/ui/patch_hub/lore_mailing_lists.sh
+++ b/src/ui/patch_hub/lore_mailing_lists.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/ui/patch_hub/patch_hub_core.sh"
 
 # This function displays a checklist menu of the available mailing lists from lore.kernel.org

--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # The `patch_hub_core.sh` file centralizes the states representing the
 # sequences of screen of the `patch-hub` feature. The feature is implemented
 # as a state-machine that roughly follows the Model-View-Controller pattern. The roles

--- a/src/ui/patch_hub/patchset_details_and_actions.sh
+++ b/src/ui/patch_hub/patchset_details_and_actions.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/ui/patch_hub/patch_hub_core.sh"
 
 # This function is responsible for showing the screen with a patchset details

--- a/src/ui/patch_hub/search_string_in_lore.sh
+++ b/src/ui/patch_hub/search_string_in_lore.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/ui/patch_hub/patch_hub_core.sh"
 
 # This function displays an input box that allows the user to search a string in

--- a/src/ui/patch_hub/settings.sh
+++ b/src/ui/patch_hub/settings.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/ui/patch_hub/patch_hub_core.sh"
 
 # Screen that shows all types of settings available.

--- a/src/vm.sh
+++ b/src/vm.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 include "${KW_LIB_DIR}/lib/kw_config_loader.sh"
 include "${KW_LIB_DIR}/lib/kwlib.sh"
 


### PR DESCRIPTION
The scripts at src/ were missing shellbang, while  the  scripts  at  the root of kw (kw, setup.sh, run_tests.sh) and at tests/ do have shellbang. So, we add shellbang to files at src/ to make code more consistent.

Closes #998.

A quick notice. I used the following bash script to automate adding the shellbang:

```bash
tmp_file='/tmp/a.txt'
find src/ -type f -name '*.sh' | while read fname; do
  firstline=$(head --lines 1 "${fname}")
  if [ "${firstline}" != '#!/bin/bash' ]; then
    (printf '#!/bin/bash\n' ; cat "${fname}" ) > "${tmp_file}"
    mv "${tmp_file}" "${fname}"
  fi
done
```