### PR TITLE
src: lib: lore: Fix empty message ID bug in `get_patchset_bookmark_st…

### DIFF
--- a/src/lib/lore.sh
+++ b/src/lib/lore.sh
@@ -917,18 +917,23 @@ function parse_raw_patchset_data()
 # This function gets the bookmark status of a patchset, 0 being not in the local
 # bookmarked database and 1 being in the local bookmarked database.
 #
-# @patchset_url: The URL of the patchset that identifies the entry in the local
+# @message_id: The URL of the patchset that identifies the entry in the local
 #   bookmarked database
+#
+# Return:
+# Returns 22 (EINVAL)
 function get_patchset_bookmark_status()
 {
-  local patchset_url="$1"
+  local message_id="$1"
   local count
+
+  [[ -z "$message_id" ]] && return 22 # EINVAL
 
   if [[ ! -f "${BOOKMARKED_SERIES_PATH}" ]]; then
     create_lore_bookmarked_file
   fi
 
-  count=$(grep --count "$patchset_url" "${BOOKMARKED_SERIES_PATH}")
+  count=$(grep --count "$message_id" "${BOOKMARKED_SERIES_PATH}")
   if [[ "$count" == 0 ]]; then
     printf '%s' 0
   else

--- a/tests/unit/lib/lore_test.sh
+++ b/tests/unit/lib/lore_test.sh
@@ -350,6 +350,9 @@ function test_get_patchset_bookmark_status()
 {
   local output
 
+  get_patchset_bookmark_status ''
+  assert_equals_helper 'Empty URL should return 22' "$LINENO" 22 "$?"
+
   {
     printf 'entry1Æhttp://lore.kernel.org/amd-gfx/0138948.2424-1-lore@kernel.org/\n'
     printf 'entry2Æhttp://lore.kernel.org/linux-staging/1676464.997845-1-lore@kernel.org/\n'


### PR DESCRIPTION
…atus`

The function `get_patchset_bookmark_status` is used by patch-hub UI to determine if given patchset is already in the Lore bookmarked database. However, because the function uses `grep` to check if the patchset message ID is present in the file that represents the bookmark database, an empty message ID returns 1, which means true to being in the database.

To fix this, check if the message ID passed as argument is empty and return 22 EINVAL in case it is.

Note: Took the opportunity to rename the argument name from `patchset_url` to `message_id`, as it is more precise.