### PR TITLE
src: _kw: Fix Zsh completion of `kw pomodoro` `--description` option

### DIFF
--- a/src/_kw
+++ b/src/_kw
@@ -413,6 +413,7 @@ _kw_p() { _kw_pomodoro }
 _kw_pomodoro()
 {
   local -a set_timer_options=()
+  local -a tag_options=()
 
   if ((words[(I)-t|--set-timer])); then
     set_timer_options=(


### PR DESCRIPTION
In the Zsh completions for kw, options that depend on other options being completed to be suggested are implemented using indexed arrays. Conceptually, if 'option A' depends on 'option B' being completed to be suggested, the array that defines 'option A' will be empty until 'option B' has been completed.

In the case of `kw pomodoro`, the `--description` option should only be suggested if the prompt has the `--set-timer` and `--tag` options. However, for a given shell session, the correct behavior only happens once, from which `--description` will be suggested even when the prompt has only `kw pomodoro`. The cause of this is that we do not declare a local empty array for the options that come after `--tag`, so once it has been set with `--description`, it will contain it to the remainder of the shell session.

To fix this behavior declare a local empty array for the options that depend on the `--tag` at the start of the completion function for `kw pomodoro`.