### PR TITLE
tests: integration: kw_ssh_test: Add integration tests for kw ssh functionality

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -88,7 +88,7 @@ function run_tests()
       test_dir=$(dirname "${target}")
 
       # Format the test name to be displayed in the output.
-      current_test="$(basename "$test_dir")/$(basename "$target" | sed 's/.sh//')"
+      current_test="$(basename "$test_dir")/$(basename "$target" | sed 's/\.sh//')"
 
       say "Running test [${current_test}]"
       say "$SEPARATOR"

--- a/tests/integration/kw_ssh_test.sh
+++ b/tests/integration/kw_ssh_test.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+
+include './src/lib/kwio.sh'
+include './tests/unit/utils.sh'
+include './tests/integration/utils.sh'
+
+declare -g SSH_CONTAINER_NAME='ssh-server-container'
+declare -g KW_GLOBAL_CONFIG_FILE='/root/.config/kw/remote.config'
+
+# This function calls setup_nested_ssh_server to configure the SSH server
+# inside the container of each distribution in the DISTROS array.
+#
+# Returns:
+# return 0: If all SSH servers are configured successfully.
+# return 1: If the SSH server configuration fails for any distribution.
+function oneTimeSetUp()
+{
+  local distro
+  local container
+
+  setup_container_environment "$VERBOSE" 'ssh'
+
+  for distro in "${DISTROS[@]}"; do
+    setup_nested_ssh_server "$distro"
+    if [[ "$?" -ne 0 ]]; then
+      complain "Failed to configure ssh server for ${distro}. Exiting setup."
+      return 1
+    fi
+  done
+}
+
+# This function sets up an SSH server environment inside a specified container
+# for testing purposes.
+#
+# @distro: The distribution name for which the SSH server is being configured.
+#
+# Returns:
+# return 0: If the SSH server is set up successfully.
+# return 1: If an unsupported OS type is specified or if any command fails
+#           during the setup.
+function setup_nested_ssh_server()
+{
+  local distro="$1"
+  local container="kw-${distro}"
+  local containerfile_ssh="${SAMPLES_DIR}/Containerfile_ssh"
+  local podman_tmp_utils="${CONTAINER_DIR}/test_resources/kw-ssh-tests"
+  local container_workdir='/root'
+  local package_install_command
+
+  case "$distro" in
+    debian)
+      package_install_command='apt update --yes --quiet=3 && apt install --yes'
+      ;;
+    archlinux)
+      package_install_command='pacman -Syu --noconfirm'
+      # Install specific dependencies in archlinux to run these tests
+      package_install_command+=' openssh aardvark-dns'
+      ;;
+    fedora)
+      package_install_command='dnf makecache --quiet && dnf install --assumeyes'
+      # Install specific dependencies in fedora to run these tests
+      package_install_command+=' fuse-overlayfs'
+      ;;
+    *)
+      complain "Unsupported OS type: ${distro}"
+      return 1
+      ;;
+  esac
+
+  # Install dependencies to run podman inside the main container
+  container_exec "$container" "${package_install_command} podman > /dev/null 2>&1"
+  # Copy the Containerfile_ssh to the container's workdir directory
+  container_copy "$container" "$containerfile_ssh" "$container_workdir"
+  # Copy the kw-ssh-tests directory to the container's workdir directory
+  container_copy "$container" "$podman_tmp_utils" "$container_workdir"
+  # Execute the kw_setup_ssh_env script located in /bin within the specified container
+  # This script creates an SSH server inside a container to test the kw ssh feature.
+  container_exec "$container" 'kw_setup_ssh_env > /dev/null 2>&1'
+}
+
+# This function tests the 'kw ssh' connection functionality. It verifies that a
+# connection can be established from a local container to an SSH server
+# container.
+function test_kw_ssh_connection()
+{
+  local ssh_user='root'
+  local expected_output='Connection successful'
+  local ssh_port=22
+  local ssh_container_ip_address
+  local distro
+  local container
+  local output
+
+  for distro in "${DISTROS[@]}"; do
+    container="kw-${distro}"
+    # Get the IP address of the SSH server container
+    ssh_container_ip_address=$(container_exec "$container" "podman inspect --format '{{.NetworkSettings.IPAddress}}' ${SSH_CONTAINER_NAME}")
+
+    output=$(container_exec "$container" "kw ssh --remote ${ssh_user}@${ssh_container_ip_address}:${ssh_port} --command 'echo Connection successful'")
+    assert_equals_helper "kw ssh connection failed for ${distro}" "$LINENO" "$expected_output" "$output"
+  done
+}
+
+# This function tests the SSH connection functionality using a remote global
+# configuration file. It ensures that the 'kw ssh' command can establish a
+# connection to an SSH server and execute a command.
+function test_kw_ssh_connection_remote_global_config_file()
+{
+  local expected_output='Connection successful'
+  local ssh_container_ip_address
+  local distro
+  local container
+  local output
+
+  for distro in "${DISTROS[@]}"; do
+    container="kw-${distro}"
+    # Get the IP address of the ssh container
+    ssh_container_ip_address=$(container_exec_in_nested_container "$container" "$SSH_CONTAINER_NAME" 'hostname --all-ip-addresses' | xargs)
+
+    # Update the global config file with the correct IP address of the SSH server
+    container_exec "$container" "sed --in-place \"s/localhost/${ssh_container_ip_address}/\" ${KW_GLOBAL_CONFIG_FILE}"
+    output=$(container_exec "$container" 'kw ssh --command "echo Connection successful"')
+    assert_equals_helper "kw ssh connection failed for ${distro}" "$LINENO" "$expected_output" "$output"
+  done
+}
+
+# This function tests the 'kw ssh --send' functionality It verifies that a file
+# can be sent from a local container to an SSH server container.
+function test_kw_ssh_send_to_path()
+{
+  local test_file='file.data'
+  local distro
+  local container
+  local output
+  local expected_output
+  local container_test_filepath
+  local ssh_server_container_test_filepath
+  local container_tmp_dir
+
+  for distro in "${DISTROS[@]}"; do
+    container="kw-${distro}"
+
+    ssh_container_ip_address=$(container_exec_in_nested_container "$container" "$SSH_CONTAINER_NAME" 'hostname --all-ip-addresses' | xargs)
+    # Update the global config file with the correct IP address of the SSH server
+    container_exec "$container" "sed --in-place \"s/localhost/${ssh_container_ip_address}/\" ${KW_GLOBAL_CONFIG_FILE}"
+
+    # Create temporary directories for the test in both the local and SSH server containers
+    container_tmp_dir=$(container_exec "$container" 'mktemp --directory')
+    ssh_server_container_tmp_dir=$(container_exec_in_nested_container "$container" "$SSH_CONTAINER_NAME" 'mktemp --directory')
+
+    # Define the full path of the test file on the local container
+    container_test_filepath="${container_tmp_dir}/${test_file}"
+
+    container_exec "$container" "touch ${container_test_filepath}"
+    container_exec "$container" "kw ssh --send ${container_test_filepath} --to ${ssh_server_container_tmp_dir} > /dev/null"
+
+    # Define the file path on the SSH server
+    ssh_server_container_test_filepath="${ssh_server_container_tmp_dir}/${test_file}"
+
+    # Check if the file exists on the SSH server by listing its path
+    output=$(container_exec_in_nested_container "$container" "$SSH_CONTAINER_NAME" "ls ${ssh_server_container_test_filepath}")
+    expected_output="$ssh_server_container_test_filepath"
+    assert_equals_helper "kw ssh --send ${test_file} connection failed for ${distro}" "$LINENO" "$expected_output" "$output"
+  done
+}
+
+# This function tests the 'kw ssh --get' functionality It verifies that a file
+# can be sent from a local container to an SSH server container.
+function test_kw_ssh_get_to_path()
+{
+  local test_dir_name='dir_testing'
+  local test_file_name='a.data'
+  local ssh_server_container_tmp_dir
+  local ssh_server_container_test_filepath
+  local container_tmp_dir
+  local distro
+  local container
+  local expected_output
+  local output
+
+  for distro in "${DISTROS[@]}"; do
+    container="kw-${distro}"
+
+    ssh_container_ip_address=$(container_exec_in_nested_container "$container" "$SSH_CONTAINER_NAME" 'hostname --all-ip-addresses' | xargs)
+
+    # Update the global remote.config file with the correct IP address of the SSH server
+    container_exec "$container" "sed --in-place \"s/localhost/${ssh_container_ip_address}/\" ${KW_GLOBAL_CONFIG_FILE}"
+
+    container_tmp_dir=$(container_exec "$container" 'mktemp --directory')
+    ssh_server_container_tmp_dir=$(container_exec_in_nested_container "$container" "$SSH_CONTAINER_NAME" 'mktemp --directory')
+
+    ssh_server_container_test_filepath="${ssh_server_container_tmp_dir}/${test_dir_name}/${test_file_name}"
+
+    container_exec_in_nested_container "$container" "$SSH_CONTAINER_NAME" "mkdir --parents ${ssh_server_container_tmp_dir}/${test_dir_name}"
+    container_exec_in_nested_container "$container" "$SSH_CONTAINER_NAME" "touch ${ssh_server_container_test_filepath}"
+
+    # Retrieve the file from the SSH server to the local container
+    container_exec "$container" "kw ssh --get ${ssh_server_container_tmp_dir}/${test_dir_name} --to ${container_tmp_dir} > /dev/null"
+
+    # Check if the file exists in the local container by listing its path
+    output=$(container_exec "$container" "ls ${container_tmp_dir}/${test_dir_name}/${test_file_name}")
+
+    # Set the expected output to the path of the file on the local container
+    expected_output="${container_tmp_dir}/${test_dir_name}/${test_file_name}"
+    assert_equals_helper "kw ssh --get ${ssh_server_container_test_filepath} retrieval failed for ${distro}" "$LINENO" "$expected_output" "$output"
+  done
+}
+
+function tearDown()
+{
+  local distro
+  local container
+
+  for distro in "${DISTROS[@]}"; do
+    container="kw-${distro}"
+    # Replace any IP address in the format xxx.xxx.xxx.xxx with localhost
+    container_exec "$container" "sed --in-place 's/[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/localhost/' ${KW_GLOBAL_CONFIG_FILE}"
+  done
+}
+
+invoke_shunit

