### PR TITLE
documentation: dependencies: fedora: Fix procps dependency in fedora

### DIFF
--- a/documentation/dependencies/fedora.dependencies
+++ b/documentation/dependencies/fedora.dependencies
@@ -24,5 +24,5 @@ curl
 perl-XML-XPath
 coreutils
 b4
-procps
+procps-ng
 pciutils


### PR DESCRIPTION
In fedora distro, when installing kw with setup.sh, it is always requested to install the package procps, even when it's already installed.

The problem is that the command `rpm -q procps` seems to specifically not recognize that this package is already installed. However, with `rpm -q procps-ng` (which is the same exact package) it works fine.

So, change the dependency to 'procps-ng' instead of 'procps' to fix this problem.

Fixes: #1010