### PR TITLE
documentation: dependencies: add device-module related dependencies

### DIFF
--- a/documentation/dependencies/arch.dependencies
+++ b/documentation/dependencies/arch.dependencies
@@ -26,3 +26,5 @@ curl
 perl-xml-xpath
 coreutils
 b4
+procps-ng
+pciutils

--- a/documentation/dependencies/debian.dependencies
+++ b/documentation/dependencies/debian.dependencies
@@ -28,3 +28,5 @@ curl
 libxml-xpath-perl
 coreutils
 b4
+procps
+pciutils

--- a/documentation/dependencies/fedora.dependencies
+++ b/documentation/dependencies/fedora.dependencies
@@ -24,3 +24,5 @@ curl
 perl-XML-XPath
 coreutils
 b4
+procps
+pciutils


### PR DESCRIPTION
The device module depends on `lscpi` and `ps`, which are  available  via the packages `pciutils` and `procps`. Normally these  dependencies  will already be installed by default, but we cannot assume they are,  so  add them to the dependency lists.

Closes #1000