### PR TITLE
src: lib: dialog_ui: Remove `LC_CTYPE` override for async loading screen spinner

### DIFF
--- a/src/lib/dialog_ui.sh
+++ b/src/lib/dialog_ui.sh
@@ -250,12 +250,10 @@ function create_loading_screen_notification()
 function spin_frame()
 {
   local frame_offset="$1"
-  local LC_CTYPE=C
   local spin='⣾⣽⣻⢿⡿⣟⣯⣷'
-  local char_width=3
 
   frame_offset=$(((frame_offset) % ${#spin}))
-  printf "%s" "${spin:$frame_offset:$char_width}"
+  printf "%s" "${spin:$frame_offset:1}"
 }
 
 # Create simple async loading screen notification for delayed actions.
@@ -293,7 +291,7 @@ function create_async_loading_screen_notification()
     # We should not use --clear because this flushes the infobox
     cmd+='dialog --colors'
     spin="$(spin_frame $frame_offset)"
-    frame_offset=$((frame_offset + 3))
+    frame_offset=$((frame_offset + 1))
 
     # Add Infobox screen
     cmd+=" --infobox $'${loading_message} ${spin}'"


### PR DESCRIPTION
The function `create_async_loading_screen_notification` creates a Dialog loading screen with a spinner to signal users that a delayed action is happening underneath. However, users reported environments that had problems with the characters used for the spinner while using `kw patch-hub` and running the test suite for `src/lib/dialog_ui.sh`.

The problem stems from the environment variable `LC_CTYPE` (used to determine character handling rules) being overridden to account for using the spinner characters that are Unicode (multibyte). The logic behind this is sound, as the encoding aspect should be considered because these spinner characters have a length of 3 bytes. Nevertheless, not handling this matter fixes the problem for the environments mentioned above and doesn't introduce regressions for the environments that didn't face the issues.

In this context, remove the override of `LC_CTYPE` and consider the spinner characters of length 1.

Closes: #965