### PR TITLE
src: build: fix unrelated warning in kw b --help

### DIFF
--- a/kw
+++ b/kw
@@ -119,7 +119,7 @@ function kw()
       ;;
     build | b)
       (
-        include "${KW_LIB_DIR}/build.sh"
+        include "${KW_LIB_DIR}/build.sh" "$@"
 
         build_kernel_main '' "$@"
         local ret="$?"

--- a/src/build.sh
+++ b/src/build.sh
@@ -441,6 +441,23 @@ function build_help()
     '  build (--verbose) - Show a detailed output'
 }
 
-# Every time build.sh is loaded its proper configuration has to be loaded as well
+function check_include_interrupt()
+{
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --help | -h)
+        build_help "$1"
+        exit
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+}
+
+# Check if loading config is necessary
+check_include_interrupt "$@"
+
 load_build_config
 load_notification_config

--- a/src/lib/kw_include.sh
+++ b/src/lib/kw_include.sh
@@ -30,5 +30,6 @@ function include()
     declare -gA KW_INCLUDED_PATHS=(["$fullpath"]=1)
   fi
 
-  . "$filepath" --source-only
+  shift
+  . "$filepath" --source-only "$@"
 }


### PR DESCRIPTION
When including the file build.sh, all the configurations were loaded under all conditions, so simply running kw b --help would show unrelated warning if used in a folder with no config files. So the following changes are made:
- Change "include" function to pass arguments to included file
- Change "build.sh" to interrupt loading the config if "--help" flag was detected

Fix suggestion for issue #824