### PR TITLE
src: report: Fix the default error messages

### DIFF
--- a/src/report.sh
+++ b/src/report.sh
@@ -287,9 +287,8 @@ function show_report()
     done
     printf '\n'
   elif [[ -n "${options_values['STATISTICS']}" ]]; then
-    warning "${options_values['ERROR']}"
+    warning "kw doesn't have any statistics of the target period: ${target_period}"
   fi
-
   if [[ -n "${options_values['POMODORO']}" && -n "${pomodoro_raw_data}" ]]; then
     say "# Pomodoro Report: ${target_period}"
     printf '%s\n\n' "${pomodoro_metadata['ALL_TAGS']}"
@@ -299,7 +298,7 @@ function show_report()
       printf '%s\n%s\n' '- Sessions:' "${pomodoro_sessions["$tag"]}"
     done
   elif [[ -n "${options_values['POMODORO']}" ]]; then
-    warning "${options_values['ERROR']}"
+    warning "kw doesn't have any Pomodoro data of the target period: ${target_period}"
   fi
 }
 

--- a/tests/unit/report_test.sh
+++ b/tests/unit/report_test.sh
@@ -453,7 +453,7 @@ function test_show_report()
   statistics_raw_data=''
   options_values['ERROR']='Some error message'
   output=$(show_report)
-  expected='Some error message'
+  expected="kw doesn't have any statistics of the target period: ${target_period}"
   assert_equals_helper 'No statistics should result in error message' "$LINENO" "$expected" "$output"
 
   # Error message for Pomodoro
@@ -462,7 +462,7 @@ function test_show_report()
   pomodoro_raw_data=''
   options_values['ERROR']='Another error message'
   output=$(show_report)
-  expected='Another error message'
+  expected="kw doesn't have any Pomodoro data of the target period: ${target_period}"
   assert_equals_helper 'No Pomodoro data should result in error message' "$LINENO" "$expected" "$output"
 
   # Expect output for statistics


### PR DESCRIPTION
If the kw report is called without any arguments or with --all flag and the statistics and Pomodoro data are not present then ideally we should get two separate errors. It looks like this currently - 

![image](https://github.com/kworkflow/kworkflow/assets/89456541/3e846aa0-412a-41af-9d13-c62e554a8922)

Because the `options_values['ERROR']` value is getting overwritten in the 

I'm opening this PR for discussion and subsequent improvement, there could be a better way to implement this.

![image](https://github.com/kworkflow/kworkflow/assets/89456541/63a8cc46-41f9-45f6-8a30-d0330a76e976)
