### PR TITLE
documentation: man: update man pages to use correct config files

### DIFF
--- a/documentation/man/features/kw-build.rst
+++ b/documentation/man/features/kw-build.rst
@@ -40,7 +40,7 @@ OPTIONS
 
 -n, \--menu:
   The menu option invokes the kernel menuconfig. Notice that the default menu
-  config can be changed in the **kworkflow.config** file by setting a different
+  config can be changed in the **build.config** file by setting a different
   option in *menu_config*. If the user is working in a *cross-compile*
   environment, it is recommended to use this option to avoid messing with the
   config file manually.
@@ -48,7 +48,7 @@ OPTIONS
 -d, \--doc:
   The doc option provides a mechanism for building the kernel-doc; by default,
   it will build htmldocs. Users can change the default documentation output by
-  changing the parameter *doc_type* in the **kworkflow.config** file.
+  changing the parameter *doc_type* in the **build.config** file.
 
 -S, \--cpu-scaling:
   The cpu-scaling option lets the user set whichever CPU usage they want from
@@ -61,12 +61,12 @@ OPTIONS
 
 -w, \--warnings (1 | 2 | 3 | 12 | 13 | 23 | 123):
   This can be used to enable compilation warnings accordingly. You can set the
-  default log level via `build.config` file under the option `warning_level`.
+  default log level via **build.config** file under the option `warning_level`.
   Please check the kernel's ``make help`` for more info.
 
 -s, \--save-log-to=path:
   This option will save the full compilation log with the enabled warnings to
-  the specified path. You can set the default log path in the `build.config`
+  the specified path. You can set the default log path in the **build.config**
   file via `log_path` option.
 
 \--llvm:
@@ -104,8 +104,9 @@ OPTIONS
 
 EXAMPLES
 ========
