### PR TITLE
add comments on returns that didnt have errno error codes

### DIFF
--- a/database/migrate_legacy_data_20220101.sh
+++ b/database/migrate_legacy_data_20220101.sh
@@ -99,7 +99,7 @@ function migrate_statistics()
   cmd_manager 'SILENT' "mv ${datadir}/statistics ${datadir}/legacy_statistics"
   if [[ "$?" != 0 ]]; then
     complain "Couldn't rename ${datadir}/statistics ${datadir}/legacy_statistics"
-    return 1 #EPERM
+    return 1 # EPERM
   fi
 }
 
@@ -161,7 +161,7 @@ function migrate_pomodoro()
   cmd_manager 'SILENT' "mv ${datadir}/pomodoro ${datadir}/legacy_pomodoro"
   if [[ "$?" != 0 ]]; then
     complain "Couldn't rename ${datadir}/pomodoro ${datadir}/legacy_pomodoro"
-    return 1 #EPERM
+    return 1 # EPERM
   fi
 }
 
@@ -216,20 +216,20 @@ function migrate_kernel_configs()
   cmd_manager 'SILENT' "cp -r ${configs_dir}/. ${datadir}/configs"
   if [[ "$?" != 0 ]]; then
     complain "Couldn't copy kernel config files from ${configs_dir} to ${datadir}/configs"
-    return 1 #EPERM
+    return 1 # EPERM
   fi
 
   # mark migrated directories to avoid duplicated data
   cmd_manager 'SILENT' "mv ${datadir}/configs/configs ${datadir}/configs/legacy_configs"
   if [[ "$?" != 0 ]]; then
     complain "Couldn't rename ${datadir}/configs/configs to ${datadir}/configs/legacy_configs"
-    return 1 #EPERM
+    return 1 # EPERM
   fi
 
   cmd_manager 'SILENT' "mv ${datadir}/configs/metadata ${datadir}/configs/legacy_metadata"
   if [[ "$?" != 0 ]]; then
     complain "Couldn't rename ${datadir}/configs/metadata to ${datadir}/configs/legacy_metadata"
-    return 1 #EPERM
+    return 1 # EPERM
   fi
 }
 

--- a/kw
+++ b/kw
@@ -321,7 +321,7 @@ function kw()
 
         complain 'Invalid option'
         kworkflow_help
-        return 1
+        return 1 # EPERM
       )
       ;;
   esac

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -64,7 +64,7 @@ function report_results()
       done
     fi
 
-    return 1
+    return 1 # EPERM
   fi
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -544,7 +544,7 @@ function setup_global_config_file()
     fi
   else
     warning "setup could not find $config_file_template"
-    return 2
+    return 2 # ENOENT
   fi
 }
 

--- a/src/debug.sh
+++ b/src/debug.sh
@@ -48,7 +48,7 @@ function debug_main()
   if [[ "$?" -gt 0 ]]; then
     complain "Invalid option: ${options_values['ERROR']}"
     debug_help
-    return 22
+    return 22 # EINVAL
   fi
 
   test_mode="${options_values['TEST_MODE']}"
@@ -961,7 +961,7 @@ function parser_debug_options()
         populate_remote_info "$2"
         if [[ "$?" == 22 ]]; then
           options_values['ERROR']="$option"
-          return 22
+          return 22 # EINVAL
         fi
         options_values['TARGET']="$REMOTE_TARGET"
         shift 2
@@ -1029,7 +1029,7 @@ function parser_debug_options()
         ;;
       *)
         options_values['ERROR']="$1"
-        return 22
+        return 22 # EINVAL
         ;;
     esac
   done

--- a/src/kernel_config_manager.sh
+++ b/src/kernel_config_manager.sh
@@ -245,7 +245,7 @@ function get_config_from_proc()
   case "$target" in
     1) # VM
       # We do not support this option with VM
-      return 95
+      return 95 # ENOTSUP
       ;;
     2) # LOCAL
       # Try to find /proc/config, if we cannot find, attempt to load the module

--- a/src/kw_remote.sh
+++ b/src/kw_remote.sh
@@ -406,7 +406,7 @@ function parse_remote_options()
     return 22 # EINVAL
   elif [[ "${options_values['DEFAULT_REMOTE']}" == 1 ]]; then
     options_values['ERROR']='Expected a string values after --set-default='
-    return 22
+    return 22 # EINVAL
   elif [[ -z "${options_values['ADD']}" && -z "${options_values['REMOVE']}" &&
     -z "${options_values['RENAME']}" && -z "${options_values['LIST']}" &&
     -z "${options_values['DEFAULT_REMOTE']}" ]]; then

--- a/src/kw_ssh.sh
+++ b/src/kw_ssh.sh
@@ -316,7 +316,7 @@ function parser_ssh_options()
         populate_remote_info "$2"
         if [[ "$?" == 22 ]]; then
           options_values['ERROR']="$option"
-          return 22
+          return 22 # EINVAL
         fi
         shift 2
         ;;
@@ -357,7 +357,7 @@ function parser_ssh_options()
         ;;
       *)
         options_values['ERROR']="$1"
-        return 22
+        return 22 # EINVAL
         ;;
     esac
   done

--- a/src/lib/dialog_ui.sh
+++ b/src/lib/dialog_ui.sh
@@ -931,7 +931,7 @@ function prettify_string()
   local variable_to_concatenate="$2"
 
   if [[ -z "$fixed_text" || -z "$variable_to_concatenate" ]]; then
-    return 22
+    return 22 # EINVAL
   fi
 
   printf '\Zb\Z6%s\Zn%s\\n' "$fixed_text" "$variable_to_concatenate"

