### PR TITLE
src: pomodoro: added  --repeat-previous option to pomodoro

### DIFF
--- a/documentation/man/features/kw-pomodoro.rst
+++ b/documentation/man/features/kw-pomodoro.rst
@@ -9,6 +9,7 @@ SYNOPSIS
 | *kw* (*p* | *pomodoro*) (-t | \--set-timer) <time>(h | m | s) [(-g | \--tag) <tag> [(-d | \--description) <desc>] [\--verbose]]
 | *kw* (*p* | *pomodoro*) (-c | \--check-timer) [\--verbose]
 | *kw* (*p* | *pomodoro*) (-s | \--show-tags) [\--verbose]
+| *kw* (*p* | *pomodoro*) (\--repeat-previous) [\--verbose]
 
 DESCRIPTION
 ===========
@@ -55,6 +56,10 @@ OPTIONS
 -s, \--show-tags:
   This option shows all the registered tags.
 
+\--repeat-previous:
+  This option repeats the last Pomodoro timebox, with the same tag and description,
+  if applied.
+
 \--verbose:
   Display commands executed under the hood.
 
@@ -76,6 +81,10 @@ Create a Pomodoro timebox of 1 hour with tag name 'kernel-dev' and description
 'amd-gfx patch reviews'::
 
   kw pomodoro --set-timer 1h --tag 'kernel-dev' --description 'amd-gfx patch reviews'
+
+To repeat that same Pomodoro timebox, with the same tag name and description::
+
+  kw pomodoro --repeat-previous
 
 Create a Pomodoro timebox of 99 seconds with tag name corresponding to the tag
 of ID 42::

--- a/src/_kw
+++ b/src/_kw
@@ -429,6 +429,7 @@ _kw_pomodoro()
 
   _arguments : \
     '(--verbose)--verbose[enable verbose mode]' \
+    '(--repeat-previous)--repeat-previous[repeats the last Pomodoro session]' \
     '(-t --set-timer -c --check-timer -s --show-tags)'{-t,--set-timer}'[set the timer for the Pomodoro timebox]: : ' \
     '(-c --check-timer -t --set-timer -s --show-tags)'{-c,--check-timer}'[shows information of each active Pomodoro timebox]' \
     '(-s --show-tags -c --check-timer -t --set-timer)'{-s,--show-tags}'[shows registered tags]' \

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -56,7 +56,7 @@ function _kw_autocomplete()
   kw_options['explore']='--log --grep --all --only-header --only-source --exactly --show-context --verbose'
   kw_options['e']="${kw_options['explore']}"
 
-  kw_options['pomodoro']='--set-timer --check-timer --show-tags --tag --description --help --verbose'
+  kw_options['pomodoro']='--set-timer --check-timer --show-tags --tag --description --repeat-previous --help --verbose'
   kw_options['p']="${kw_options['pomodoro']}"
 
   kw_options['report']='--day --week --month --year --output --statistics --pomodoro --all --verbose'


### PR DESCRIPTION
`kw pomodoro --repeat-previous`allows the user to repeat the last pomodoro argument commands used by him, without having to type it all over again.

Resolves #1009