### PR TITLE
src: build: Remove redundant override of `load_build_config`

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -247,50 +247,6 @@ function full_cleanup()
   cmd_manager "$flag" "$cmd"
 }
 
-# This function loads the kw build configuration files into memory, populating
-# the $build_config hashtable. The files are parsed in a specific order,
-# allowing higher level setting definitions to overwrite lower level ones.
-function load_build_config()
-{
-  if [[ -v build_config && "$OVERRIDE_BUILD_CONFIG" != 1 ]]; then
-    unset OVERRIDE_BUILD_CONFIG
-    return
-  fi
-
-  local -a config_dirs
-  local config_dirs_size
-
-  if [[ -v XDG_CONFIG_DIRS ]]; then
-    IFS=: read -ra config_dirs <<< "$XDG_CONFIG_DIRS"
-  else
-    [[ -d '/etc/xdg' ]] && config_dirs=('/etc/xdg')
-  fi
-
-  # Old users may not have split their configs yet
-  parse_configuration "$KW_ETC_DIR/$BUILD_CONFIG_FILENAME" build_config
-
-  # XDG_CONFIG_DIRS is a colon-separated list of directories for config
-  # files to be searched, in order of preference. Since this function
-  # reads config files in a reversed order of preference, we must
-  # traverse it from back to top. Example: if
-  # XDG_CONFIG_DIRS=/etc/xdg:/home/user/myconfig:/etc/myconfig
-  # we will want to parse /etc/myconfig, then /home/user/myconfig, then
-  # /etc/xdg.
-  config_dirs_size="${#config_dirs[@]}"
-  for ((i = config_dirs_size - 1; i >= 0; i--)); do
-    parse_configuration "${config_dirs["$i"]}/$KWORKFLOW/$BUILD_CONFIG_FILENAME" build_config
-  done
-
-  parse_configuration "${XDG_CONFIG_HOME:-"$HOME/.config"}/$KWORKFLOW/$BUILD_CONFIG_FILENAME" build_config
-
-  if [[ -f "$PWD/$KW_DIR/$BUILD_CONFIG_FILENAME" ]]; then
-    parse_configuration "$PWD/$KW_DIR/$BUILD_CONFIG_FILENAME" build_config
-  else
-    # Old users may not have used kw init yet, so they wouldn't have .kw
-    warning "Please use kw init to update your config files"
-  fi
-}
-
 function parse_build_options()
 {
   local long_options='help,info,menu,doc,ccache,cpu-scaling:,warnings::,save-log-to:,llvm,clean,full-cleanup,verbose,cflags:'


### PR DESCRIPTION
In kw, the `src/lib/kw_config_loader.sh` module takes care of configuration precedence for all the configurations, i.e., it composes configurations from the most preferred scope to the least one. Although the function `load_build_config` defined inside
`src/lib/kw_config_loader.sh` takes care of this behavior for the configurations of `kw build`, this function is also defined in `src/build.sh`, doing virtually the same as the former definition. This double definition causes the one from build to override the one in the config loader (config loader is sourced first).

Three problems arise from this situation:
 - Duplicated/redundant code.
 - The definition from build has a bug that outputs a warning to the user that doesn't makes sense.
 - It breaks the project's pattern of delegating any and all configuration loading to the `src/lib/kw_config_loader.sh` module.

Probably, `load_build_config` from build was created before the inception of the config loader and we forgot to remove it after adding the module. That may be the reason why the code is duplicated and has a bug that doesn't exist in the config loader version.

To address the three problems described above, remove the definition of `load_build_config` from `src/build.sh`.

Fixes: #824

Thanks-to: Rodrigo Siqueira \<Rodrigo.Siqueira@amd.com\>
Thanks-to: André Gustavo Nakagomi Lopez \<andregnl@usp.br\>