### PR TITLE
Add the Handbook index on documentation

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -26,6 +26,16 @@ check:
    content/developmentworkflow
    content/tracingandprofiling
 
+Kw Handbook
+===========
+
+Device and tips for new contributors.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Handbook:
+
+
 Kw code doc
 ===========
 


### PR DESCRIPTION
There is some information not covered by the current documentation, mainly those related to the project workflow that are not clear to new contributors.

add the new Handbook index in index.rst file.