### PR TITLE
src: plugins: kernel_install: utils: fix coding style error

### DIFF
--- a/src/plugins/kernel_install/utils.sh
+++ b/src/plugins/kernel_install/utils.sh
@@ -40,7 +40,7 @@ function cmd_manager()
       ;;
   esac
 
-  eval "$@"
+  "$@"
 }
 
 function command_exists()
@@ -197,7 +197,7 @@ function collect_deploy_info()
   bootloader="[bootloader]=$bootloader"
 
   # Get distro
-  distro=$(cat /etc/*-release | grep -w 'ID\(_LIKE\)\?' | cut -d = -f 2 | xargs echo)
+  distro=$(grep < /etc/*-release -w 'ID\(_LIKE\)\?' | cut -d = -f 2 | xargs echo)
   distro="[distro]='$distro'"
 
   # Build associative array data


### PR DESCRIPTION
Replace the cat command by < which is equivalent but faster.

Drop eval to preserve whitespace/symbols.