--- a/tests/integration/podman/Containerfile_archlinux
+++ b/tests/integration/podman/Containerfile_archlinux
@@ -5,3 +5,12 @@ RUN pacman -Syu --noconfirm git
 COPY ./clone_and_install_kw.sh .
 
 RUN bash ./clone_and_install_kw.sh
+
+# Copy scripts from the "scripts/" folder to a temporary directory
+COPY scripts/ /tmp/scripts/
+
+# Grant execution permissions to the copied scripts
+RUN chmod +x /tmp/scripts/*
+
+# Move the scripts to /bin
+RUN mv /tmp/scripts/* /bin/

--- a/tests/integration/podman/Containerfile_debian
+++ b/tests/integration/podman/Containerfile_debian
@@ -5,3 +5,12 @@ RUN apt update -y && apt upgrade -y && apt install git -y
 COPY ./clone_and_install_kw.sh .
 
 RUN bash ./clone_and_install_kw.sh
+
+# Copy scripts from the "scripts/" folder to a temporary directory
+COPY scripts/ /tmp/scripts/
+
+# Grant execution permissions to the copied scripts
+RUN chmod +x /tmp/scripts/*
+
+# Move the scripts to /bin
+RUN mv /tmp/scripts/* /bin/

--- a/tests/integration/podman/Containerfile_fedora
+++ b/tests/integration/podman/Containerfile_fedora
@@ -5,3 +5,12 @@ RUN dnf install -y git
 COPY ./clone_and_install_kw.sh .
 
 RUN bash ./clone_and_install_kw.sh
+
+# Copy scripts from the "scripts/" folder to a temporary directory
+COPY scripts/ /tmp/scripts/
+
+# Grant execution permissions to the copied scripts
+RUN chmod +x /tmp/scripts/*
+
+# Move the scripts to /bin
+RUN mv /tmp/scripts/* /bin/

--- a/tests/integration/podman/scripts/kw_setup_ssh_env
+++ b/tests/integration/podman/scripts/kw_setup_ssh_env
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# This script creates an SSH server inside a container to test the kw ssh
+# feature.
+
+set -e
+
+function detect_distro()
+{
+  if [[ -f '/etc/os-release' ]]; then
+    . /etc/os-release
+    printf "%s\n" "$ID"
+  else
+    printf 'Distribution not detected\n'
+  fi
+}
+
+# This function configures the container storage environment. The primary
+# objective is to resolve issues related to the overlay storage driver on Arch
+# Linux systems. For Arch Linux, it sets the storage configuration to use an
+# alternative setup defined in archlinux_storage.conf and removes the existing
+# container storage directory
+function configure_container_environment()
+{
+  local distro
+  local podman_tmp_utils='/root/kw-ssh-tests'
+  local containers_config_dir='/etc/containers'
+  local arch_storage_conf="${podman_tmp_utils}/archlinux_storage.conf"
+  local containers_config_file="${containers_config_dir}/containers.conf"
+  local storage_config_file="${containers_config_dir}/storage.conf"
+
+  distro=$(detect_distro)
+
+  if [[ "$distro" =~ 'arch' ]]; then
+    printf "%s" "$(< ${arch_storage_conf})" > "$storage_config_file"
+    rm --recursive --force '/var/lib/containers/storage'
+  fi
+}
+
+# Ensure /usr/sbin is in the PATH
+function ensure_path()
+{
+  if ! grep --quiet '/usr/sbin' <<< "$PATH"; then
+    printf "export PATH=\"\$PATH:/usr/sbin\"\n" >> ~/.bashrc
+    source ~/.bashrc
+  fi
+}
+
+# Generate SSH keys for the root user without a passphrase
+function generate_ssh_keys()
+{
+  local ssh_key_dir='/root/.ssh'
+  local ssh_key_file="${ssh_key_dir}/id_rsa"
+
+  ssh-keygen -t rsa -b 4096 -C 'testing@example.com' -N '' -f "$ssh_key_file"
+  cp --recursive "${ssh_key_file}.pub" /root/
+}
+
+# Build and run the SSH server container
+function setup_ssh_server_container()
+{
+  local image_name='ssh-server'
+  local ssh_container_name='ssh-server-container'
+
+  podman build --tag "$image_name" --file '/root/Containerfile_ssh'
+  podman run --detach --name "$ssh_container_name" "$image_name"
+}
+
+function main()
+{
+  ensure_path
+  configure_container_environment
+  generate_ssh_keys
+  setup_ssh_server_container
+}
+
+main

--- a/tests/integration/podman/test_resources/kw-ssh-tests/archlinux_storage.conf
+++ b/tests/integration/podman/test_resources/kw-ssh-tests/archlinux_storage.conf
@@ -1,0 +1,4 @@
+[storage]
+driver="vfs"
+runroot="/var/run/containers"
+graphroot="/var/lib/containers/storage"

--- a/tests/integration/samples/Containerfile_ssh
+++ b/tests/integration/samples/Containerfile_ssh
@@ -1,0 +1,27 @@
+# This Containerfile sets up a Debian-based container with an SSH server. The
+# purpose of this container is to test SSH connections using the kw ssh tool.
+# It installs necessary packages, configures the SSH server, and sets up root
+# login with a pre-defined password and SSH public key authentication.
+
+# Start with the Debian image
+FROM debian:latest
+
+# Install necessary packages
+RUN apt-get update && \
+    apt-get install -y openssh-server iptables rsync && \
+    mkdir -p /var/run/sshd && \
+    echo 'root:password' | chpasswd && \
+    sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
+    sed -i 's/UsePAM yes/UsePAM no/' /etc/ssh/sshd_config && \
+    mkdir -p /root/.ssh && \
+    chmod 700 /root/.ssh
+
+# Copy SSH public key and set permissions
+COPY id_rsa.pub /root/.ssh/authorized_keys
+RUN chmod 600 /root/.ssh/authorized_keys
+
+# Expose the SSH port
+EXPOSE 22
+
+# Start the SSH service
+CMD ["/usr/sbin/sshd", "-D"]

--- a/tests/integration/utils.sh
+++ b/tests/integration/utils.sh
@@ -121,6 +121,7 @@ function setup_container_environment()
       --volume "${KWROOT_DIR}":"${working_directory}:Z" \
       --env PATH='/root/.local/bin:/usr/bin' \
       --name "${container_name}" \
+      --privileged \
       --detach \
       "${container_img}" sleep infinity > /dev/null
 

--- a/tests/integration/utils.sh
+++ b/tests/integration/utils.sh
@@ -413,7 +413,8 @@ function container_exec()
   # Escape single quotes in the container command
   container_command=$(str_escape_single_quotes "$container_command")
 
-  cmd+=" ${container_name} /bin/sh -c $'${container_command}' 2> /dev/null"
+  cmd+=" ${container_name} /bin/bash -c $'${container_command}' 2> /dev/null"
+
   eval "$cmd"
 
   if [[ "$?" -ne 0 ]]; then


### PR DESCRIPTION
This pull request introduces a comprehensive set of integration tests for the kw ssh functionality. The new tests cover various features, including establishing SSH connections, transferring files, and configuring remote environments across different distributions (Debian, Archlinux, and Fedora). Additionally, several utility functions and configuration scripts were added or updated to support these tests.