### PR TITLE
Add `--show-context` to kw explore

### DIFF
--- a/documentation/man/features/kw-explore.rst
+++ b/documentation/man/features/kw-explore.rst
@@ -7,7 +7,7 @@ kw-explore - Explore folder
 SYNOPSIS
 ========
 *kw* (*e* | *explore*) [(-l | \--log) | (-g | \--grep) | (-a | \--all) | \--verbose]
-                       [(-c | \--only-source) | (-H | \--only-header)] <expr>
+                       [(-c | \--only-source) | (-H | \--only-header)] [(-C[<num>] | \--show-context[=<num>])] <expr>
                        [-p] [<dir> | <file>]
 
 DESCRIPTION
@@ -45,5 +45,23 @@ OPTIONS
 -H | \--only-header:
   With this option, it is possible to show only the results from the header.
 
+-C[<num>] | \--show-context[=<num>]:
+  Show <num> lines of additional context above and below the matched line.
+  If <num> is not specified, the default value of 3 will be used.
+
 \--verbose:
   Verbose mode allows the user to see the commands executed under the hood.
+
+EXAMPLES
+========
+To show matched line with context using long-form flag::
+
+  kw explore --show-context=5 search_string
+
+To show matched line with context using short flag::
+
+  kw explore -C5 search_string
+
+Search through all tracked and untracked files, default value of 3 will be used for context::
+
+  kw explore -C --all search_string

--- a/src/_kw
+++ b/src/_kw
@@ -282,6 +282,7 @@ _kw_explore()
     '(-a --all -l --log -g --grep)'{-a,--all}'[search for all matches in files under or not git management]' \
     '(-c --only-source -H --only-header)'{-c,--only-source}'[show only results from the source]' \
     '(-H --only-header -c --only-source)'{-H,--only-header}'[show only results from the header]' \
+    '(-C --show-context)'{-C-,--show-context=-}'[set the context value]' \
     '1: : ' \
     '2: :_files'
 }

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -53,7 +53,7 @@ function _kw_autocomplete()
 
   kw_options['remote']='--add --remove --rename --list --global --set-default --verbose'
 
-  kw_options['explore']='--log --grep --all --only-header --only-source --exactly --verbose'
+  kw_options['explore']='--log --grep --all --only-header --only-source --exactly --show-context --verbose'
   kw_options['e']="${kw_options['explore']}"
 
   kw_options['pomodoro']='--set-timer --check-timer --show-tags --tag --description --help --verbose'

--- a/src/explore.sh
+++ b/src/explore.sh
@@ -15,6 +15,7 @@ function explore_main()
   local flag
   local search
   local path
+  local context
   local ret
 
   if [[ "$1" =~ -h|--help ]]; then
@@ -31,6 +32,7 @@ function explore_main()
   flag="${options_values['TEST_MODE']:-'SILENT'}"
   search="${options_values['SEARCH']}"
   path="${options_values['PATH']:-'.'}"
+  context="${options_values['CONTEXT']:-0}"
 
   [[ -n "${options_values['VERBOSE']}" ]] && flag='VERBOSE'
 
@@ -48,19 +50,19 @@ function explore_main()
 
   if [[ "${options_values['TYPE']}" -eq 2 ]]; then
     # Use GNU GREP
-    explore_files_gnu_grep "$search" "$path" "$flag"
+    explore_files_gnu_grep "$search" "$path" "$context" "$flag"
     return
   fi
 
   if [[ "${options_values['TYPE']}" -eq 3 ]]; then
     # Search in directories controlled or not by git
-    explore_all_files_git "$search" "$path" "$flag"
+    explore_all_files_git "$search" "$path" "$context" "$flag"
     return
   fi
 
   if [[ -z "${options_values['TYPE']}" ]]; then
     # Search in files under git control
-    explore_files_under_git "$search" "$path" "$flag"
+    explore_files_under_git "$search" "$path" "$context" "$flag"
     return
   fi
 }
