### PR TITLE
`kw patch-hub`: Overhaul listing of patchsets

### DIFF
--- a/src/lib/lore.sh
+++ b/src/lib/lore.sh
@@ -797,7 +797,7 @@ function fetch_latest_patchsets_from()
 # into an array reference passed as argument. The format of the metadata follows the
 # pattern:
 #
-#  V <version_of_patchset> | #<number_of_patches> | <patchset_title>
+#  V <version> | #<total_in_series> | <message_title> | <updated> | <author_name>
 #
 # @_formatted_patchsets_list: Array reference to output formatted range of patchsets metadata
 # @starting_index: Starting index of range from `representative_patches`
@@ -812,7 +812,7 @@ function format_patchsets()
   for i in $(seq "$starting_index" "$ending_index"); do
     read_patch_into_dict "${representative_patches["$i"]}" 'patchset'
     _formatted_patchsets_list["$i"]=$(printf 'V%-2s |#%-3s| ' "${patchset['version']}" "${patchset['total_in_series']}")
-    _formatted_patchsets_list["$i"]+=$(printf ' %-100s' "${patchset['message_title']}")
+    _formatted_patchsets_list["$i"]+=$(printf '%-60.60s | %s | %-30.30s' "${patchset['message_title']}" "${patchset['updated']:0:-6}" "${patchset['author_name']}")
   done
 }
 
@@ -1048,16 +1048,12 @@ function remove_series_from_bookmark_by_index()
 #
 # @_bookmarked_series: An array reference to be populated with all the bookmarked
 #   series.
-#
-# TODO:
-# - Better decide which information will be shown in the bookmarked patches screen
 function get_bookmarked_series()
 {
   local -n _bookmarked_series="$1"
   declare -A series
   local index=0
   local timestamp
-  local tmp_data
 
   if [[ ! -f "${BOOKMARKED_SERIES_PATH}" ]]; then
     return 2 # ENOENT
@@ -1067,8 +1063,8 @@ function get_bookmarked_series()
 
   while IFS='' read -r raw_patchset; do
     read_patch_into_dict "${raw_patchset}" 'series'
-    tmp_data=$(printf ' %s | %-70s | %s' "${series['timestamp']}" "${series['message_title']}" "${series['author_name']}")
-    _bookmarked_series["$index"]="${tmp_data}"
+    _bookmarked_series["$index"]=$(printf ' %s | %-60.60s ' "${series['timestamp']}" "${series['message_title']}")
+    _bookmarked_series["$index"]+=$(printf '| %s' "${series['author_name']}")
     ((index++))
   done < "${BOOKMARKED_SERIES_PATH}"
 }

--- a/src/lib/lore.sh
+++ b/src/lib/lore.sh
@@ -34,9 +34,30 @@ declare -gA available_lore_mailing_lists
 # Special character used for separate data.
 declare -gr SEPARATOR_CHAR='Æ'
 
-# Number of patchsets processed current lore fetch session.
-# Also, the size of `list_of_mailinglist_patches`.
-declare -g PATCHSETS_PROCESSED=0
+# Indexed array of patches that represent patchsets ordered from the latest to
+# the earliest. A patchset is a set of individual patches sent together to form
+# a broader change and its first message in the series is elected to be the
+# representative. An element of the array is a sequence of message's attributes
+# separated by `SEPARATOR_CHAR` in the following order:
+#   message ID, message title, author name, author email, version, number in series,
+#   total in series, updated, and in reply to (optional).
+declare -ag representative_patches
+
+# Associative array with metadata of every patch that was processed during a
+# fetch session of patchsets. This information is used to determine representative
+# patches (see function `processed_representative_patches`). An element's general
+# format is:
+#   individual_patches_metadata['message_id']='<version>,<number_in_series>'
+declare -Ag individual_patches_metadata
+
+# Associative array used to check if a given representative patch was already
+# processed. Each element is a boolean where a non-empty value is true and an
+# empty one is false.
+declare -Ag processed_representative_patches
+
+# Total number of processed representative patches in current fetch session. Also,
+# the size of the indexed array `representative_patches`.
+declare -g REPRESENTATIVE_PATCHES_PROCESSED=0
 
 # Any query to the lore servers is paginated and the maximum number of individual
 # messages returned is 200. This variable represents this value.
@@ -51,21 +72,6 @@ declare -gr LORE_PAGE_SIZE=200
 # minimum exclusive (minorant) as the message of index `MIN_INDEX` isn't included
 # in the response (neither the message of index 0 exists).
 declare -g MIN_INDEX=0
-
-# This is a global array that kw uses to store the list of new patches from a
-# target mailing list. After kw parses the data from lore, we will have a list
-# that follows this pattern:
-#
-#  Author, email, version, total patches, patch title, link
-#
-# Note: To separate those elements, we use the variable SEPARATOR_CHAR, which
-# can be a ',' but by default, we use 'Æ'. We used ',' in the example for make
-# it easy to undertand.
-declare -ag list_of_mailinglist_patches
-
-# This associative array stores the current processed patchsets and it is used
-# to check if a given patchset was already processed.
-declare -Ag processed_patchsets
 
 # This function creates the directory used by kw for any lore related data.
 #
@@ -137,27 +143,6 @@ function retrieve_available_mailing_lists()
 
     ((page++))
   done
-}
-
-# This function parser the message-id link for trying to find if the target
-# patch is the first one from the series (in the case of a patchset, the first
-# patch is the cover-letter) or not. This is useful for identifying cover
-# letters or patches from a sequence.
-#
-# @message_id_link String with the message id link
-#
-# Return
-# If it is the first patch, return 0; otherwise, return 1.
-function is_introduction_patch()
-{
-  local message_id_link="$1"
-  local sequence
-
-  sequence=$(grep --only-matching --perl-regexp '\-[0-9]+\-' <<< "$message_id_link")
-  sequence=$(printf '%s' "$sequence" | tr -d '-')
-
-  [[ "$sequence" == 1 ]] && return 0
-  return 1
 }
 
 # This function extracts the patch metadata of a lore message title. A patch
@@ -343,61 +328,6 @@ function remove_patch_metadata_from_message_title()
   printf '%s' "$message_title"
 }
 
