### PR TITLE
tests: unit: lib: lore_test: Replace TEST-MODE with TEST_MODE

### DIFF
--- a/tests/unit/lib/lore_test.sh
+++ b/tests/unit/lib/lore_test.sh
@@ -890,10 +890,10 @@ function test_get_raw_lore_message()
   local expected="curl --silent 'https://domain/list/message-id/raw'"
   local output
 
-  output=$(get_raw_lore_message 'http://domain/list/message-id/' 'TEST-MODE')
+  output=$(get_raw_lore_message 'http://domain/list/message-id/' 'TEST_MODE')
   assert_equals_helper 'Wrong command issued' "$LINENO" "$expected" "$output"
 
-  output=$(get_raw_lore_message 'http://domain/list/message-id' 'TEST-MODE')
+  output=$(get_raw_lore_message 'http://domain/list/message-id' 'TEST_MODE')
   assert_equals_helper 'Wrong command issued' "$LINENO" "$expected" "$output"
 }
 


### PR DESCRIPTION
The unit test test_get_raw_lore_message hangs because it needs an internet connection, which is not expected for a unit test. This error happened because of a typo in the unit test flag, which originally used TEST-MODE instead of TEST_MODE. This commit addresses this issue by using the correct flag.

Fixes: 9c4a5dd ("src: lib: lore: Handle patch not yet processed when electing representative")