### PR TITLE
src: _kw: Revise `kw remote` Zsh completions

### DIFF
--- a/src/_kw
+++ b/src/_kw
@@ -438,20 +438,26 @@ _kw_pomodoro()
 
 _kw_remote()
 {
-  local -a remote_commands=(
-    '--add:add a named remote to kw management'
-    '--remove:remove an existing remote from kw management'
-    '--rename:rename an existing remote'
+  local -a set_default=()
+
+  set_default=(
+    '(-s --set-default --add --list --remove --rename)'{-s-,--set-default=}'[set existing remote as default]:remote-name: '
   )
 
-  _arguments : \
-    '(-v --verbose)'{-v,--verbose}'[be a little more verbose and show remote url after name]' \
-    '(-s --set-default)--list[list all available remotes]' \
-    '(-s --set-default --list)'{-s-,--set-default=-}'[set default remote to an existing one]: : ' \
-
-  if [[ "$CURRENT" -lt 3 ]]; then
-    _describe -t remote-commands 'remote command' remote_commands
+  if ((words[(I)--add])); then
+    set_default=(
+      '(-s --set-default --list --remove --rename)'{-s,--set-default}'[set remote to be added as default]'
+    )
   fi
+
+  _arguments : \
+    '--global[use global configurations]' \
+    '(-v --verbose)'{-v,--verbose}'[be a little more verbose and show remote url after name]' \
+    '(-s --set-default --add --remove --rename)--list[list all available remotes]' \
+    '(--list --remove --rename)--add[add a named remote to kw management]:remote-name: :user-ip-port: ' \
+    '(--list -s --set-default --add --remove)--rename[rename an existing remote from kw management]:old-remote-name: :new-remote-name: ' \
+    '(--list -s --set-default --add --rename)--remove[remove an existing remote from kw management]:remote-name: ' \
+    $set_default
 }
 
 _kw_r() { _kw_report }


### PR DESCRIPTION
The Zsh completions for the `kw remote` feature are broken, because:

  1. The `--list`, `--add`, `--rename`, and `remove` aren't mutually exclusive, as they should.
  2. The `--add` and `--rename` options require 2 arguments, but the completions assume they don't need any and suggest other options.
  3. The `--remove` option requires 1 argument, but the completions assume it doesn't need any and suggest other options.
  4. The `--set-default|-s` option followed by `--add` shouldn't accept arguments, yet it does.

In this sense, fix problems 1 to 3 by declaring `--add`, `--rename`, and `--remove` as completions to `_arguments` instead of `_describe`, and fix 4 by altering the completion of `--set-default|-s`, if `--add` has been completed.