### PR TITLE
src: config: Fix values with space separation in `kw config`

### DIFF
--- a/src/config.sh
+++ b/src/config.sh
@@ -66,7 +66,7 @@ function config_main()
   target_config_file=$(printf '%s' "$parameters" | cut -d '.' -f 1)
   option_and_value="${parameters#*.}"
   option=$(printf '%s' "$option_and_value" | cut -d ' ' -f 1)
-  value=$(printf '%s' "$option_and_value" | cut -d ' ' -f 2)
+  value=$(printf '%s' "$option_and_value" | cut -d ' ' -f 2-)
 
   if [[ "${options_values['SCOPE']}" == 'global' ]]; then
     base_path="${KW_ETC_DIR}"


### PR DESCRIPTION
When manually configuring kw with `kw config`, it does not accept configurations with space separation, even with single ou double quotes put.

For example, the command
`kw config notification.sound_alert_command 'paplay berimbau.wav'`

will result in the wrong configuration
`notification.sound_alert_command=paplay`

Because of that, change `kw config` to receive the value as all characters after the first space following configuration name, instead of just the first word.

Fixes: #1008