-# Usually, the Linux kernel patch title has a lot of helpful information, and
-# this function is responsible for extracting patch information from the patch
-# title. This function extracts:
-#
-#  Patch version, Total of patches, Patch title, URL
-#
-# @message_title: Raw patch title to be parsed.
-# @message_id: Message title of patch to be parsed.
-#
-# Return: Return a string with patch version, total patches, and patch title
-# separated by SEPARATOR_CHAR.
-#
-# FIXME: In this function, we collect metadata from the patch title; this is
-# useful but fragile since we rely on developers following the right approach.
-# Ideally, we should use this approach as a last resource to collect the
-# information; we should always favor the lore API. For sure, we can get the
-# total patches by parsing "-NUMBER-" in the message-id, but for the patch
-# version, this is not so straightforward.
-function extract_metadata_from_patch_title()
-{
-  local message_title="$1"
-  local message_id="$2"
-  local patch_metadata
-  local version
-  local total_in_series
-
-  patch_metadata="$(get_patch_metadata "$message_title")"
-  version="$(get_patch_version "$patch_metadata")${SEPARATOR_CHAR}"
-  total_in_series="$(get_patch_total_in_series "$patch_metadata")${SEPARATOR_CHAR}"
-  message_title="$(remove_patch_metadata_from_message_title "$message_title" "$patch_metadata")${SEPARATOR_CHAR}"
-
-  printf '%s%s%s%s' "$version" "$total_in_series" "$message_title" "$message_id"
-}
-
-# This function was tailored to run in a subshell because we want to run this
-# sort of data processing in parallel to avoid blocking users for a long time.
-#
-# @id: Id used to retrieve the data processed by this function
-# @base_dir: Where this function will save the data
-# @processed_line: Pre-filled data
-# @message_id_link: Message id to be composed in the final result
-# @title: Patch title
-function thread_for_process_patch()
-{
-  local id="$1"
-  local base_dir="$2"
-  local processed_line="$3"
-  local message_id_link="$4"
-  local title="$5"
-
-  processed_line+=$(extract_metadata_from_patch_title "$title" "$message_id_link")
-
-  printf '%s' "${processed_line}" > "${base_dir}/${id}"
-}
-
 # Some people set their names like "Second name, First name", this extra comma
 # is not ideal when dealing with emails. This function converts names as
 # "Second name, First name" to "First name Second name"
@@ -424,18 +354,22 @@ function process_name()
   printf '%s' "${full_name[1]} ${full_name[0]}"
 }
 
-# This function resets all data structures that represent the current lore
-# fetch session. A lore fetch session is constituted by an array with the
-# latest patchsets of a lore public mailing list ordered, the number of patchsets
-# processed (the size of the array), and the minimum exclusive index of the
-# response (see `MIN_INDEX` declaration).
+# This function resets all data structures that constitute the current fetch
+# session. Five elements define a fetch session:
+#   1. List of representative patches ordered from latest to earliest;
+#   2. Table with the metadata of all individual patches processed;
+#   3. Table with all representative patches processed;
+#   4. Total number of representative patches processed;
+#   5. Earliest page processed.
 function reset_current_lore_fetch_session()
 {
-  list_of_mailinglist_patches=()
-  PATCHSETS_PROCESSED=0
+  representative_patches=()
+  unset individual_patches_metadata
+  declare -Ag individual_patches_metadata
+  unset processed_representative_patches
+  declare -Ag processed_representative_patches
+  REPRESENTATIVE_PATCHES_PROCESSED=0
   MIN_INDEX=0
-  unset processed_patchsets
-  declare -Ag processed_patchsets
 }
 
 # This function composes a query URL to a public mailing list archived
@@ -480,126 +414,194 @@ function compose_lore_query_url_with_verification()
   printf '%s' "$query_url"
 }
 
-# This function pre-processes an XML file containing a list of patches, extracting
-# just the metadata needed to process an XML element representing a patch. The `xpath`
-# command is used to capture the desired fields for each patch. A simplified example
-# of an XML element representing a patch is:
+# This function pre-processes a raw XML containing a list of patches. The `xpath`
+# command is used to capture the desired fields for each patch. A simplified
+# example of an XML element that represents a patch is (the thr:in-reply-to field
+# is optional):
 #   <entry>
 #     <author>
-#       <name>David Tadokoro</name>
-#       <email>davidbtadokoro@usp.br</email>
+#       <name>John Smith</name>
+#       <email>john@smith.com</email>
 #     </author>
-#     <title>[PATCH] drm/amdkfd: Fix memory allocation</title>
+#     <title>[PATCH] dir/subdir: Fix bug xpto</title>
 #     <updated>2023-08-09T21:27:00Z</updated>
-#     <link href="http://lore.kernel.org/amd-gfx/20230809212615.137674-1-davidbtadokoro@usp.br/"/>
+#     <link href="http://lore.kernel.org/list/0xc0ffee-4-john@smith.com/"/>
+#     <thr:in-reply-to href="http://lore.kernel.org/list/0xc0ffee-0-john@smith.com/"/>
 #   </entry>
 #
 # The pre-processed version of this example element would be:
-#   David Tadokoro
-#   davidbtadokoro@usp.br
-#   [PATCH] drm/amdkfd: Fix memory allocation
-#    href="http://lore.kernel.org/amd-gfx/20230809212615.137674-1-davidbtadokoro@usp.br/"
+#   John Smith
+#   john@smith.com
+#   [PATCH] dir/subdir: Fix bug xpto
+#   2023-08-09T21:27:00Z
+#   href="http://lore.kernel.org/list/0xc0ffee-4-john@smith.com/"
+#   href="http://lore.kernel.org/list/0xc0ffee-0-john@smith.com/"
 #
-# @xml_file_path: Path to XML file
+# @raw_xml: String with raw XML.
 #
 # Return:
 # The status code is the same as the `xpath` command and the pre-processed XML file
 # is outputted to the standard output
-function pre_process_xml_result()
+function pre_process_raw_xml()
 {
-  local xml_file_path="$1"
+  local raw_xml="$1"
   local xpath_query
-  local raw_xml
+  local xpath_output
   local -r NAME_EXP='//entry/author/name/text()'
   local -r EMAIL_EXP='//entry/author/email/text()'
   local -r TITLE_EXP='//entry/title/text()'
+  local -r UPDATED_EXP='//entry/updated/text()'
   local -r LINK_EXP='//entry/link/@href'
+  local -r IN_REPLY_TO_EXP='//entry/thr:in-reply-to/@href'
 
-  raw_xml=$(< "$xml_file_path")
-  xpath_query="${NAME_EXP}|${EMAIL_EXP}|${TITLE_EXP}|${LINK_EXP}"
-  printf '%s' "$raw_xml" | xpath -q -e "$xpath_query"
+  xpath_query="${NAME_EXP}|${EMAIL_EXP}|${TITLE_EXP}|${UPDATED_EXP}|${LINK_EXP}|${IN_REPLY_TO_EXP}"
+  xpath_output=$(printf '%s' "$raw_xml" | xpath -q -e "$xpath_query" | sed 's/^[ \t]*//')
+
+  printf '%s\n ' "$xpath_output"
 }
 
-# This function converts a list of patches into a list of patchsets stored
-# in the `list_of_mailinglist_patches` array. A patchset differs from a
-# single patch, because the first includes all patches in a series of patches
-# which can have different version. For each multipart patchset, the first patch
-# is either a cover letter or a actual patch and is the representative of the
-# patchset. This patch metadata is the one stored in `list_of_mailinglist_patches`.
+# This function processes a list of individual patches from an Atom feed into an
+# indexed array that is passed as reference. All patches that are processed in
+# this function are marked in the `individual_patches_metadata` global hastable.
+# The order of patches in the resulting `@_individual_patches` array is the same
+# order as in the Atom feed.
 #