@@ -75,8 +77,8 @@ function explore_main()
 # This function also set options_values
 function parse_explore_options()
 {
-  local long_options='log,grep,all,only-header,only-source,exactly,verbose'
-  local short_options='l,g,a,H,c'
+  local long_options='log,grep,all,only-header,only-source,exactly,verbose,show-context::'
+  local short_options='l,g,a,H,c,C::'
   local options
 
   if [[ "$#" -eq 0 ]]; then
@@ -97,6 +99,7 @@ function parse_explore_options()
   options_values['TYPE']=''
   options_values['SCOPE']=''
   options_values['EXACTLY']=''
+  options_values['CONTEXT']=''
   options_values['VERBOSE']=''
 
   eval "set -- $options"
@@ -160,6 +163,24 @@ function parse_explore_options()
         options_values['VERBOSE']=1
         shift
         ;;
+      --show-context | -C)
+        if [[ -n "${options_values['CONTEXT']}" ]]; then
+          options_values['ERROR']='Invalid arguments: Multiple context values!'
+          return 22 # EINVAL
+        fi
+
+        if [[ ! "$2" ]]; then
+          options_values['CONTEXT']=3
+        elif [[ ! "$2" =~ ^[0-9]+$ ]]; then
+          options_values['ERROR']='Context value must be a non-negative integer!'
+          return 22 # EINVAL
+        else
+          options_values['CONTEXT']="$2"
+          shift
+        fi
+
+        shift
+        ;;
       --) # End of options, beginning of arguments
         shift
         ;;
@@ -196,7 +217,7 @@ function explore_git_log()
 
   flag=${flag:-'SILENT'}
 
-  cmd_manager "$flag" "git log --grep='$search_string' $path"
+  cmd_manager "$flag" "git log --grep='${search_string}' ${path}"
 }
 
 # This function searches string in files under git control.
@@ -209,11 +230,12 @@ function explore_files_under_git()
 {
   local regex="$1"
   local path="$2"
-  local flag="$3"
+  local context="$3"
+  local flag="$4"
 
   flag=${flag:-'SILENT'}
 
-  cmd_manager "$flag" "git grep -e '$regex' -nI $path"
+  cmd_manager "$flag" "git grep --context ${context} -e '${regex}' --line-number -I ${path}"
 }
 
 # This function uses git grep tool to search string in files under or not git
@@ -228,11 +250,12 @@ function explore_all_files_git()
 {
   local regex="$1"
   local path="$2"
-  local flag="$3"
+  local context="$3"
+  local flag="$4"
 
   flag=${flag:-'SILENT'}
 
-  cmd_manager "$flag" "git grep --no-index -e '$regex' -nI $path"
+  cmd_manager "$flag" "git grep --no-index --context ${context} -e '${regex}' --line-number -I ${path}"
 }
 
 # This function allows the use of gnu grep utility to manages the search for
@@ -246,11 +269,12 @@ function explore_files_gnu_grep()
 {
   local regex="$1"
   local path="$2"
-  local flag="$3"
+  local context="$3"
+  local flag="$4"
 
   flag=${flag:-'SILENT'}
 
-  cmd_manager "$flag" "grep --color -nrI $path -e '$regex'"
+  cmd_manager "$flag" "grep --color --line-number --recursive -I ${path} --context ${context} -e '${regex}'"
 }
 
 function explore_help()
@@ -267,5 +291,6 @@ function explore_help()
     '  explore,e --all,-a <string> - Search for all <string> match under or not of git management' \
     '  explore,e --only-source,-c <string> - Search for all <string> in source files' \
     '  explore,e --only-header,-H <string> - Search for all <string> in header files' \
+    '  explore,e --show-context[=<num>],-C[<num>] <string> - Print <num> lines of output context (default: 3)' \
     '  explore,e --verbose - Show a detailed output'
 }


### PR DESCRIPTION
The issue proposed to use the batcat command but this commit uses the built-in -C flags in git grep and GNU grep instead, to avoid adding more dependencies to kw.

This commit also updates the docs as well as the tests for kw-explore.

Is the choice of using `-C` appropriate? Or would it be confusing because there is also the `-c` which exists. Please suggest your thoughts on this.

Closes: #1052