### PR TITLE
Update `kw remote` documentation

### DIFF
--- a/documentation/man/features/kw-remote.rst
+++ b/documentation/man/features/kw-remote.rst
@@ -11,7 +11,7 @@ SYNOPSIS
 | *kw remote* [--global] \--remove <name>
 | *kw remote* [--global] \--rename <old-name> <new-name>
 | *kw remote* [--global] \--list
-| *kw remote* [--global] (-s | \--set-default)=<name>
+| *kw remote* [--global] -s<name> | \--set-default=<name>
 
 DESCRIPTION
 ===========
@@ -40,7 +40,7 @@ OPTIONS
 \--global:
   Force use global config file instead of the local one.
 
-\-s=<name>, \--set-default=<name>:
+\-s<name>, \--set-default=<name>:
   Set default remote to remote named <name>.
 
 \-v, \--verbose:
@@ -73,4 +73,3 @@ You can also list all your available remotes via::
 If you want to set the default remote::
 
   kw remote --set-default=new-default-remote
-

--- a/src/kw_remote.sh
+++ b/src/kw_remote.sh
@@ -428,7 +428,7 @@ function remote_help()
     '  remote [--global] --add <name> <USER@IP:PORT> [--set-default] - Add new remote' \
     '  remote [--global] --remove <name> - Remove remote' \
     '  remote [--global] --rename <old> <new> - Rename remote' \
-    '  remote [--global] --set-default=<remote-name> - Set default remote' \
+    '  remote [--global] --set-default=<remote-name>,-s<reomte-name> - Set default remote' \
     '  remote [--global] --list - List remotes' \
     '  remote [--global] (--verbose | -v) - be verbose'
 }


### PR DESCRIPTION
The -s being an optional argument the long form flag can read the argument with the "=" but the short flag cannot read  "=" or space.
This commit fixes the documentation to reflect the above points.

`-s<name` works but `-s=<name>` doesn't.