### PR TITLE
tests: unit: lib: lore_test: Fix race condition in `test_thread_for_process_individual_patch`

### DIFF
--- a/tests/unit/lib/lore_test.sh
+++ b/tests/unit/lib/lore_test.sh
@@ -760,6 +760,7 @@ function test_thread_for_process_individual_patch()
     "$author_email1" "$updated1" "$line1" 0 "$shared_dir_path" &
   thread_for_process_individual_patch "$message_id2" "$message_title2" "$author_name2" \
     "$author_email2" "$updated2" "$line2" 1 "$shared_dir_path"
+  wait
 
   [[ -f "${shared_dir_path}/0" ]]
   # shellcheck disable=SC2319


### PR DESCRIPTION
[What]

In the test function `test_thread_for_process_individual_patch` there is
a race condition in the subsequent lines

  thread_for_process_individual_patch [...] "$shared_dir_path" &
  thread_for_process_individual_patch [...] "$shared_dir_path"

In the lines above, we launch two executions of
`thread_for_process_individual_patch`, one in the background (the first
one) and one to be executed in the main thread. The reasoning is that we
are testing the parallel aspect of the function, so we launch two
parallel threads of execution.

The problem is that the main thread finishes the second execution of
`thread_for_process_individual_patch` and starts making assertions on
the first execution of the function. This means that if the first
execution gets scheduled in a way that the main thread gets to the
assertions first, the test will fail, making these test cases flaky.

[How to reproduce race condition]

To reproduce the case in which the test fails, change the first
execution of `thread_for_process_individual_patch` to

  (sleep 5 && thread_for_process_individual_patch [...]) &

run the specific tests with `./run_tests.sh --unit test lib/lore_test`,
and see the fail.

[The fix]

Add a `wait` command to force the main thread to wait for the first
execution to end before making assertions about it.