### PR TITLE
src: lib: lore: Make query filter for Lore request more robust

### DIFF
--- a/src/lib/lore.sh
+++ b/src/lib/lore.sh
@@ -361,11 +361,8 @@ function compose_lore_query_url_with_verification()
     return 22 # EINVAL
   fi
 
-  # TODO: We need to use the query prefix 's:Re:' to filter out replies and match
-  # only real patches. Are we filtering possible patches? If no, can we filter more
-  # messages to obtain a lighter response file?
-  query_filter="?x=A&o=${min_index}&q=rt:..+AND+NOT+s:Re"
-  [[ -n "$additional_filters" ]] && query_filter+="+AND+${additional_filters}"
+  query_filter="?x=A&o=${min_index}&q=((s:patch+OR+s:rfc)+AND+NOT+s:re:)"
+  [[ -n "$additional_filters" ]] && query_filter+="+AND+(${additional_filters})"
   query_url="${LORE_URL}/${target_mailing_list}/${query_filter}"
   printf '%s' "$query_url"
 }

--- a/tests/unit/lib/lore_test.sh
+++ b/tests/unit/lib/lore_test.sh
@@ -484,22 +484,22 @@ function test_compose_lore_query_url_with_verification_valid_cases()
 
   target_mailing_list='amd-gfx'
   min_index='200'
-  expected='https://lore.kernel.org/amd-gfx/?x=A&o=200&q=rt:..+AND+NOT+s:Re'
+  expected='https://lore.kernel.org/amd-gfx/?x=A&o=200&q=((s:patch+OR+s:rfc)+AND+NOT+s:re:)'
   output=$(compose_lore_query_url_with_verification "$target_mailing_list" "$min_index")
   assert_equals_helper 'Valid arguments should return 0' "$LINENO" 0 "$?"
   assert_equals_helper 'Wrong query URL outputted' "$LINENO" "$expected" "$output"
 
   target_mailing_list='amd-gfx'
   min_index='-200'
-  expected='https://lore.kernel.org/amd-gfx/?x=A&o=-200&q=rt:..+AND+NOT+s:Re'
+  expected='https://lore.kernel.org/amd-gfx/?x=A&o=-200&q=((s:patch+OR+s:rfc)+AND+NOT+s:re:)'
   output=$(compose_lore_query_url_with_verification "$target_mailing_list" "$min_index")
   assert_equals_helper 'Valid arguments should return 0' "$LINENO" 0 "$?"
   assert_equals_helper 'Wrong query URL outputted' "$LINENO" "$expected" "$output"
 
   target_mailing_list='amd-gfx'
   min_index='200'
-  additional_filters='s:drm%2Famdgpu+AND+NOT+f:David%20Tadokoro'
-  expected='https://lore.kernel.org/amd-gfx/?x=A&o=200&q=rt:..+AND+NOT+s:Re+AND+s:drm%2Famdgpu+AND+NOT+f:David%20Tadokoro'
+  additional_filters='s:drm%2Famdgpu+AND+NOT+f:Linus%20Torvalds'
+  expected='https://lore.kernel.org/amd-gfx/?x=A&o=200&q=((s:patch+OR+s:rfc)+AND+NOT+s:re:)+AND+(s:drm%2Famdgpu+AND+NOT+f:Linus%20Torvalds)'
   output=$(compose_lore_query_url_with_verification "$target_mailing_list" "$min_index" "$additional_filters")
   assert_equals_helper 'Valid arguments should return 0' "$LINENO" 0 "$?"
   assert_equals_helper 'Wrong query URL outputted' "$LINENO" "$expected" "$output"


### PR DESCRIPTION
When fetching patches from Lore, patch-hub composes a query URL that contain base filters along with additional filters. The base filters basically aims to filter out any message from the given mailing list that is not a patch. However, this query filter simply filters out messages that have the string 'Re:' in the subject.

In this context, make this query filter more robust by enforcing that the subject mustn't contain the string 're:', while also containing the strings 'patch' or 'rfc' (all case insensitive). The query filter is also constructed as an isolated logical expression to not conflict with potential added filters.

Note: Took the opportunity to anonymize a test information.