### PR TITLE
src: kw_remote: Fix typo in short help

### DIFF
--- a/src/kw_remote.sh
+++ b/src/kw_remote.sh
@@ -428,7 +428,7 @@ function remote_help()
     '  remote [--global] --add <name> <USER@IP:PORT> [--set-default] - Add new remote' \
     '  remote [--global] --remove <name> - Remove remote' \
     '  remote [--global] --rename <old> <new> - Rename remote' \
-    '  remote [--global] --set-default=<remonte-name> - Set default remote' \
+    '  remote [--global] --set-default=<remote-name> - Set default remote' \
     '  remote [--global] --list - List remotes' \
     '  remote [--global] (--verbose | -v) - be verbose'
 }


### PR DESCRIPTION
Running `kw remote -h` outputs the short help of the `kw remote` feature. In this short help, there is a typo of the word 'remote', so fix the typo.