### PR TITLE
src: ui: patch_hub: patchset_details_and_actions: Fix returning from 'Details and Actions' bug

### DIFF
--- a/src/ui/patch_hub/latest_patchsets_from_mailing_list.sh
+++ b/src/ui/patch_hub/latest_patchsets_from_mailing_list.sh
@@ -7,7 +7,6 @@ declare -ga formatted_patchsets_list
 # These patchsets are ordered by their recieved time in the lore.kernel.org servers.
 function show_latest_patchsets_from_mailing_list()
 {
-  local additional_filters="$1"
   local starting_index
   local ending_index
   local box_title
@@ -30,6 +29,8 @@ function show_latest_patchsets_from_mailing_list()
     else
       screen_sequence['SHOW_SCREEN']='registered_mailing_lists'
     fi
+    reset_current_lore_fetch_session
+    additional_filters=''
     return
   fi
 
@@ -68,6 +69,7 @@ function show_latest_patchsets_from_mailing_list()
         else
           screen_sequence['SHOW_SCREEN']='registered_mailing_lists'
         fi
+        additional_filters=''
       fi
       ;;
   esac

--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -23,6 +23,7 @@ include "${KW_LIB_DIR}/ui/patch_hub/search_string_in_lore.sh"
 # These are references to data structures used all around the state-machine.
 declare -ga bookmarked_series
 declare -g current_mailing_list
+declare -g additional_filters
 
 # This associative array is used to determine the states and  topass arguments
 # between states.
@@ -64,7 +65,7 @@ function patch_hub_main_loop()
         ret="$?"
         ;;
       'latest_patchsets_from_mailing_list')
-        show_latest_patchsets_from_mailing_list "${screen_sequence['SHOW_SCREEN_PARAMETER']}"
+        show_latest_patchsets_from_mailing_list
         ret="$?"
         ;;
       'bookmarked_patches')

--- a/src/ui/patch_hub/patchset_details_and_actions.sh
+++ b/src/ui/patch_hub/patchset_details_and_actions.sh
@@ -52,6 +52,7 @@ function show_patchset_details_and_actions()
 
     3) # Return
       screen_sequence['SHOW_SCREEN']="${screen_sequence['PREVIOUS_SCREEN']}"
+      screen_sequence['SHOW_SCREEN_PARAMETER']=''
       ;;
   esac
 }

--- a/src/ui/patch_hub/search_string_in_lore.sh
+++ b/src/ui/patch_hub/search_string_in_lore.sh
@@ -44,5 +44,5 @@ function search_string_in_lore()
   current_mailing_list='all'
 
   screen_sequence['SHOW_SCREEN']='latest_patchsets_from_mailing_list'
-  screen_sequence['SHOW_SCREEN_PARAMETER']="$(url_encode "$string")"
+  additional_filters="$(url_encode "$string")"
 }

--- a/tests/unit/ui/patch_hub/search_string_in_lore_test.sh
+++ b/tests/unit/ui/patch_hub/search_string_in_lore_test.sh
@@ -25,6 +25,7 @@ function test_show_search_string_in_lore()
 {
   local output
   local expected
+  declare -g additional_filters=''
 
   # shellcheck disable=SC2317
   function create_inputbox_screen()
@@ -55,7 +56,7 @@ function test_show_search_string_in_lore()
 
   show_search_string_in_lore
   assert_equals_helper 'Wrong screen set' "$LINENO" 'latest_patchsets_from_mailing_list' "${screen_sequence['SHOW_SCREEN']}"
-  assert_equals_helper 'Wrong screen parameter' "$LINENO" 'query-string' "${screen_sequence['SHOW_SCREEN_PARAMETER']}"
+  assert_equals_helper 'Wrong additional filter' "$LINENO" 'query-string' "$additional_filters"
   assert_equals_helper 'Wrong current list' "$LINENO" 'all' "$current_mailing_list"
 
   # shellcheck disable=SC2317
@@ -75,6 +76,7 @@ function test_search_string_in_lore()
 {
   local output
   local expected
+  declare -g additional_filters=''
 
   # shellcheck disable=SC2317
   function create_message_box()
@@ -89,12 +91,12 @@ function test_search_string_in_lore()
 
   search_string_in_lore 'query-string'
   assert_equals_helper 'Wrong screen set' "$LINENO" 'latest_patchsets_from_mailing_list' "${screen_sequence['SHOW_SCREEN']}"
-  assert_equals_helper 'Wrong screen parameter' "$LINENO" 'query-string' "${screen_sequence['SHOW_SCREEN_PARAMETER']}"
+  assert_equals_helper 'Wrong screen parameter' "$LINENO" 'query-string' "$additional_filters"
   assert_equals_helper 'Wrong current list' "$LINENO" 'all' "$current_mailing_list"
 
   search_string_in_lore 'Robson Cruzoé'
   assert_equals_helper 'Wrong screen set' "$LINENO" 'latest_patchsets_from_mailing_list' "${screen_sequence['SHOW_SCREEN']}"
-  assert_equals_helper 'Wrong screen parameter' "$LINENO" 'Robson%20Cruzo%C3%A9' "${screen_sequence['SHOW_SCREEN_PARAMETER']}"
+  assert_equals_helper 'Wrong screen parameter' "$LINENO" 'Robson%20Cruzo%C3%A9' "$additional_filters"
   assert_equals_helper 'Wrong current list' "$LINENO" 'all' "$current_mailing_list"
 }
 


### PR DESCRIPTION
[What]

With the implementation of 'Search String in Lore', the function `show_latest_patchsets_from_mailing_list` accepts an argument for additional filters to be passed in the Lore request. This argument is passed via the `screen_sequence` data structure used to pass information between the screens that compose patch-hub UI. However, because in the screen 'Details and Actions' the
`screen_sequence['SHOW_SCREEN_PARAMETER']` contains data about a patchset (not an additional filter) and because this value isn't reset when returning from this screen, `show_latest_patchsets_from_mailing_list` makes an invalid request that causes the fetch to fail, when it shouldn't.

In this context, make the screen 'Details and Actions' reset the value of `screen_sequence['SHOW_SCREEN_PARAMETER']` when returning and adapt other parts to not also break the 'Search String in Lore' feature.

[Why]

Undoubtedly, users will go back and forth between the listing of latest patchsets and a patchset details and actions, so this bug is a major flaw in patch-hub.

[How]

The fix goes by simply resetting the value of
`screen_sequence['SHOW_SCREEN_PARAMETER']` in the function `show_patchset_details_and_actions` when the user hits the button 'Return'. However, because 'Search String in Lore' also uses this value to work, just this reset breaks this feature. So, besides the reset, we add a global variable to patch-hub UI declared in `patch_hub_core.sh` to pass additional filters instead of using
`screen_sequence['SHOW_SCREEN_PARAMETER']` for this.

Closes: #1028