-# @pre_processed_patches: String containing a list of pre-processed patches
-# TODO:
-# - The function `is_introduction_patch` basically filters which patch is a
-#   representative of the patchset by the message-ID. Some valid representatives
-#   are wrongly filtered out, because of what the function considers a message-ID
-#   from a representative.
-# - The function `extract_metadata_from_patch_title` called by `thread_for_process_patch`
-#   counts the cover letter as a patch which results in patchsets with cover letters
-#   having one more patch than in reality.
-function process_patchsets()
+# @raw_xml: String with Atom feed containing the list of individual patches.
+# @_individual_patches: Indexed array reference to store processed patches.
+function process_individual_patches()
 {
-  local pre_processed_patches="$1"
-  local shared_dir_for_parallelism
-  local processed_patchset
-  local starting_index
-  local patch_title
-  local patch_url
-  local count
-  local line
-  local pids
-  local i
+  local raw_xml="$1"
+  local -n _individual_patches="$2"
+  local pre_processed_patches
+  local message_id=''
+  local message_title=''
+  local author_name=''
+  local author_email=''
+  local version=''
+  local number_in_series=''
+  local total_in_series=''
+  local updated=''
+  local in_reply_to=''
+  local patch_metadata=''
+  local patch_attribute_number=0
+  local i=0
 
-  shared_dir_for_parallelism=$(create_shared_memory_dir)
+  pre_processed_patches=$(pre_process_raw_xml "$raw_xml")
 
-  starting_index="$PATCHSETS_PROCESSED"
-  count=0
-  i=0
+  while IFS=$'\n' read -r line; do
+    if [[ "$patch_attribute_number" == 5 ]]; then
+      patch_attribute_number=0
 
-  while IFS= read -r line; do
-    if [[ "$line" =~ ^[[:space:]]href= ]]; then
-      patch_url=$(str_get_value_under_double_quotes "$line")
+      patch_metadata=$(get_patch_metadata "$message_title")
+      version=$(get_patch_version "$patch_metadata")
+      number_in_series=$(get_patch_number_in_series "$patch_metadata")
+      total_in_series=$(get_patch_total_in_series "$patch_metadata")
+      message_title=$(remove_patch_metadata_from_message_title "$message_title" "$patch_metadata")
 
-      if [[ "${processed_patchsets["$patch_url"]}" != 1 ]] && is_introduction_patch "$patch_url"; then
-        # Processes each patch in parallel
-        thread_for_process_patch "$PATCHSETS_PROCESSED" "$shared_dir_for_parallelism" \
-          "$processed_patchset" "$patch_url" "$patch_title" &
-        pids[i]="$!"
+      # Mark individual patch as processed and store metadata
+      individual_patches_metadata["$message_id"]="${version},${number_in_series}"
+
+      _individual_patches["$i"]="${message_id}${SEPARATOR_CHAR}${message_title}${SEPARATOR_CHAR}"
+      _individual_patches["$i"]+="${author_name}${SEPARATOR_CHAR}${author_email}${SEPARATOR_CHAR}"
+      _individual_patches["$i"]+="${version}${SEPARATOR_CHAR}${number_in_series}${SEPARATOR_CHAR}"
+      _individual_patches["$i"]+="${total_in_series}${SEPARATOR_CHAR}${updated}${SEPARATOR_CHAR}"
+
+      # In case the patch has a 'In-Reply-To' field, `line` contains this value,
+      # so process it and read next line of pre processed.
+      if [[ "$line" =~ ^href= ]]; then
+        in_reply_to=$(str_get_value_under_double_quotes "$line")
+        _individual_patches["$i"]+="$in_reply_to"
         ((i++))
-        ((PATCHSETS_PROCESSED++))
-        processed_patchsets["$patch_url"]=1
+        continue
       fi
 
-      processed_patchset=''
-      count=0
-      continue
+      ((i++))
     fi
 
-    # Based on the way that we build our xpath expression, we can rely on this sequence:
-    # Name, Email, Title, Link
-    # Since we have a dedicated function to extract title metadata, we want to
-    # save the title in a separated variable for later processing.
-    case "$count" in
-      0) # NAME
-        processed_patchset="$(process_name "$line")${SEPARATOR_CHAR}"
+    case "$patch_attribute_number" in
+      0) # Author's name
+        author_name=$(process_name "$line")
         ;;
-      1) # EMAIL
-        processed_patchset+="${line}${SEPARATOR_CHAR}"
+      1) # Author's email
+        author_email="$line"
         ;;
-      2) # TITLE
-        patch_title="$line"
+      2) # Message title
+        message_title="$line"
+        ;;
+      3) # Updated
+        updated="$line"
+        updated=$(printf '%s' "$updated" | sed 's/-/\//g' | sed 's/T/ /')
+        updated="${updated:0:-4}"
+        ;;
+      4) # Message-ID
+        message_id=$(str_get_value_under_double_quotes "$line")
         ;;
     esac
 
-    ((count++))
+    ((patch_attribute_number++))
   done <<< "$pre_processed_patches"
+}
 
