### PR TITLE
Add documentation to single quotes use and fix codestyle for files in /src

### DIFF
--- a/documentation/content/codingstyle.rst
+++ b/documentation/content/codingstyle.rst
@@ -280,6 +280,18 @@ it stays consistent across multiple platforms. If you need to add extra lines
 while generating a string you can use the ``$'\n'`` literal to add a new line
 character or other special characters.
 
+Single quotes instead double quotes
+-----------------------------------
+
+Whenever you have a variable that stands for a string that doesn’t contain 
+shell expansions, use single quotes instead of double quotes. For example::
+
+  var='literal-value' #Single quotes
+
+or::
+
+  path="${HOME}/path/to/file" #Double quotes
+
 String concatenation
 --------------------
 

--- a/src/backup.sh
+++ b/src/backup.sh
@@ -134,7 +134,7 @@ function restore_config()
         complain "It looks like that the file $config_file differs from the backup version."
         cmd="diff -u --color=always ${KW_DATA_DIR}/configs/configs/${config_file} ${file}"
         cmd_manager "$flag" "$cmd"
-        if [[ $(ask_yN 'Do you want to replace it and its metadata?') =~ "0" ]]; then
+        if [[ $(ask_yN 'Do you want to replace it and its metadata?') =~ '0' ]]; then
           continue
         fi
       fi

--- a/src/debug.sh
+++ b/src/debug.sh
@@ -854,7 +854,7 @@ function convert_event_syntax_to_sys_path_hash()
       if [[ "$specific_event" =~ .*'['.*']'.* ]]; then
         specific_filter=${specific_event%]*}
         specific_filter=${specific_filter##*[}
-        specific_event=$(cut -d "[" -f1 <<< "$specific_event")
+        specific_event=$(cut -d '[' -f1 <<< "$specific_event")
       fi
 
       hash_key="${EVENT_BASE_PATH}/${root_event}/${specific_event}"

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -547,7 +547,7 @@ function prepare_remote_dir()
   distro_info=$(which_distro "$remote" "$port" "$user")
   distro=$(detect_distro '/' "$distro_info")
 
-  if [[ $distro =~ "none" ]]; then
+  if [[ "$distro" =~ 'none' ]]; then
     complain "Unfortunately, there's no support for '$distro_info'"
     exit 95 # ENOTSUP
   fi

--- a/src/explore.sh
+++ b/src/explore.sh
@@ -34,9 +34,9 @@ function explore_main()
 
   [[ -n "${options_values['VERBOSE']}" ]] && flag='VERBOSE'
 
-  if [[ "${options_values['SCOPE']}" == "HEADER" ]]; then
+  if [[ "${options_values['SCOPE']}" == 'HEADER' ]]; then
     path="${path}/*.h"
-  elif [[ "${options_values['SCOPE']}" == "SOURCE" ]]; then
+  elif [[ "${options_values['SCOPE']}" == 'SOURCE' ]]; then
     path="${path}/*.c"
   fi
 
@@ -80,7 +80,7 @@ function parse_explore_options()
   local options
 
   if [[ "$#" -eq 0 ]]; then
-    options_values['ERROR']="Expected string or parameter. See man for detail."
+    options_values['ERROR']='Expected string or parameter. See man for detail.'
     return 22 # EINVAL
   fi
 
@@ -105,7 +105,7 @@ function parse_explore_options()
     case "$1" in
       --log | -l)
         if [[ -n "${options_values['TYPE']}" && "${options_values['TYPE']}" -ne 1 ]]; then
-          options_values['ERROR']="Invalid arguments: Multiple search type!"
+          options_values['ERROR']='Invalid arguments: Multiple search type!'
           return 22 # EINVAL
         fi
 
@@ -114,7 +114,7 @@ function parse_explore_options()
         ;;
       --grep | -g)
         if [[ -n "${options_values['TYPE']}" && "${options_values['TYPE']}" -ne 2 ]]; then
-          options_values['ERROR']="Invalid arguments: Multiple search type!"
+          options_values['ERROR']='Invalid arguments: Multiple search type!'
           return 22 # EINVAL
         fi
 
@@ -123,7 +123,7 @@ function parse_explore_options()
         ;;
       --all | -a)
         if [[ -n "${options_values['TYPE']}" && "${options_values['TYPE']}" -ne 3 ]]; then
-          options_values['ERROR']="Invalid arguments: Multiple search type!"
+          options_values['ERROR']='Invalid arguments: Multiple search type!'
           return 22 # EINVAL
         fi
 
@@ -132,24 +132,24 @@ function parse_explore_options()
         ;;
       --only-header | -H)
         if [[ -n "${options_values['SCOPE']}" ]]; then
-          if [[ "${options_values['SCOPE']}" != "HEADER" ]]; then
-            options_values['ERROR']="Invalid arguments: Multiple search scope!"
+          if [[ "${options_values['SCOPE']}" != 'HEADER' ]]; then
+            options_values['ERROR']='Invalid arguments: Multiple search scope!'
             return 22 # EINVAL
           fi
         fi
 
-        options_values['SCOPE']="HEADER"
+        options_values['SCOPE']='HEADER'
         shift
         ;;
       --only-source | -c)
         if [[ -n "${options_values['SCOPE']}" ]]; then
-          if [[ "${options_values['SCOPE']}" != "SOURCE" ]]; then
-            options_values['ERROR']="Invalid arguments: Multiple search scope!"
+          if [[ "${options_values['SCOPE']}" != 'SOURCE' ]]; then
+            options_values['ERROR']='Invalid arguments: Multiple search scope!'
             return 22 # EINVAL
           fi
         fi
 
