### PR TITLE
src: kw_remote: Add dashes to remote commands

### DIFF
--- a/documentation/man/features/kw-remote.rst
+++ b/documentation/man/features/kw-remote.rst
@@ -7,9 +7,9 @@ kw-remote - Manage set of tracked test machines
 SYNOPSIS
 ========
 | *kw remote* [-v | \--verbose]
-| *kw remote* [--global] add <name> <user>@<remote>[:<port>]
-| *kw remote* [--global] remove <name>
-| *kw remote* [--global] rename <old-name> <new-name>
+| *kw remote* [--global] \--add <name> <user>@<remote>[:<port>]
+| *kw remote* [--global] \--remove <name>
+| *kw remote* [--global] \--rename <old-name> <new-name>
 | *kw remote* [--global] \--list
 | *kw remote* [--global] (-s | \--set-default)=<name>
 
@@ -21,16 +21,16 @@ available locally at `.kw/remote.config` or globally at `~/.config/kw/remote.con
 
 OPTIONS
 =======
-add <name> <remote-address>:
+\--add <name> <remote-address>:
   Adds a remote named <name> for the test machine at <remote-address>. Notice
   that <remote_address> must follow the pattern `<user>@<remote>[:<port>]` where
   `remote` can be an IP or a name server and `:<port>` is optional (default port
   is 22).
 
-remove <name>:
+\--remove <name>:
   Remove the remote named <name>.
 
-rename <old-name> <new-name>:
+\--rename <old-name> <new-name>:
   Rename the remote named <old-name> to <new-name>. If you try a name already
   in use, kw will fail with a message.
 
@@ -52,19 +52,19 @@ EXAMPLES
 In case you want **kw** to track a new test machine, you can use::
 
   cd <kernel-path>
-  kw remote add origin root@my-test-machine
+  kw remote --add origin root@my-test-machine
 
 If you do not use port 22, you can use::
 
-  kw remote add my-x86-test-system root@my-test-machine:5555
+  kw remote --add my-x86-test-system root@my-test-machine:5555
 
 If you want to remove some remote::
 
-  kw remote remove origin
+  kw remote --remove origin
 
 If you want to rename::
 
-  kw remote rename origina arm-device
+  kw remote --rename origina arm-device
 
 You can also list all your available remotes via::
 

--- a/documentation/tutorials/deploy-kernel.rst
+++ b/documentation/tutorials/deploy-kernel.rst
@@ -70,7 +70,7 @@ Before trying to deploy your new kernel, let's first update
 `kworkflow.config` and `remote.config` by making sure that you set the following
 options correctly::
 
-  kw remote add my-x86-test-system root@<IP or NAME>:<PORT>
+  kw remote --add my-x86-test-system root@<IP or NAME>:<PORT>
 
 .. note::
    If you don't know anything about `kworkflow.config` or `remote.config`, take

--- a/src/_kw
+++ b/src/_kw
@@ -438,9 +438,9 @@ _kw_pomodoro()
 _kw_remote()
 {
   local -a remote_commands=(
-    'add:add a named remote to kw management'
-    'remove:remove an existing remote from kw management'
-    'rename:rename an existing remote'
+    '--add:add a named remote to kw management'
+    '--remove:remove an existing remote from kw management'
+    '--rename:rename an existing remote'
   )
 
   _arguments : \

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -51,7 +51,7 @@ function _kw_autocomplete()
 
   kw_options['config']='--local --global --show --help --verbose'
 
-  kw_options['remote']='add remove rename --list --global --set-default --verbose'
+  kw_options['remote']='--add --remove --rename --list --global --set-default --verbose'
 
   kw_options['explore']='--log --grep --all --only-header --only-source --exactly --verbose'
   kw_options['e']="${kw_options['explore']}"

--- a/src/kw_remote.sh
+++ b/src/kw_remote.sh
@@ -139,7 +139,7 @@ function add_new_remote()
 
   # We expect at exact two parameters
   if [[ "${#add_parameters[*]}" != 2 ]]; then
-    complain 'Expected: add <name-without-space> <[user@]ip[:port]>'
+    complain 'Expected: --add <name-without-space> <[user@]ip[:port]>'
     exit 22 # EINVAL
   fi
 
@@ -236,7 +236,7 @@ function remove_remote()
 
   # We expect at exact two parameters
   if [[ "${#remove_parameters[*]}" != 1 ]]; then
-    complain 'Expected: remove <name-without-space>'
+    complain 'Expected: --remove <name-without-space>'
     exit 22 # EINVAL
   fi
 
@@ -280,7 +280,7 @@ function rename_remote()
 
   # We expect at exact two parameters
   if [[ "${#rename_parameters[*]}" != 2 ]]; then
-    complain 'Expected: rename <OLD-name-without-space> <NEW-name-without-space>'
+    complain 'Expected: --rename <OLD-name-without-space> <NEW-name-without-space>'
     exit 22 # EINVAL
   fi
 
@@ -359,15 +359,15 @@ function parse_remote_options()
         remote_help "$1"
         exit
         ;;
-      add)
+      --add)
         options_values['ADD']=1
         shift
         ;;
-      remove)
+      --remove)
         options_values['REMOVE']=1
         shift
         ;;
-      rename)
+      --rename)
         options_values['RENAME']=1
         shift
         ;;
@@ -411,7 +411,7 @@ function parse_remote_options()
     -z "${options_values['RENAME']}" && -z "${options_values['LIST']}" &&
     -z "${options_values['DEFAULT_REMOTE']}" ]]; then
     options_values['ERROR']='"kw remote" should be proceeded by valid option'$'\n'
-    options_values['ERROR']+='Usage: kw remote (add | remove | rename | --list | --set-default) <params>[...]'
+    options_values['ERROR']+='Usage: kw remote (--add | --remove | --rename | --list | --set-default) <params>[...]'
     return 22 # EINVAL
   fi
 }
@@ -425,9 +425,9 @@ function remote_help()
   fi
   printf '%s\n' 'kw remote:' \
     '  remote - handle remote options' \
-    '  remote add [--global] <name> <USER@IP:PORT> [--set-default] - Add new remote' \
-    '  remote remove [--global] <name> - Remove remote' \
-    '  remote rename [--global] <old> <new> - Rename remote' \
+    '  remote [--global] --add <name> <USER@IP:PORT> [--set-default] - Add new remote' \
+    '  remote [--global] --remove <name> - Remove remote' \
+    '  remote [--global] --rename <old> <new> - Rename remote' \
     '  remote [--global] --set-default=<remonte-name> - Set default remote' \
     '  remote [--global] --list - List remotes' \
     '  remote [--global] (--verbose | -v) - be verbose'

--- a/tests/unit/kw_remote_test.sh
+++ b/tests/unit/kw_remote_test.sh
@@ -465,17 +465,17 @@ function test_set_default_remote_we_already_have_the_default_remote()
 function test_parse_remote_options()
 {
   # Add option
-  parse_remote_options add origin 'root@la:3333'
+  parse_remote_options --add origin 'root@la:3333'
   assert_equals_helper 'Request add' "($LINENO)" "${options_values['ADD']}" 1
   assert_equals_helper 'Remote options' "($LINENO)" "${options_values['PARAMETERS']}" 'origin root@la:3333 '
 
   # Remove
-  parse_remote_options remove origin
+  parse_remote_options --remove origin
   assert_equals_helper 'Request remove' "($LINENO)" "${options_values['REMOVE']}" 1
   assert_equals_helper 'Remote options' "($LINENO)" "${options_values['PARAMETERS']}" 'origin '
 
   # Rename
-  parse_remote_options rename origin xpto
+  parse_remote_options --rename origin xpto
   assert_equals_helper 'Request rename' "($LINENO)" "${options_values['RENAME']}" 1
   assert_equals_helper 'Remote options' "($LINENO)" "${options_values['PARAMETERS']}" 'origin xpto '
 }


### PR DESCRIPTION
This change was asked by @rodrigosiqueira in [this closed pull request](https://github.com/kworkflow/kworkflow/pull/996).

`kw remote` commands lack a clear pattern related to double dashes (--). Notably, `kw remote add`, `kw remote remove` and `kw remote rename` do not include dashes, but `kw remote --list` does.

So, to make it more clear, execute the following changes:
- `kw remote add` to `kw remote --add`
- `kw remote remove` to `kw remote --remove`
- `kw remote rename` to `kw remote --rename`