--- a/src/lib/kw_string.sh
+++ b/src/lib/kw_string.sh
@@ -29,7 +29,7 @@ function str_is_a_number()
 
   value=$(str_strip "$value")
   [[ "$value" =~ ^[-]?[0-9]+$ ]] && return 0
-  return 1
+  return 1 # EPERM
 }
 
 # Calculate the length of a string
@@ -206,7 +206,7 @@ function str_has_special_characters()
   local str="$*"
 
   [[ "$str" == *['!'@#\$%^\&*\(\)+]* ]] && return 0
-  return 1
+  return 1 # EPERM
 }
 
 # Get value under double-quotes. This function only returns the first match if

--- a/src/lib/kwlib.sh
+++ b/src/lib/kwlib.sh
@@ -169,7 +169,7 @@ function is_kernel_root()
     -d "${DIR}/scripts" ]]; then
     return 0
   fi
-  return 1
+  return 1 # EPERM
 }
 
 # Finds the root of the linux kernel repo containing the given file
@@ -268,7 +268,7 @@ function is_a_patch()
   local file_content
 
   if [[ ! -f "$FILE_PATH" ]]; then
-    return 1
+    return 1 # EPERM
   fi
 
   file_content=$(< "$FILE_PATH")
@@ -284,7 +284,7 @@ function is_a_patch()
 
   for expected_str in "${PATCH_EXPECTED_STRINGS[@]}"; do
     if [[ ! "$file_content" =~ $expected_str ]]; then
-      return 1
+      return 1 # EPERM
     fi
   done
 

--- a/src/lib/remote.sh
+++ b/src/lib/remote.sh
@@ -67,7 +67,7 @@ function is_ssh_connection_configured()
       ret="$?"
 
       # User canceled the manual update
-      [[ "$ret" == 125 ]] && return 125
+      [[ "$ret" == 125 ]] && return 125 # ECANCELED
       # Some other unknown error occurred
       [[ "$ret" != 0 ]] && return 101 # ENETUNREACH
 

--- a/src/lib/web.sh
+++ b/src/lib/web.sh
@@ -74,7 +74,7 @@ function is_html_file()
 
   grep --silent '\(<head>\|<body>\)' "$file_path"
   [[ "$?" == 0 ]] && return 0
-  return 1
+  return 1 # EPERM
 }
 
 # This function recieves a string and converts it to contain only characters that

--- a/src/mail.sh
+++ b/src/mail.sh
@@ -600,7 +600,7 @@ function mail_verify()
   if [[ "${#missing_conf}" -gt 0 ]]; then
     complain 'Missing configurations required for send-email:'
     printf '  %s\n' "${missing_conf[@]}"
-    return 22
+    return 22 # EINVAL
   fi
 
   success 'It looks like you are ready to send patches as:'

--- a/src/maintainers.sh
+++ b/src/maintainers.sh
@@ -59,7 +59,7 @@ function maintainers_main()
   # Check if is a valid path
   if [[ ! -d "$FILE_OR_DIR" && ! -f "$FILE_OR_DIR" ]]; then
     complain 'Invalid path'
-    return 1
+    return 1 # EPERM
   fi
 
   FILE_OR_DIR="$(realpath "${FILE_OR_DIR}")"
@@ -68,7 +68,7 @@ function maintainers_main()
   if ! is_a_patch "$FILE_OR_DIR"; then
     if [[ -n "$update_patch" ]]; then
       complain 'Option --update-patch was passed but given path is not a patch.'
-      return 1
+      return 1 # EPERM
     fi
     is_file_a_patch=false
     script_options="${script_options} -f"
@@ -85,7 +85,7 @@ function maintainers_main()
   # Check if kernel root was found.
   if [[ -z "$kernel_root" ]]; then
     complain 'Neither the given path nor the working path is in a kernel tree.'
-    return 1
+    return 1 # EPERM
   fi
 
   # If file is not a patch and outside a kernel tree, it must be an user's
@@ -93,7 +93,7 @@ function maintainers_main()
   # because it is most likely a user's mistake. So better let the user know.
   if ! "$is_file_a_patch" && ! "$is_file_inside_kernel_tree"; then
     complain 'The given file is not a patch and is outside a kernel tree.'
-    return 1
+    return 1 # EPERM
   fi
 
   cmd_manager "$flag" "cd ${kernel_root}"

--- a/src/pomodoro.sh
+++ b/src/pomodoro.sh
@@ -138,7 +138,7 @@ function is_tag_already_registered()
   is_tag_registered=$(select_from "tag WHERE name IS '${tag_name}'" '' '' '' '' "$flag")
 
   [[ -n "${is_tag_registered}" ]] && return 0
-  return 1
+  return 1 # EPERM
 }
 
 # This is the thread function that will be used to notify when the Pomodoro

--- a/src/report.sh
+++ b/src/report.sh
@@ -448,7 +448,7 @@ function parse_report_options()
 
   if [[ "$reference_count" -gt 1 ]]; then
     complain 'Please, only use a single time reference'
-    return 22
+    return 22 # EINVAL
   elif [[ "$reference_count" == 0 ]]; then
     # If no option, set day as a default
     options_values['DAY']=$(get_today_info '+%Y/%m/%d')


### PR DESCRIPTION
Some of the return statements didn't have a comment at the end saying what was the error code. This PR adds comments to most return statements by providing meaningful error codes to the user, improving the codestyle.

Signed-off-by: Bruno Rocha Levi <brunolevilevi@usp.br>
Co-developed-by: Lucas Antonio Pataluch dos Santos <lucasantonio.santos@usp.br>