-        options_values['SCOPE']="SOURCE"
+        options_values['SCOPE']='SOURCE'
         shift
         ;;
       --exactly)
@@ -173,7 +173,7 @@ function parse_explore_options()
         elif [[ -z "${options_values['PATH']}" ]]; then
           options_values['PATH']="$1"
         else
-          options_values['ERROR']="Too many parameters"
+          options_values['ERROR']='Too many parameters'
           return 22 # EINVAL
         fi
         shift

--- a/src/kernel_config_manager.sh
+++ b/src/kernel_config_manager.sh
@@ -425,7 +425,7 @@ function fetch_config()
   cmd_manager "$flag" "$cmd"
 
   if [[ -f "${config_base_path}/${output}" ]]; then
-    if [[ -z "$force" && $(ask_yN "Do you want to overwrite ${output} in your current directory?") =~ "0" ]]; then
+    if [[ -z "$force" && "$(ask_yN "Do you want to overwrite ${output} in your current directory?")" =~ '0' ]]; then
       warning 'Operation aborted'
       return 125 #ECANCELED
     fi
@@ -480,7 +480,7 @@ function fetch_config()
         ;;
     esac
 
-    printf "%s" "$mods" > "${KW_CACHE_DIR}/lsmod"
+    printf '%s' "$mods" > "${KW_CACHE_DIR}/lsmod"
 
     cmd="make localmodconfig LSMOD=${KW_CACHE_DIR}/lsmod${output_kbuild_flag}"
 

--- a/src/lib/dialog_ui.sh
+++ b/src/lib/dialog_ui.sh
@@ -253,7 +253,7 @@ function spin_frame()
   local spin='⣾⣽⣻⢿⡿⣟⣯⣷'
 
   frame_offset=$(((frame_offset) % ${#spin}))
-  printf "%s" "${spin:$frame_offset:1}"
+  printf '%s' "${spin:$frame_offset:1}"
 }
 
 # Create simple async loading screen notification for delayed actions.

--- a/src/lib/kw_config_loader.sh
+++ b/src/lib/kw_config_loader.sh
@@ -107,8 +107,8 @@ function show_build_variables()
     [cflags]='Specify compilation flags'
   )
 
-  printf '%s\n' "  Kernel build options:"
-  local -n descriptions="build"
+  printf '%s\n' '  Kernel build options:'
+  local -n descriptions='build'
 
   print_array build_config build
 }
@@ -139,8 +139,8 @@ function show_deploy_variables()
     [strip_modules_debug_option]='Modules will be stripped after they are installed which will reduce the initramfs size'
   )
 
-  printf '%s\n' "  Kernel deploy options:"
-  local -n descriptions="deploy"
+  printf '%s\n' '  Kernel deploy options:'
+  local -n descriptions='deploy'
   print_array deploy_config deploy
 }
 
@@ -165,8 +165,8 @@ function show_mail_variables()
     [default_cc_recipients]='E-mail addresses to always be included as CC: recipients'
   )
 
-  printf '%s\n' "  kw mail options:"
-  local -n descriptions="mail"
+  printf '%s\n' '  kw mail options:'
+  local -n descriptions='mail'
   print_array mail_config mail
 }
 
@@ -192,8 +192,8 @@ function show_vm_variables()
     [mount_point]='VM mount point'
   )
 
-  printf '%s\n' "  Kernel vm options:"
-  local -n descriptions="vm"
+  printf '%s\n' '  Kernel vm options:'
+  local -n descriptions='vm'
   print_array vm_config vm
 }
 
@@ -217,8 +217,8 @@ function show_notification_variables()
     [visual_alert_command]='Command for visual notification'
   )
 
-  printf '%s\n' "  Kernel notification options:"
-  local -n descriptions="notification"
+  printf '%s\n' '  Kernel notification options:'
+  local -n descriptions='notification'
 
   print_array notification_config notification
 }
@@ -241,7 +241,7 @@ function show_lore_variables()
     [lists]='List that you want to follow'
   )
 
-  printf '%s\n' "  Kernel upstream Lore options:"
+  printf '%s\n' '  Kernel upstream Lore options:'
   local -n descriptions='lore'
 
   print_array lore_config lore

--- a/src/lib/kw_db.sh
+++ b/src/lib/kw_db.sh
@@ -313,7 +313,7 @@ function generate_where_clause()
     attribute="$(cut --delimiter=',' --fields=1 <<< "$clause")"
     value="${condition_array_ref["${clause}"]}"
 
-    if [[ "$clause" =~ "," ]]; then
+    if [[ "$clause" =~ ',' ]]; then
       relational_op=$(cut --delimiter=',' --fields=2 <<< "$clause")
     fi
 

--- a/src/lib/kw_time_and_date.sh
+++ b/src/lib/kw_time_and_date.sh
@@ -18,7 +18,7 @@ function sec_to_format()
   local value="$1"
   local format="$2"
 
-  value=${value:-"0"}
+  value=${value:-'0'}
   format=${format:-'+%H:%M:%S'}
 
   date -d@"$value" -u "$format"

--- a/src/mail.sh
+++ b/src/mail.sh
@@ -1103,7 +1103,7 @@ function parse_mail_options()
         fi
         # TODO: find a better way to handle spaces inside pass_option_to_send_email
         for i in "$@"; do
-          if [[ "${i}" =~ " " ]]; then
+          if [[ "${i}" =~ ' ' ]]; then
             pass_option_to_send_email+=" ${i@Q}"
           else
             pass_option_to_send_email+=" ${i}"


### PR DESCRIPTION
Add documentation for use of single quotes (') instead of double quotes when there are no Bash expansions. Also updated files in `/src` that didn't follow this rule.