### PR TITLE
Expand kw env list to show the path info

### DIFF
--- a/tests/unit/kw_env_test.sh
+++ b/tests/unit/kw_env_test.sh
@@ -112,13 +112,12 @@ function test_show_available_envs()
   create_new_env
 
   local expected=(
-    'All kw environments set for your local folder:'
-    'farofa'
-    'tapioca'
+    'Other kw environments:'
+    "* farofa: ${KW_CACHE_DIR}/${ENV_DIR}/farofa"
+    "* tapioca: ${KW_CACHE_DIR}/${ENV_DIR}/tapioca"
   )
 
   output=$(list_env_available_envs)
-
   compare_command_sequence 'Did not list all envs correctly' "$LINENO" 'expected' "$output"
 }
 


### PR DESCRIPTION
Recently, we got some user feedback that they wish to know the env path to enable them to use other kernel custom commands. This commit addresses this issue by improving the kw env --list to also show the env path.