### PR TITLE
tests: integration: Fix permission denied inside containers due to SELinux

### DIFF
--- a/tests/integration/utils.sh
+++ b/tests/integration/utils.sh
@@ -111,7 +111,7 @@ function setup_container_environment()
     # processes) and get the output of each of them separately.
     container_run \
       --workdir "${working_directory}" \
-      --volume "${KWROOT_DIR}":"${working_directory}" \
+      --volume "${KWROOT_DIR}":"${working_directory}:Z" \
       --env PATH='/root/.local/bin:/usr/bin' \
       --name "${container_name}" \
       --detach \


### PR DESCRIPTION
SELinux is causing permission troubles to podman containers when the current mode is set to "enforcing". It does not allow to execute setup.sh inside the container, for example.

This problem is related with how podman is built, being, currently, a quite common podman issue. Yet, it has an easy fix: add :z when mounting the volume.

For more references, read [podman troubleshooting page](https://github.com/containers/podman/blob/main/troubleshooting.md#2-cant-use-volume-mount-get-permission-denied).

Helps: #1016