### PR TITLE
Update the checkout action version in all workflows

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 

--- a/.github/workflows/kcov.yml
+++ b/.github/workflows/kcov.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 3
 

--- a/.github/workflows/shellcheck_reviewdog.yml
+++ b/.github/workflows/shellcheck_reviewdog.yml
@@ -6,7 +6,7 @@ jobs:
     name: runner / shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: shellcheck
         uses: reviewdog/action-shellcheck@v1
         with:

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -5,7 +5,7 @@ jobs:
   sh-checker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run the sh-checker
         uses: luizm/action-sh-checker@v0.3.0
         env:

--- a/.github/workflows/test_setup_and_docs.yml
+++ b/.github/workflows/test_setup_and_docs.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # This is here just because git-email cannot be installed in the 
       # Github CI otherwise.

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 3
 


### PR DESCRIPTION
GitHub actions using Node.js 16 are being deprecated. This also comes up as a warning in the workflow run logs. This commit updates the checkout actions version to v4 which uses Node.js 20.

I have tested the actions on my fork and they executed without any warnings.

![image](https://github.com/kworkflow/kworkflow/assets/89456541/0f137e8f-1e91-4a24-a744-b43dc3531f9f)