-For these examples, we suppose the fields in your **kworkflow.config** file are
-already configured.
+For these examples, we assume that the relevant fields in your configuration 
+files (located by default in **.kw/**) have already been setup. We recommend
+the use of ``kw config`` for managing your local and global configurations.
 
 For building and installing a new module version based on the current kernel
 version, you can use::

--- a/documentation/man/features/kw-codestyle.rst
+++ b/documentation/man/features/kw-codestyle.rst
@@ -29,8 +29,9 @@ OPTIONS
 
 EXAMPLES
 ========
-For these examples, we suppose the fields in your **kworkflow.config** file are
-already configured.
+For these examples, we assume that the relevant fields in your configuration 
+files (located by default in **.kw/**) have already been setup. We recommend
+the use of ``kw config`` for managing your local and global configurations.
 
 For checking the code style::
 

--- a/documentation/man/features/kw-deploy.rst
+++ b/documentation/man/features/kw-deploy.rst
@@ -31,22 +31,23 @@ executed:
 
 You can specify the deploy target via command line by using the flag
 ``--remote <remote>:<port>`` (e.g., ``--remote 172.16.254.1:22``); however, if
-you do this frequently you will probably prefer to add this information to your
-local **kworkflow.config**. See the example below::
+you plan on deploying to the same remote frequently can benefit from using the
+``kw remote`` feature to save the SSH information in a configuration file
+used by kw, for example::
 
-  default_deploy_target=remote
-  ssh_user=root
-  ssh_ip=172.16.254.1
-  ssh_port=22
+  kw remote --add origin root@172.16.254.1
+
+For more information, check ``kw remote --help``
 
 If you want to install a new kernel version in your host machine, you can use
 the flag ``--local``; you will need to use your root password.
 
-Another typical operation when deploying a new kernel to a test machine, it is
-the reboot after the update. You can explicitly say it for **kw** by adding the
-flag ``--reboot``, add this to the **kworkflow.config** with::
+Another typical operation when deploying a new kernel to a test machine is
+rebooting after the update. You can add the ``--reboot`` flag to a command to
+explicitly make **kw** reboot the machine afterwards, or you can set this to 
+always happen by modifying ``reboot_after_deploy`` flag in **deploy.config** with::
 
-  reboot_after_deploy=yes
+  kw config deploy.reboot_after_deploy yes
 
 This can be used with conjunction the :ref:`build<build-doc>` command by
 invoking ``kw bd``.
@@ -117,8 +118,9 @@ OPTIONS
 
 EXAMPLES
 ========
-For these examples, we suppose the fields in your **kworkflow.config** file are
-already configured.
+For these examples, we assume that the relevant fields in your configuration 
+files (located by default in **.kw/**) have already been setup. We recommend
+the use of ``kw config`` for managing your local and global configurations.
 
 First, if you are working in a specific kernel module, and if you want to
 install your recent changes in your local machine you can use::

--- a/documentation/man/features/kw-drm.rst
+++ b/documentation/man/features/kw-drm.rst
@@ -26,8 +26,8 @@ OPTIONS
 \--local, \--remote [<remote>:<port>]:
   This option specifies the target device for the drm action, it can be a
   remote or local machine. If these options are not explicitly passed via
-  command line, **kw** going to take the target set in the variable
-  *default_deploy_target* (**kworkflow.config**) for identifying the target.
+  command line, **kw** is going to take the target set in the variable
+  *default_deploy_target* (**deploy.config**) for identifying the target.
   It is important to highlight that the drm feature **does not support VM**.
 
 -lm, \--load-module=<module>[:<param1>,...][;<module>:...]:
@@ -68,8 +68,9 @@ OPTIONS
 
 EXAMPLES
 ========
-For these examples, we suppose the fields in your **kworkflow.config** file are
-already configured.
+For these examples, we assume that the relevant fields in your configuration 
+files (located by default in **.kw/**) have already been setup. We recommend
+the use of ``kw config`` for managing your local and global configurations.
 
 If you are working with DRM drivers, you can take advantage of load and unload
 commands combined with GUI control commands. For example::

--- a/documentation/man/features/kw-init.rst
+++ b/documentation/man/features/kw-init.rst
@@ -11,9 +11,9 @@ SYNOPSIS
 
 DESCRIPTION
 ===========
-This command creates a **.kw** folder containing a **kworkflow.config** file in
+This command creates a **.kw** folder containing default configuration files in
 the current kernel directory. The primary reason for running ``kw init`` is to
-pick up a freshly created config file.
+pick up freshly created config files.
 
 OPTIONS
 =======
@@ -25,7 +25,7 @@ OPTIONS
   creating the local config file.
 
 \--arch <arch>:
-  Set the variable `arch` from the newly created **kworkflow.config** file.
+  Set the variable `arch` from the newly created **build.config** file.
   Before actually changing it, this option checks if *<arch>* is a valid
   architecture found in the **arch** folder from the kernel directory.
 
@@ -34,7 +34,7 @@ OPTIONS
   and *<port>*, respectively.
 
 \--target <target>:
-  Set the variable `default_deploy_target` from **kworkflow.config** to
+  Set the variable `default_deploy_target` from **deploy.config** to
   *<target>*, which can be local or remote.
 
 \--verbose:
@@ -45,17 +45,19 @@ EXAMPLES
 For these examples, we suppose that the kernel directory is your current
 directory.
 
-For initializing a **kworkflow.config** with `arch` set to arm, use::
+For initializing a **build.config** with `arch` set to arm, use::
 
   kw init --arch arm
 
-To initialize **kworkflow.config** with `arch` set to x86, `ssh_user` set to
-john, `ssh_ip` set to localhost, and `ssh_port` set to 2222, run::
+To initialize **build.config** with `arch` set to x86 and a **kworkflow.config** 
+with `ssh_user` set to john, `ssh_ip` set to localhost, and `ssh_port` 
+set to 2222, run::
 
   kw init --arch x86 --remote john@localhost:2222
 
-For initializing a **kworkflow.config** with `arch` set to arm64, `target` set to
-remote, `ssh_user` mary, `ssh_ip` localhost, and `ssh_port` 1234, run::
+For initializing a **build.config** with `arch` set to arm64, a **deploy.config**
+with `target` set to remote and a **kworkflow.config** with `ssh_user` mary, 
+`ssh_ip` localhost, and `ssh_port` 1234, run::
 
   kw init --arch arm64 --remote mary@localhost:1234 --target remote
 

--- a/documentation/man/features/kw-kernel-config-manager.rst
+++ b/documentation/man/features/kw-kernel-config-manager.rst
@@ -62,8 +62,9 @@ OPTIONS
 
 EXAMPLES
 ========
-In the following examples, we assume your **kworkflow.config** file is already
-properly configured.
+For these examples, we assume that the relevant fields in your configuration 
+files (located by default in **.kw/**) have already been setup. We recommend
+the use of ``kw config`` for managing your local and global configurations.
 
 In case you want **kw** to save your current **.config** file, you can use::
 

--- a/documentation/man/features/kw-mail.rst
+++ b/documentation/man/features/kw-mail.rst
@@ -29,12 +29,12 @@ the union of the recipients of each patch as the recipients of the cover-letter.
 .. note::
   You can block certain e-mail addresses from being automatically added to the
   recipients list of the patches using the *blocked_emails* option in the
-  *kworkflow.config* file.
+  **mail.config** file.
 
 .. note::
   You can add To\: and CC\: recipients to be included by default using the
   *default_to_recipients* and *default_cc_recipients* configurations, respectively,
-  in the *mail.config* file.
+  in the **mail.config** file.
 
 .. note::
   Any option recognized by ``git send-email`` can be passed directly to it if
@@ -53,7 +53,7 @@ OPTIONS
 
   .. note::
     You can change the default arguments used to send emails in the
-    *kworkflow.config* file.
+    **mail.config** file.
 
 \--to='<recipient>,...':
   Specify the recipients that will receive the patch via e-mail. The

--- a/documentation/man/features/kw-maintainers.rst
+++ b/documentation/man/features/kw-maintainers.rst
@@ -36,8 +36,9 @@ OPTIONS
 
 EXAMPLES
 ========
-For these examples, we suppose the fields in your **kworkflow.config** file are
-already configured.
+For these examples, we assume that the relevant fields in your configuration 
+files (located by default in **.kw/**) have already been setup. We recommend
+the use of ``kw config`` for managing your local and global configurations.
 
 If you want to check the maintainers::
 

--- a/documentation/man/features/kw-ssh.rst
+++ b/documentation/man/features/kw-ssh.rst
@@ -51,8 +51,9 @@ OPTIONS
 EXAMPLES
 ========
 
-For these examples, we suppose the fields in your **kworkflow.config** file are
-already configured.
+For these examples, we assume that the relevant fields in your configuration 
+files (located by default in **.kw/**) have already been setup. We recommend
+the use of ``kw config`` for managing your local and global configurations.
 
 After you start your VM you can ssh into it with::
 

--- a/documentation/man/features/kw-vm.rst
+++ b/documentation/man/features/kw-vm.rst
@@ -21,7 +21,7 @@ OPTIONS
 =======
 -m, \--mount:
   This mounts the QEMU image in a specific directory, based on the data available
-  in the **kworkflow.config** file. Notice that the configuration file has the
+  in the **vm.config** file. Notice that the configuration file has the
   information about the source image and destination mount point.
 
 .. note::
@@ -29,10 +29,10 @@ OPTIONS
 
 -n, \--umount:
   This unmounts the previously mounted QEMU image, based on the parameters
-  available in the **kworkflow.config** file.
+  available in the **vm.config** file.
 
 -u, \--up:
-  This starts the QEMU VM based on parameters in the **kworkflow.config** file.
+  This starts the QEMU VM based on parameters in the **vm.config** file.
 
 \--alert=(s | v | (sv | vs) | n):
   Defines the alert behaviour upon the command completion.

--- a/documentation/man/kw.rst
+++ b/documentation/man/kw.rst
@@ -19,8 +19,8 @@ DESCRIPTION
 ===========
 **kw** mission is: reduce the overhead related with infrastructure project
 setup in projects that have a similar workflow to the Linux Kernel. It can (and
-should) be customized by editing the **kworkflow.config** file, as discussed in
-section `ABOUT kworflow.config`_.
+should) be customized by editing its various configuration files (preferably 
+through the **kw config** command).
 
 COMMANDS
 ========
@@ -88,6 +88,7 @@ This section describes a tool available in **kw** to help developers keep track
 of configuration files and other features provided by **kw** that do not fit in
 the previous sections.
 
+  | :ref:`kw-config<config-doc>`
   | :ref:`kw-backup<backup-doc>`
   | :ref:`kw-init<init-doc>`
   | :ref:`kw-device<device-doc>`
@@ -111,108 +112,11 @@ version, \--version, -v
 ~~~~~~~~~~~~~~~~~~~~~~~
 Show kworkflow version.
 
-ABOUT kworflow.config
-=====================
-.. _`ABOUT kworkflow.config`:
-
-**kw** reads its configuration from two files: the global
-*<path>/etc/kworkflow.config* file and the local **kworkflow.config** file
-present at the current working directory. The global **kworkflow.config** is a
-part of the **kw** code and provides the overall behavior for **kw**. Local
-**kworkflow.config** settings override global ones; you may have one
-**kworkflow.config** per project. In this section, we describe the possible
-fields you can specify in the configuration files.
-
-ssh_user=<user>
----------------
-Sets the user to be used by ssh. By default **kw** uses ``root``.
-
-ssh_ip=<ip>
------------
-Sets the IP address to be used by ssh. By default **kw** uses ``localhost``.
-
-ssh_port=<port>
----------------
-Sets the ssh port. By default **kw** uses ``2222``.
-
-ssh_configfile=<ssh-config-file>
---------------------------------
-Provides an optional SSH configuration file to be used by ssh. For more details
-see ``man ssh_config``.
-
-hostname=<hostname>
--------------------
-Sets the hostname to be used when an SSH configuration file is provided.
-
-arch=<architecture>
--------------------
-Allows you to specify the default architecture used by **kw**. By default,
-**kw** uses ``x86_64``.
-
-kernel_img_name=<kernel-image-name>
------------------------------------
-Use this option as a way to indicate to kw the kernel image name. This is the
-file present in the directory ``arch/*/boot/``; keep in mind that the kernel
-image name might change based on the user config file or target architecture.
-
-cross_compile=<cross-compile-toolchain-name>
---------------------------------------------
-Kw supports cross compile setup, use this option to indicate the target
-toolchain.
-
-menu_config=<menu-option>
--------------------------
-Default kernel menu used by **kw**, the default is ``nconfig``.
-
-alert=[vs | s | v | n]
-----------------------
-Default alert options, you have:
-
-1. v: enables visual notification.
-
-2. s: enables sound notification.
-
-3. vs or sv: enables both.
-
-4. n (or any other option): disables notifications.
-
-sound_alert_command=<command>
------------------------------
-Command to run for sound completion alert. By default, **kw** uses
-``paplay INSTALLPATH/sounds/complete.wav &``
-
-visual_alert_command=<command>
-------------------------------
-Command to run for visual completion alert. By default, **kw** uses
-``notify-send -i checkbox -t 10000 "kw" "Command: \\"$COMMAND\\" completed!"``
-
-.. note::
-  You may use the *COMMAND* variable, which will be replaced by the kw command
-  whose conclusion the user wished to be alerted of.
-
-default_deploy_target
----------------------
-By default, **kw** deploys in the *remote*; however, you can change this
-behavior with this variable. The available options are: *local* and *remote*.
-
-reboot_remote_by_default
-------------------------
-Reboot machine after the deploy finishes.
-
-gui_on=<command>
-----------------
-This option is disabled by default, if enabled, it requires a command that
-instructs kw to turn on the GUI.
-
-gui_off=<command>
------------------
-This option is disabled by default, if enabled, it requires a command that
-instructs kw to turn off the GUI.
-
 EXAMPLES
 ========
-For these examples, we suppose the fields in your **kworkflow.config** file is
-already configured.
+For these examples, we assume that the relevant fields in your configuration 
+files (located by default in **.kw/**) have already been setup. We recommend
+the use of ``kw config`` for managing your local and global configurations.
 
 First, if you are working in a specific kernel module, and if you want to
 install your recent changes in your local machine you can use::


### PR DESCRIPTION
Most man pages still mentioned a root level kworkflow.config file as the only source of user-adjustable settings. This commit replaces outdated references to kworkflow.config with the specific .kw/<command>.config format currently used by kw config and also recommends the use of kw config to adjust these options.

In doing so, this commit also removes the list of adjustable options from the main kw.rst man page, as these were outdated, are now mostly command-specific and could cause confusion in new users. Further changes are needed to redistribute these explanations (when needed) to more adequate locations.