### PR TITLE
Add --snippet option to 'kw explore'

### DIFF
--- a/documentation/man/features/kw-explore.rst
+++ b/documentation/man/features/kw-explore.rst
@@ -6,7 +6,7 @@ kw-explore - Explore folder
 
 SYNOPSIS
 ========
-*kw* (*e* | *explore*) [(-l | \--log) | (-g | \--grep) | (-a | \--all) | \--verbose]
+*kw* (*e* | *explore*) [(-l | \--log) | (-g | \--grep) | (-a | \--all) | \--snippet | \--verbose]
                        [(-c | \--only-source) | (-H | \--only-header)] <expr>
                        [-p] [<dir> | <file>]
 
@@ -44,6 +44,10 @@ OPTIONS
 
 -H | \--only-header:
   With this option, it is possible to show only the results from the header.
+
+\--snippet:
+  This option forces ``kw (e | explore)`` to display small snippet previews
+  of files with the matched line at the center.
 
 \--verbose:
   Verbose mode allows the user to see the commands executed under the hood.

--- a/src/_kw
+++ b/src/_kw
@@ -282,6 +282,7 @@ _kw_explore()
     '(-a --all -l --log -g --grep)'{-a,--all}'[search for all matches in files under or not git management]' \
     '(-c --only-source -H --only-header)'{-c,--only-source}'[show only results from the source]' \
     '(-H --only-header -c --only-source)'{-H,--only-header}'[show only results from the header]' \
+    '(--snippet)--snippet[show small preview of files with the matched line at the center]' \
     '1: : ' \
     '2: :_files'
 }

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -53,7 +53,7 @@ function _kw_autocomplete()
 
   kw_options['remote']='--add --remove --rename --list --global --set-default --verbose'
 
-  kw_options['explore']='--log --grep --all --only-header --only-source --exactly --verbose'
+  kw_options['explore']='--log --grep --all --only-header --only-source --exactly --snippet --verbose'
   kw_options['e']="${kw_options['explore']}"
 
   kw_options['pomodoro']='--set-timer --check-timer --show-tags --tag --description --help --verbose'


### PR DESCRIPTION
### Commit:
Often when exploring code in the Linux Kernel, it's usually desirable to not only see the paths and matched lines, but also the content from near lines. This option allows 'kw explore' to show small previews of the matched files interactively, helping the process of finding the right code.

### Inspiration
We got inspired by issue #83. However, we implemented something different from what was actually suggested in the issue's thread so we are not sure if this a solution to the problem. We believe this is an interesting addition to `kw explore` and gives it more power, but of course we are open to feedback and to know if this feature, in the current state, is good enough to be integrated into kw. 