-  # Wait for specific PID to avoid interfering in other functionalities.
-  for pid in "${pids[@]}"; do
-    wait "$pid"
-  done
+# This function processes representative patches (i.e. the first message in a
+# patchset) from a list of processed individual patches. The patches determined
+# as representatives are stored (in the same order as the argument
+# `@_individual_patches_array`) in the global indexed array
+# `representative_patches`. It uses `processed_representative_patches`, a global
+# hastable, to not duplicate representative patches. Subsequent calls of this
+# function append patches to `representative_patches` instead of resetting it
+# (this is done with the function `reset_current_lore_fetch_session`)
+#
+# @_individual_patches_array: Indexed array reference with processed list of
+#   individual patches.
+function process_representative_patches()
+{
+  local -n _individual_patches_array="$1"
+  local message_id
+  local in_reply_to_message_id
+  local -a patch_metadata
+  local -a in_reply_to_metadata
+  local is_representative_patch
 
-  for i in $(seq "$starting_index" "$((PATCHSETS_PROCESSED - 1))"); do
-    list_of_mailinglist_patches["$i"]=$(< "${shared_dir_for_parallelism}/${i}")
+  for patch in "${_individual_patches_array[@]}"; do
+    is_representative_patch=''
+    unset patch_dict
+    declare -A patch_dict
+
+    read_patch_into_dict "$patch" 'patch_dict'
+
+    # To avoid duplication, check if patch has been processed as representative
+    message_id="${patch_dict['message_id']}"
+    [[ -n "${processed_representative_patches["$message_id"]}" ]] && continue
+
+    # Assume that patch number 0 is always the representative as the cover letter
+    if [[ "${patch_dict['number_in_series']}" == 0 ]]; then
+      is_representative_patch=1
+    # Assume that, when there is no patch number 0, number 1 is the representative
+    elif [[ "${patch_dict['number_in_series']}" == 1 ]]; then
+      # Assume that patch number 1 without 'In-Reply-To' means no number 0
+      if [[ "${patch_dict['total_in_series']}" == 1 ||
+        -z "${patch_dict['in_reply_to']}" ]]; then
+        is_representative_patch=1
+      else
+        patch_metadata=()
+        in_reply_to_metadata=()
+        in_reply_to_message_id="${patch_dict['in_reply_to']}"
+        IFS=',' read -ra patch_metadata <<< "${individual_patches_metadata["$message_id"]}"
+        IFS=',' read -ra in_reply_to_metadata <<< "${individual_patches_metadata["$in_reply_to_message_id"]}"
+
+        # Assume that, if 'In-Reply-To' is not patch number 0 from the same
+        # version, number 1 is the representative
+        if [[ "${patch_metadata[0]}" != "${in_reply_to_metadata[0]}" || "${in_reply_to_metadata[1]}" != 0 ]]; then
+          is_representative_patch=1
+        fi
+      fi
+    fi
+
+    if [[ -n "$is_representative_patch" ]]; then
+      representative_patches["$REPRESENTATIVE_PATCHES_PROCESSED"]="$patch"
+      ((REPRESENTATIVE_PATCHES_PROCESSED++))
+      processed_representative_patches["${patch_dict['message_id']}"]=1
+    fi
   done
 }
 
@@ -611,18 +613,14 @@ function process_patchsets()
 #  2. Make a request to the URL built in step 1 to obtain a list of patches ordered
 #     by the recieved time on the lore.kernel.org servers.
 #  3. Process the list of patches to a list of patchsets stored in the
-#     `list_of_mailinglist_patches` array.
+#     `representative_patches` array.
 #
-# In case the number of patchsets in `list_of_mailinglist_patches` is less than
+# In case the number of patchsets in `representative_patches` is less than
 # `page` times `patchsets_per_page`, update `MIN_INDEX` and repeat steps 1 to 3.
 #
 # This function considers the totality of ordered patchsets in chunks of the same
 # size named pages. The `page` argument indicates until which page of the latest
 # patchsets should the fetch occur.
-#
-# Each entry in `list_of_mailinglist_patches` has the following patchset metadata
-# separated by `SEPARATOR_CHAR`:
-#   author name, author email, patchset version, number of patches, patch title, message-ID
 #
 # @target_mailing_list: A string name that matches the mailing list name
 #   registered to lore
@@ -642,10 +640,6 @@ function fetch_latest_patchsets_from()
   local patchsets_per_page="$3"
   local additional_filters="$4"
   local flag="$5"
-  local raw_xml
-  local lore_query_url
-  local xml_result_file_name
-  local pre_processed_patches
   local xml_result_file_name
   local lore_query_url
   local raw_xml
@@ -654,7 +648,7 @@ function fetch_latest_patchsets_from()
   flag=${flag:-'SILENT'}
   xml_result_file_name="${target_mailing_list}-patches.xml"
 
-  while [[ "$PATCHSETS_PROCESSED" -lt "$((page * patchsets_per_page))" ]]; do
+  while [[ "$REPRESENTATIVE_PATCHES_PROCESSED" -lt "$((page * patchsets_per_page))" ]]; do
     # Building URL for querying lore servers for a xml file with patches.
     lore_query_url=$(compose_lore_query_url_with_verification "$target_mailing_list" "$MIN_INDEX" "$additional_filters")
     ret="$?"
@@ -679,25 +673,23 @@ function fetch_latest_patchsets_from()
       break
     fi
 
-    # Processing patches into patchsets that will be stored in `list_of_mailinglist_patches`.
-    pre_processed_patches=$(pre_process_xml_result "${CACHE_LORE_DIR}/${xml_result_file_name}")
-    # TODO: Is passing `pre_processed_patches` (huge string) as argument a possible bottleneck?
-    process_patchsets "$pre_processed_patches"
+    process_individual_patches "$raw_xml" 'individual_patches'
+    process_representative_patches 'individual_patches'
 
     # Update minimum exclusive index.
     MIN_INDEX=$((MIN_INDEX + LORE_PAGE_SIZE))
   done
 }
 
-# This function formats a range of patchsets metadata from `list_of_mailinglist_patches`
+# This function formats a range of patchsets metadata from `representative_patches`
 # into an array reference passed as argument. The format of the metadata follows the
 # pattern:
 #
 #  V <version_of_patchset> | #<number_of_patches> | <patchset_title>
 #
 # @_formatted_patchsets_list: Array reference to output formatted range of patchsets metadata
-# @starting_index: Starting index of range from `list_of_mailinglist_patches`
-# @ending_index: Ending index of range `list_of_mailinglist_patches`
+# @starting_index: Starting index of range from `representative_patches`
+# @ending_index: Ending index of range `representative_patches`
 function format_patchsets()
 {
   local -n _formatted_patchsets_list="$1"
@@ -706,15 +698,15 @@ function format_patchsets()
   declare -A patchset
 
   for i in $(seq "$starting_index" "$ending_index"); do
-    parse_raw_patchset_data "${list_of_mailinglist_patches["$i"]}" 'patchset'
-    _formatted_patchsets_list["$i"]=$(printf 'V%-2s |#%-3s|' "${patchset['patchset_version']}" "${patchset['total_patches']}")
-    _formatted_patchsets_list["$i"]+=$(printf ' %-100s' "${patchset['patchset_title']}")
+    read_patch_into_dict "${representative_patches["$i"]}" 'patchset'
+    _formatted_patchsets_list["$i"]=$(printf 'V%-2s |#%-3s| ' "${patchset['version']}" "${patchset['total_in_series']}")
+    _formatted_patchsets_list["$i"]+=$(printf ' %-100s' "${patchset['message_title']}")
   done
 }
 
-# This function outputs the starting index in the `list_of_mailinglist_patches` array of a given
-# page, i.e., if the patchsets of the page 2 are from `list_of_mailinglist_patches[30]` until
-# `list_of_mailinglist_patches[59]`, this function outputs '30'.
+# This function outputs the starting index in the `representative_patches` array of a given
+# page, i.e., if the patchsets of the page 2 are from `representative_patches[30]` until
+# `representative_patches[59]`, this function outputs '30'.
 #
 # @page: Number of the target page.
 # @patchsets_per_page: Number of patchsets per page
@@ -725,16 +717,16 @@ function get_page_starting_index()
   local starting_index
 
   starting_index=$(((page - 1) * patchsets_per_page))
