### PR TITLE
src: plugins: kernel_install: utils: add regex support for kw d --uninstall

### DIFF
--- a/documentation/man/features/kw-deploy.rst
+++ b/documentation/man/features/kw-deploy.rst
@@ -85,9 +85,10 @@ OPTIONS
 -s, \--ls-line:
   List available kernels separated by comma.
 
--u <kernel-name>[,...], \--uninstall <kernel-name>[,...]:
+-u (<kernel-name> | regex:<pattern>)[,...], \--uninstall (<kernel-name> | regex:<pattern>)[,...]:
   Remove a single kernel or multiple kernels; for removing
-  multiple kernels it is necessary to separate them with comma.
+  multiple kernels it is necessary to separate them with comma. A regex pattern
+  can also be passed as input, prefixed with 'regex:'.
 
 -f, \--force:
   Remove kernels even if they were not installed by kw (only valid with
@@ -153,3 +154,21 @@ any other kw user. If you want to install a custom kernel from this package,
 you can use::
 
   kw deploy --from-package 5.19.0-THIS-IS-AN-EXAMPLE+.kw.tar
+
+Using kw deploy --uninstall:
+
+Uninstall argument can be a full kernel name.
+
+  kw deploy --uninstall kernel1
+
+Or a comma-separated list of full names.
+
+  kw deploy --uninstall kernel1,kernel2,kernel3
+
+Or a regular expression prefixed with regex: .
+
+  kw deploy --uninstall regex:kernel*
+
+Or a list comma-separated list of full names and regular expressions.
+
+  kw deploy --uninstall regex:kernel[1-3],kernel4,regex:kernel[5-6]

--- a/tests/unit/deploy_test.sh
+++ b/tests/unit/deploy_test.sh
@@ -684,6 +684,14 @@ function test_kernel_uninstall()
   deploy_remote_cmd+=" --uninstall-kernels '1' 'remote' '$single_kernel' 'TEST_MODE' ''"
   run_kernel_uninstall_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"$deploy_remote_cmd\""
   assert_equals_helper 'Reboot option' "$LINENO" "$run_kernel_uninstall_cmd" "$output"
+
+  # Kernel with regex
+  output=$(run_kernel_uninstall 3 1 "regex:(5.*-rc7)" 'TEST_MODE' '' 1)
+  deploy_remote_cmd="$DEPLOY_REMOTE_PREFIX"
+  deploy_remote_cmd+=" --uninstall-kernels '1' 'remote' 'regex:(5.*-rc7)' 'TEST_MODE' ''"
+  run_kernel_uninstall_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"$deploy_remote_cmd\""
+  assert_equals_helper 'Regex option' "$LINENO" "$run_kernel_uninstall_cmd" "$output"
+
 }
 
 function test_cleanup()


### PR DESCRIPTION
Currently, the command kw d --uninstall just supports a comma-separated kernel list, but for some cases it's better to provide a regex pattern that will match the desired kernels to be uninstalled.
   
Closes: #344 