-  # Avoid an starting index greater than the max index of `list_of_mailinglist_patches`
-  if [[ "$starting_index" -gt "$((${#list_of_mailinglist_patches[@]} - 1))" ]]; then
-    starting_index=$((${#list_of_mailinglist_patches[@]} - 1))
+  # Avoid an starting index greater than the max index of `representative_patches`
+  if [[ "$starting_index" -gt "$((${#representative_patches[@]} - 1))" ]]; then
+    starting_index=$((${#representative_patches[@]} - 1))
   fi
   printf '%s' "$starting_index"
 }
 
-# This function outputs the ending index in the `list_of_mailinglist_patches` array of a given
-# page, i.e., if the patchsets of the page 2 are from `list_of_mailinglist_patches[30]` until
-# `list_of_mailinglist_patches[59]`, this function outputs '59'.
+# This function outputs the ending index in the `representative_patches` array of a given
+# page, i.e., if the patchsets of the page 2 are from `representative_patches[30]` until
+# `representative_patches[59]`, this function outputs '59'.
 #
 # @page: Number of the target page
 # @patchsets_per_page: Number of patchsets per page
@@ -745,9 +737,9 @@ function get_page_ending_index()
   local ending_index
 
   ending_index=$(((page * patchsets_per_page) - 1))
-  # Avoid an ending index greater than the max index of `list_of_mailinglist_patches`
-  if [[ "$ending_index" -gt "$((${#list_of_mailinglist_patches[@]} - 1))" ]]; then
-    ending_index=$((${#list_of_mailinglist_patches[@]} - 1))
+  # Avoid an ending index greater than the max index of `representative_patches`
+  if [[ "$ending_index" -gt "$((${#representative_patches[@]} - 1))" ]]; then
+    ending_index=$((${#representative_patches[@]} - 1))
   fi
   printf '%s' "$ending_index"
 }
@@ -872,7 +864,7 @@ function create_lore_bookmarked_file()
 # Note that the function assumes that the `@raw_patchset` passed as argument contains the
 # necessary attributes and is correctly formatted, leaving this responsability to the caller.
 #
-# @raw_patchset: Raw data of patchset in the same format as list_of_mailinglist_patches
+# @raw_patchset: Raw data of patchset in the same format as representative_patches
 #   to be added to the local bookmarked database
 # @download_dir_path: The directory where the patchset .mbx was saved
 function add_patchset_to_bookmarked_database()
@@ -953,8 +945,6 @@ function get_bookmarked_series()
   declare -A series
   local index=0
   local timestamp
-  local patch_title
-  local patch_author
   local tmp_data
 
   if [[ ! -f "${BOOKMARKED_SERIES_PATH}" ]]; then
@@ -964,8 +954,8 @@ function get_bookmarked_series()
   _bookmarked_series=()
 
   while IFS='' read -r raw_patchset; do
-    parse_raw_patchset_data "${raw_patchset}" 'series'
-    tmp_data=$(printf ' %s | %-70s | %s' "${series['timestamp']}" "${series['patchset_title']}" "${series['patchset_author']}")
+    read_patch_into_dict "${raw_patchset}" 'series'
+    tmp_data=$(printf ' %s | %-70s | %s' "${series['timestamp']}" "${series['message_title']}" "${series['author_name']}")
     _bookmarked_series["$index"]="${tmp_data}"
     ((index++))
   done < "${BOOKMARKED_SERIES_PATH}"
@@ -996,32 +986,37 @@ function get_bookmarked_series_by_index()
   printf '%s' "${target_patch}"
 }
 
-# This function parses raw data that represents a patchset instance into
-# an associative array passed as reference. This function assumes that the
+# This function parses raw data that represents a patch instance into an
+# associative array passed as reference. This function assumes that the
 # raw data has attributes in the following order:
-#   patchset_author, author_email, patchset_version, total_patches, patchset_title,
-#   patchset_url, download_dir_path, timestamp.
+#   message ID, message title, author name, author email, version,
+#   patch number in series, total in series, updated time, in reply to (optional),
+#   download directory path (bookmark exclusive), and timestamp (bookmark exclusive)
 #
 # Note that the function doesn't verifies if the attributes are non-empty or
-# valid (i.e. represent a valid patchset instance), passing the responsability to
+# valid (i.e. represent a valid patch instance), passing the responsability to
 # the caller.
 #
-# @raw_patchset: Raw data of patchset in the same format as list_of_mailinglist_patches
-function parse_raw_patchset_data()
+# @raw_patch: Raw data of patch in the same format as in `representative_patches`
+# @_dict: Associative array reference to store parsed patch.
+function read_patch_into_dict()
 {
-  local raw_patchset="$1"
-  local -n _patchset="$2"
+  local raw_patch="$1"
+  local -n _dict="$2"
   local columns
 
-  IFS="${SEPARATOR_CHAR}" read -ra columns <<< "${raw_patchset}"
-  _patchset['patchset_author']="${columns[0]}"
-  _patchset['author_email']="${columns[1]}"
-  _patchset['patchset_version']="${columns[2]}"
-  _patchset['total_patches']="${columns[3]}"
-  _patchset['patchset_title']="${columns[4]}"
-  _patchset['patchset_url']="${columns[5]}"
-  _patchset['download_dir_path']="${columns[6]}"
-  _patchset['timestamp']="${columns[7]}"
+  IFS="${SEPARATOR_CHAR}" read -ra columns <<< "$raw_patch"
+  _dict['message_id']="${columns[0]}"
+  _dict['message_title']="${columns[1]}"
+  _dict['author_name']="${columns[2]}"
+  _dict['author_email']="${columns[3]}"
+  _dict['version']="${columns[4]}"
+  _dict['number_in_series']="${columns[5]}"
+  _dict['total_in_series']="${columns[6]}"
+  _dict['updated']="${columns[7]}"
+  _dict['in_reply_to']="${columns[8]}"
+  _dict['download_dir_path']="${columns[9]}"
+  _dict['timestamp']="${columns[10]}"
 }
 
 # This function gets the bookmark status of a patchset, 0 being not in the local

--- a/src/ui/patch_hub/latest_patchsets_from_mailing_list.sh
+++ b/src/ui/patch_hub/latest_patchsets_from_mailing_list.sh
@@ -17,7 +17,7 @@ function show_latest_patchsets_from_mailing_list()
   create_async_loading_screen_notification "Loading patchsets from ${current_mailing_list} list" &
   loading_pid="$!"
 
-  # Query patches from mailing list, this info will be saved at `list_of_mailinglist_patches[@]`.
+  # Query patches from mailing list, this info will be saved at `representative_patches[@]`.
   fetch_latest_patchsets_from "$current_mailing_list" "$PAGE" "${lore_config['patchsets_per_page']}" "$additional_filters"
   ret="$?"
   stop_async_loading_screen_notification "$loading_pid"
@@ -49,7 +49,7 @@ function show_latest_patchsets_from_mailing_list()
   case "$ret" in
     0) # OK
       screen_sequence['PREVIOUS_SCREEN']='latest_patchsets_from_mailing_list'
-      screen_sequence['SHOW_SCREEN_PARAMETER']=${list_of_mailinglist_patches["$menu_return_string"]}
+      screen_sequence['SHOW_SCREEN_PARAMETER']=${representative_patches["$menu_return_string"]}
       screen_sequence['SHOW_SCREEN']='patchset_details_and_actions'
       ;;
     1) # Next

--- a/src/ui/patch_hub/patch_hub_core.sh
+++ b/src/ui/patch_hub/patch_hub_core.sh
@@ -218,7 +218,7 @@ function list_patches()
       case "${screen_sequence['SHOW_SCREEN']}" in
         'latest_patchsets_from_mailing_list')
           screen_sequence['PREVIOUS_SCREEN']='latest_patchsets_from_mailing_list'
-          screen_sequence['SHOW_SCREEN_PARAMETER']=${list_of_mailinglist_patches["$menu_return_string"]}
+          screen_sequence['SHOW_SCREEN_PARAMETER']=${representative_patches["$menu_return_string"]}
           ;;
         'bookmarked_patches')
           screen_sequence['PREVIOUS_SCREEN']='bookmarked_patches'

--- a/src/ui/patch_hub/patchset_details_and_actions.sh
+++ b/src/ui/patch_hub/patchset_details_and_actions.sh
@@ -14,15 +14,14 @@ function show_patchset_details_and_actions()
   local patch_metadata
   local message_box
 
-  parse_raw_patchset_data "${raw_patchset}" 'patchset'
-  patch_metadata=$(prettify_string 'Series:' "${patchset['patchset_title']}")
-  patch_metadata+=$(prettify_string 'Author:' "${patchset['patchset_author']}")
-  patch_metadata+=$(prettify_string 'Version:' "${patchset['patchset_version']}")
-  patch_metadata+=$(prettify_string 'Patches:' "${patchset['total_patches']}")
+  read_patch_into_dict "$raw_patchset" 'patchset'
+  patch_metadata=$(prettify_string 'Series:' "${patchset['message_title']}")
+  patch_metadata+=$(prettify_string 'Author:' "${patchset['author_name']}")
+  patch_metadata+=$(prettify_string 'Version:' "${patchset['version']}")
+  patch_metadata+=$(prettify_string 'Patches:' "${patchset['total_in_series']}")
   message_box="$patch_metadata"
 
-  # actions_starting_status[0]=$(get_patchset_download_status "${patchset['patchset_url']}" "${lore_config['save_patches_to']}")
-  actions_starting_status[1]=$(get_patchset_bookmark_status "${patchset['patchset_url']}")
+  actions_starting_status[1]=$(get_patchset_bookmark_status "${patchset['message_id']}")
 
   create_simple_checklist 'Patchset details and actions' "$message_box" 'actions_list' 'actions_starting_status' 1
   ret="$?"
@@ -114,16 +113,16 @@ function handle_download_action()
         return
       fi
 
-      create_async_loading_screen_notification 'Downloading patchset'$'\n'"${_patchset['patchset_title']}" &
+      create_async_loading_screen_notification 'Downloading patchset'$'\n'"${_patchset['message_title']}" &
       loading_pid="$!"
 
-      output=$(download_series "${_patchset['patchset_url']}" "$download_dir_path")
+      output=$(download_series "${_patchset['message_id']}" "$download_dir_path")
       ret="$?"
       stop_async_loading_screen_notification "$loading_pid"
       if [[ "$ret" != 0 ]]; then
-        create_message_box 'Error' 'Could not download patchset:'$'\n'"${_patchset['patchset_title']}"$'\n'"[error message] ${output}"
+        create_message_box 'Error' 'Could not download patchset:'$'\n'"${_patchset['message_title']}"$'\n'"[error message] ${output}"
       else
-        message_box='Downloaded patchset:'$'\n'"- ${_patchset['patchset_title']}"$'\n'$'\n'
+        message_box='Downloaded patchset:'$'\n'"- ${_patchset['message_title']}"$'\n'$'\n'
         message_box+='Filepath:'$'\n'"$output"
         create_message_box 'Success' "$message_box"
       fi
@@ -155,24 +154,24 @@ function handle_bookmark_action()
   local loading_pid
   local ret
 
-  output=$(download_series "${_patchset['patchset_url']}" "${lore_config['save_patches_to']}")
+  output=$(download_series "${_patchset['message_id']}" "${lore_config['save_patches_to']}")
   if [[ "$?" != 0 ]]; then
-    create_message_box 'Error' 'Could not download patchset:'$'\n'"- ${_patchset['patchset_title']}"$'\n'"[error message] ${output}"
+    create_message_box 'Error' 'Could not download patchset:'$'\n'"- ${_patchset['message_title']}"$'\n'"[error message] ${output}"
     return
   fi
 
-  create_async_loading_screen_notification 'Bookmarking patchset'$'\n'"- ${_patchset['patchset_title']}" &
+  create_async_loading_screen_notification 'Bookmarking patchset'$'\n'"- ${_patchset['message_title']}" &
   loading_pid="$!"
 
   add_patchset_to_bookmarked_database "${raw_patchset}" "${lore_config['save_patches_to']}"
   ret="$?"
   stop_async_loading_screen_notification "$loading_pid"
   if [[ "$ret" != 0 ]]; then
-    create_message_box 'Error' 'Could not bookmark patchset'$'\n'"- ${_patchset['patchset_title']}"
+    create_message_box 'Error' 'Could not bookmark patchset'$'\n'"- ${_patchset['message_title']}"
     return
   fi
 
-  message_box='Bookmarked patchset:'$'\n'"- ${_patchset['patchset_title']}"$'\n'$'\n'
+  message_box='Bookmarked patchset:'$'\n'"- ${_patchset['message_title']}"$'\n'$'\n'
   message_box+='Downloaded mbox file to:'$'\n'"$output"
   create_message_box 'Success' "$message_box"
 }
@@ -186,18 +185,18 @@ function handle_remove_bookmark_action()
   local -n _patchset="$1"
   local message_box
 
-  delete_series_from_local_storage "${lore_config['save_patches_to']}" "${_patchset['patchset_url']}"
+  delete_series_from_local_storage "${lore_config['save_patches_to']}" "${_patchset['message_id']}"
   if [[ "$?" != 0 ]]; then
-    create_message_box 'Warning' 'Could not delete patchset .mbx file'$'\n'"- ${_patchset['patchset_title']}"
+    create_message_box 'Warning' 'Could not delete patchset .mbx file'$'\n'"- ${_patchset['message_title']}"
     return
   fi
 
-  remove_patchset_from_bookmark_by_url "${_patchset['patchset_url']}"
+  remove_patchset_from_bookmark_by_url "${_patchset['message_id']}"
   if [[ "$?" != 0 ]]; then
-    create_message_box 'Error' 'Could not unbookmark patchset'$'\n'"- ${_patchset['patchset_title']}"
+    create_message_box 'Error' 'Could not unbookmark patchset'$'\n'"- ${_patchset['message_title']}"
     return
   fi
 
-  message_box='Removed bookmark from patchset:'$'\n'"- ${_patchset['patchset_title']}"$'\n'$'\n'
+  message_box='Removed bookmark from patchset:'$'\n'"- ${_patchset['message_title']}"$'\n'$'\n'
   create_message_box 'Success' "$message_box"
 }

--- a/tests/unit/lib/lore_test.sh
+++ b/tests/unit/lib/lore_test.sh
@@ -530,11 +530,11 @@ function test_get_bookmarked_series()
 
   get_bookmarked_series bookmarked_series
 
-  expected=' DATE1 | TITLE1                                                                 | AUTHOR1'
+  expected=' DATE1 | TITLE1                                                       | AUTHOR1'
   assertEquals "($LINENO)" "$expected" "${bookmarked_series[0]}"
-  expected=' DATE2 | TITLE2                                                                 | AUTHOR2'
+  expected=' DATE2 | TITLE2                                                       | AUTHOR2'
   assertEquals "($LINENO)" "$expected" "${bookmarked_series[1]}"
-  expected=' DATE3 | TITLE3                                                                 | AUTHOR3'
+  expected=' DATE3 | TITLE3                                                       | AUTHOR3'
   assertEquals "($LINENO)" "$expected" "${bookmarked_series[2]}"
 }
 
@@ -1168,22 +1168,22 @@ function test_format_patchsets()
   local -a formatted_patchsets_list
   local output
 
-  representative_patches[0]='message-id0Ætitle0Æauthor0Æemail0Æ2Æ1Æ6Æupdated0Æin-reply-to0Ædir0Ætimestamp0'
-  representative_patches[1]='message-id1Ætitle1Æauthor1Æemail1Æ1Æ0Æ3Æupdated1Æin-reply-to1Ædir1Ætimestamp1'
-  representative_patches[2]='message-id2Ætitle2Æauthor2Æemail2Æ16Æ1Æ8Æupdated2Æin-reply-to2Ædir2Ætimestamp2'
-  formatted_patchsets_list[0]='Vold |#old |  titleold'
+  representative_patches[0]='message-id0Ætitle0Æauthor0Æemail0Æ2Æ1Æ6Æupdated0 11:34Æin-reply-to0Ædir0Ætimestamp0'
+  representative_patches[1]='message-id1Ætitle1Æauthor1Æemail1Æ1Æ0Æ3Æupdated1 12:23Æin-reply-to1Ædir1Ætimestamp1'
+  representative_patches[2]='message-id2Ætitle2Æauthor2Æemail2Æ16Æ1Æ8Æupdated2 21:50Æin-reply-to2Ædir2Ætimestamp2'
+  formatted_patchsets_list[0]='Vold |#old |  titleold | updatedold | authorold'
 
   format_patchsets 'formatted_patchsets_list' 1 2
   assert_equals_helper 'Wrong number of patchsets formatted' "$LINENO" 3 "${#formatted_patchsets_list[@]}"
 
-  expected='Vold |#old |  titleold'
+  expected='Vold |#old |  titleold | updatedold | authorold'
   assert_equals_helper 'Should not overwrite out-of-range entry' "$LINENO" "$expected" "${formatted_patchsets_list[0]}"
 
-  expected='V1  |#3  |  title1'
+  expected='V1  |#3  | title1                                                       | updated1 | author1'
   output=$(printf '%s' "${formatted_patchsets_list[1]}" | sed 's/ *$//') # trim trailing whitespace
   assert_equals_helper 'Wrong formatted patchset 1' "$LINENO" "$expected" "$output"
 
-  expected='V16 |#8  |  title2'
+  expected='V16 |#8  | title2                                                       | updated2 | author2'
   output=$(printf '%s' "${formatted_patchsets_list[2]}" | sed 's/ *$//') # trim trailing whitespace
   assert_equals_helper 'Wrong formatted patchset 2' "$LINENO" "$expected" "$output"
 }

--- a/tests/unit/samples/lore/pre_processed_patches_sample-1
+++ b/tests/unit/samples/lore/pre_processed_patches_sample-1
@@ -1,12 +1,17 @@
 Gilberto Gil
 gil.gil@mpb.br
 [PATCH v3] Add Palco to MPB
- href="http://lore.kernel.org/mpb/introduction"
+2023-08-09T21:27:00Z
+href="http://lore.kernel.org/mpb/introduction"
 Tim Maia
 tim.maia@soul.br
 [PATCH 3/9] tim-maia/racional: Add Bom Senso to album
- href="http://lore.kernel.org/soul/sequel"
+2023-08-09T19:10:26Z
+href="http://lore.kernel.org/soul/sequel"
+href="http://lore.kernel.org/soul/introduction"
 David Bowie
 major.tom@rock.uk
 [RFC PATCH v12] Introduce Ziggy Stardust
- href="http://lore.kernel.org/rock/introduction"
+2023-08-09T19:10:22Z
+href="http://lore.kernel.org/rock/introduction"
+ 

--- a/tests/unit/samples/lore/pre_processed_patches_sample-2
+++ b/tests/unit/samples/lore/pre_processed_patches_sample-2
@@ -1,12 +1,17 @@
 Bob Marley
 bob.marley@reggae.jm
 [PATCH v2 7/10] bob-marley/survavil: Add One Drop to album
- href="http://lore.kernel.org/reggae/sequel"
+2023-08-09T21:27:00Z
+href="http://lore.kernel.org/reggae/sequel"
 Charlie Brown Jr.
 charlie.brown@punk.br
 [PATCH 3/13] cbj/camisa10: Add Só os Loucos Sabem to album
- href="http://lore.kernel.org/punk/sequel"
+2023-08-09T19:10:26Z
+href="http://lore.kernel.org/punk/sequel"
 Seu Jorge
 seu.jorge@samba-pop.br
 [RFC] Release Músicas para Churrasco Vol.1
- href="http://lore.kernel.org/samba-pop/introduction"
+2023-08-09T19:10:22Z
+href="http://lore.kernel.org/samba-pop/introduction"
+href="http://lore.kernel.org/samba-pop/request"
+ 

--- a/tests/unit/samples/lore/query_result_sample-2.xml
+++ b/tests/unit/samples/lore/query_result_sample-2.xml
@@ -2,12 +2,12 @@
 <feed xmlns="http://www.w3.org/2005/Atom" xmlns:thr="http://purl.org/syndication/thread/1.0">
 	<entry>
 		<author>
-			<name>Gilberto Gil</name>
-			<email>gil.gil@mpb.br</email>
+			<name>Bob Marley</name>
+			<email>bob.marley@reggae.jm</email>
 		</author>
-		<title>[PATCH v3] Add Palco to MPB</title>
+		<title>[PATCH v2 7/10] bob-marley/survavil: Add One Drop to album</title>
 		<updated>2023-08-09T21:27:00Z</updated>
-		<link href="http://lore.kernel.org/mpb/introduction"/>
+		<link href="http://lore.kernel.org/reggae/sequel"/>
 		<id>urn:uuid:2f9fa3da-2057-86a4-aa20-9ad0239ff7a3</id>
 		<content type="xhtml">
 			...
@@ -15,27 +15,27 @@
 	</entry>
 	<entry>
 		<author>
-			<name>Tim Maia</name>
-			<email>tim.maia@soul.br</email>
+			<name>Charlie Brown Jr.</name>
+			<email>charlie.brown@punk.br</email>
 		</author>
-		<title type="html">[PATCH 3/9] tim-maia/racional: Add Bom Senso to album</title>
+		<title type="html">[PATCH 3/13] cbj/camisa10: Add Só os Loucos Sabem to album</title>
 		<updated>2023-08-09T19:10:26Z</updated>
-		<link href="http://lore.kernel.org/soul/sequel"/>
+		<link href="http://lore.kernel.org/punk/sequel"/>
 		<id>urn:uuid:66fe77b1-55ad-6670-73ee-54e933cf5f63</id>
-		<thr:in-reply-to href="http://lore.kernel.org/soul/introduction"/>
 		<content type="xhtml">
 			...
 		</content>
 	</entry>
 	<entry>
 		<author>
-			<name>David Bowie</name>
-			<email>major.tom@rock.uk</email>
+			<name>Seu Jorge</name>
+			<email>seu.jorge@samba-pop.br</email>
 		</author>
-		<title type="html">[RFC PATCH v12] Introduce Ziggy Stardust</title>
+		<title type="html">[RFC] Release Músicas para Churrasco Vol.1</title>
 		<updated>2023-08-09T19:10:22Z</updated>
-		<link href="http://lore.kernel.org/rock/introduction"/>
+		<link href="http://lore.kernel.org/samba-pop/introduction"/>
 		<id>urn:uuid:b09294a9-df54-a8b1-cf19-6f58c2febdd3</id>
+		<thr:in-reply-to href="http://lore.kernel.org/samba-pop/request"/>
 		<content type="xhtml">
 			...
 		</content>

--- a/tests/unit/ui/patch_hub/patch_hub_core_test.sh
+++ b/tests/unit/ui/patch_hub/patch_hub_core_test.sh
@@ -52,7 +52,7 @@ function test_show_dashboard()
 function test_list_patches_with_patches()
 {
   local -a patchsets_metadata_array
-  declare -ag list_of_mailinglist_patches
+  declare -ag representative_patches
 
   # shellcheck disable=SC2317
   function create_menu_options()
@@ -66,14 +66,14 @@ function test_list_patches_with_patches()
     'more_patches_metadata'
   )
 
-  list_of_mailinglist_patches=(
+  representative_patches=(
     'some_patch_raw_data'
     'some_other_patch_raw_data'
     'more_patches_raw_data'
   )
 
   screen_sequence['SHOW_SCREEN']='latest_patchsets_from_mailing_list'
-  list_patches 'Message test' list_of_mailinglist_patches ''
+  list_patches 'Message test' representative_patches ''
   assert_equals_helper 'Wrong screen set' "$LINENO" 'patchset_details_and_actions' "${screen_sequence['SHOW_SCREEN']}"
   assert_equals_helper 'Wrong screen parameter' "$LINENO" 'more_patches_raw_data' "${screen_sequence['SHOW_SCREEN_PARAMETER']}"
 

--- a/tests/unit/ui/patch_hub/patchset_details_and_actions_test.sh
+++ b/tests/unit/ui/patch_hub/patchset_details_and_actions_test.sh
@@ -35,13 +35,13 @@ function tearDown()
 
 function test_show_patchset_details_and_actions()
 {
-  local raw_patchset='Juca PiramaÆjucapirama@xpto.comÆV1Æ255ÆDC Patches November 19, 2022Æhttp://anotherthing.la'
+  local raw_patchset='message_idÆmessage: titleÆJuca PiramaÆjuca@pirama.foo.barÆ4Æ8Æ42Æ2024/02/14 21:32Æin_reply_to_message_id'
   local output
   local expected_result='Patchset details and actions'
 
-  expected_result+=' \Zb\Z6Series:\ZnDC Patches November 19, 2022\n'
-  expected_result+='\Zb\Z6Author:\ZnJuca Pirama\n\Zb\Z6Version:\ZnV1\n'
-  expected_result+='\Zb\Z6Patches:\Zn255\n'
+  expected_result+=' \Zb\Z6Series:\Znmessage: title\n'
+  expected_result+='\Zb\Z6Author:\ZnJuca Pirama\n\Zb\Z6Version:\Zn4\n'
+  expected_result+='\Zb\Z6Patches:\Zn42\n'
   expected_result+=' Download to specific directory Bookmark'
 
   # shellcheck disable=SC2317
@@ -201,18 +201,18 @@ test_handle_remove_bookmark_action()
     return 0
   }
 
-  patchset['patchset_url']='https://lore.kernel.org/amd-gfx/20230622215735.2026220-1-Rodrigo.Siqueira@amd.com/'
+  patchset['message_id']='message-id'
   lore_config['save_patches_to']="$SHUNIT_TMPDIR"
-  mbx_file_path="${lore_config['save_patches_to']}/20230622215735.2026220-1-Rodrigo.Siqueira@amd.com.mbx"
+  mbx_file_path="${lore_config['save_patches_to']}/message-id.mbx"
   touch "$mbx_file_path"
-  printf 'https://lore.kernel.org/list/message-ID/' >> "$BOOKMARKED_SERIES_PATH"
+  printf '%s' "${patchset['message_id']}" >> "$BOOKMARKED_SERIES_PATH"
 
   handle_remove_bookmark_action 'patchset'
   [[ ! -f "$mbx_file_path" ]]
   assert_equals_helper 'Should have removed the .mbx file' "$LINENO" 0 "$?"
   output=$(< "$BOOKMARKED_SERIES_PATH")
   # shellcheck disable=SC2076
-  [[ ! "$output" =~ "${patchset['patchset_url']}" ]]
+  [[ ! "$output" =~ "${patchset['message_id']}" ]]
   assert_equals_helper 'Should have removed patchset entry from database' "$LINENO" 0 "$?"
 }
 


### PR DESCRIPTION
There are two major problems with the listing of patchsets in the `kw patch-hub` feature:

1. Inconsistent performance that at best revolves around 20+ seconds #911 
2. Incorrectly determining representative patches #900 

This PR aims to fix both. In the case of the first problem, we could consistently maintain, at worst, times below 20 seconds (didn't verify with all lists).