### PR TITLE
tests: unit: fix reverse argument order of assert_equals_helper in test cases

### DIFF
--- a/tests/integration/device_test.sh
+++ b/tests/integration/device_test.sh
@@ -52,7 +52,7 @@ function device_info_test_helper()
     expected_output=$(sed '/GPU:/q' <<< "${expected_output}" | sed '/GPU:/d')
   fi
 
-  assertEquals "(${LINENO}): kw device failed for ${distro}" "${output}" "${expected_output}"
+  assertEquals "(${LINENO}): kw device failed for ${distro}" "${expected_output}" "${output}"
 
   # check storage information
   fs_type=$(container_inspect --format '{{.Driver}}' "${container}")

--- a/tests/unit/backup_test.sh
+++ b/tests/unit/backup_test.sh
@@ -32,7 +32,7 @@ function test_create_backup()
   done)
 
   output=$(create_backup /randomly/random/path)
-  assertEquals "$LINENO" "$output" 'We could not find the path'
+  assertEquals "$LINENO" 'We could not find the path' "$output"
 
   output=$(create_backup "$SHUNIT_TMPDIR" 'SILENT')
   filepath=$(str_remove_prefix "$output" 'Backup successfully created at ')
@@ -47,7 +47,7 @@ function test_restore_backup()
   local output
 
   output=$(restore_backup "$SHUNIT_TMPDIR"/random/path/backup.tar.gz)
-  assertEquals "($LINENO)" "$output" 'We could not find this file'
+  assertEquals "($LINENO)" 'We could not find this file' "$output"
 
   output=$(restore_backup tests/unit/samples/kw-backup-2021-08-07_23-42-51.tar.gz)
   assertTrue "($LINENO) Not all files were extracted" \
@@ -83,17 +83,17 @@ function test_restore_config()
 
   config_2_last_line=$(tail -n 1 "$KW_DATA_DIR/configs/configs/config-2")
   output=$(printf '%s\n' 'n' | restore_config)
-  assertEquals "$LINENO" "$(printf '%s\n' "$output" | head -n 1)" 'It looks like that the file config-2 differs from the backup version.'
+  assertEquals "$LINENO" 'It looks like that the file config-2 differs from the backup version.' "$(printf '%s\n' "$output" | head -n 1)"
 
   # Since we answered no above, we expect config-2 to remain the same
   assert_equals_helper "config-2 should've reamined the same" "$LINENO" "$config_2_last_line" "$(tail -n 1 "$KW_DATA_DIR/configs/configs/config-2")"
 
   output=$(printf '%s\n' 'y' | restore_config)
-  assertEquals "$LINENO" "$(printf '%s\n' "$output" | head -n 1)" 'It looks like that the file config-2 differs from the backup version.'
+  assertEquals "$LINENO" 'It looks like that the file config-2 differs from the backup version.' "$(printf '%s\n' "$output" | head -n 1)"
 
   # Now config-2 should be changed, as we said yes above
   config_2_last_line=$(tail -n 1 "$KW_DATA_DIR/configs/configs/config-2")
-  assertEquals "$LINENO" "$config_2_last_line" '# This line is different'
+  assertEquals "$LINENO" '# This line is different' "$config_2_last_line"
 }
 
 function test_restore_data_from_dir()

--- a/tests/unit/build_test.sh
+++ b/tests/unit/build_test.sh
@@ -307,7 +307,7 @@ function test_kernel_build_invalid_flag()
 
   output=$(build_kernel_main 'TEST_MODE' --notvalid 2> /dev/null)
   ret="$?"
-  assertEquals "($LINENO)" "$ret" 22
+  assertEquals "($LINENO)" 22 "$ret"
 }
 
 function test_kernel_build_outside_kernel_repository()
@@ -322,7 +322,7 @@ function test_kernel_build_outside_kernel_repository()
 
   output=$(build_kernel_main 'TEST_MODE')
   ret="$?"
-  assert_equals_helper 'We expected an error' "($LINENO)" "$ret" 125
+  assert_equals_helper 'We expected an error' "($LINENO)" 125 "$ret"
 
   cd "$FAKE_KERNEL" || {
     fail "($LINENO) It was not possible to move into temporary directory"

--- a/tests/unit/config_test.sh
+++ b/tests/unit/config_test.sh
@@ -46,29 +46,29 @@ function show_raw_configurations()
 function test_is_config_file_valid()
 {
   is_config_file_valid 'invalid'
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 
   is_config_file_valid 'builds'
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 
   is_config_file_valid 'kworkflows'
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 
   # Valid options
   is_config_file_valid 'kworkflow'
-  assertEquals "($LINENO)" "$?" 0
+  assertEquals "($LINENO)" 0 "$?"
 
   is_config_file_valid 'build'
-  assertEquals "($LINENO)" "$?" 0
+  assertEquals "($LINENO)" 0 "$?"
 }
 
 function test_is_a_valid_config_option_only_valid_options()
 {
   is_a_valid_config_option 'build' 'cross_compile'
-  assertEquals "($LINENO)" "$?" 0
+  assertEquals "($LINENO)" 0 "$?"
 
   is_a_valid_config_option 'kworkflow' 'ssh_ip'
-  assertEquals "($LINENO)" "$?" 0
+  assertEquals "($LINENO)" 0 "$?"
 }
 
 function test_is_a_valid_config_invalid_parameters()
@@ -76,16 +76,16 @@ function test_is_a_valid_config_invalid_parameters()
   local output
 
   output=$(is_a_valid_config_option 'build')
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 
   output=$(is_a_valid_config_option 'kworkflow')
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 
   output=$(is_a_valid_config_option 'kworkflow' 'this_is_invalid')
-  assertEquals "($LINENO)" "$?" 95
+  assertEquals "($LINENO)" 95 "$?"
 
   output=$(is_a_valid_config_option 'build' 'nop')
-  assertEquals "($LINENO)" "$?" 95
+  assertEquals "($LINENO)" 95 "$?"
 }
 
 function test_set_config_check_if_file_still_a_link_after_change()
@@ -118,13 +118,13 @@ function test_set_config_value_changing_default_value()
 function test_set_config_value_with_dot_in_the_value()
 {
   validate_option_parameter 'this.is valid'
-  assertEquals "($LINENO)" "$?" 0
+  assertEquals "($LINENO)" 0 "$?"
 
   validate_option_parameter 'this.is valid.also.valid'
-  assertEquals "($LINENO)" "$?" 0
+  assertEquals "($LINENO)" 0 "$?"
 
   validate_option_parameter 'this is.not.valid'
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 }
 
 function test_set_config_with_a_path_as_value()
@@ -151,10 +151,10 @@ function test_set_config_with_verbose_mode()
 function test_check_if_target_config_exist()
 {
   check_if_target_config_exist 'vm' 'vm.config'
-  assertEquals "($LINENO)" "$?" 0
+  assertEquals "($LINENO)" 0 "$?"
 
   check_if_target_config_exist 'vm' 'la.config'
-  assertEquals "($LINENO)" "$?" 2
+  assertEquals "($LINENO)" 2 "$?"
 }
 
 function test_parse_config_options()
@@ -292,9 +292,9 @@ function test_show_configurations_invalid_target()
   local output
 
   output=$(show_configurations invalid_target)
-  assertEquals "($LINENO)" "$output" 'Invalid config target: invalid_target'
+  assertEquals "($LINENO)" 'Invalid config target: invalid_target' "$output"
   show_configurations invalid_target > /dev/null 2>&1
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 }
 
 invoke_shunit

--- a/tests/unit/debug_test.sh
+++ b/tests/unit/debug_test.sh
@@ -120,7 +120,7 @@ function test_process_list()
   raw_input=''
   output=$(process_list "$raw_input" 1)
   ret="$?"
-  assert_equals_helper 'Return error:' "($LINENO)" "$ret" 22
+  assert_equals_helper 'Return error:' "($LINENO)" 22 "$ret"
 }
 
 function test_convert_event_syntax_to_sys_path_hash()
@@ -223,8 +223,8 @@ function test_convert_event_syntax_to_sys_path_hash()
     IFS=$'\n'
     printf '%s\n' "${!events_hash[*]}"
   )
-  assert_equals_helper 'Wrong syntax:' "($LINENO)" "$output" ''
-  assert_equals_helper 'Return error:' "($LINENO)" "$ret" 22
+  assert_equals_helper 'Wrong syntax:' "($LINENO)" '' "$output"
+  assert_equals_helper 'Return error:' "($LINENO)" 22 "$ret"
 
   events_hash=()
   convert_event_syntax_to_sys_path_hash ':'
@@ -233,8 +233,8 @@ function test_convert_event_syntax_to_sys_path_hash()
     IFS=$'\n'
     printf '%s\n' "${!events_hash[*]}"
   )
-  assert_equals_helper 'Wrong syntax:' "($LINENO)" "$output" ''
-  assert_equals_helper 'Return error:' "($LINENO)" "$ret" 22
+  assert_equals_helper 'Wrong syntax:' "($LINENO)" '' "$output"
+  assert_equals_helper 'Return error:' "($LINENO)" 22 "$ret"
 }
 
 function test_build_event_command_string()
@@ -311,9 +311,9 @@ function test_parser_debug_options_remote()
 {
   # 1) Parser remote without config file.
   parser_debug_options --remote 'juca@localhost:33'
-  assert_equals_helper 'Expected localhost' "$LINENO" "${remote_parameters['REMOTE_IP']}" 'localhost'
-  assert_equals_helper 'Expected port 33' "$LINENO" "${remote_parameters['REMOTE_PORT']}" 33
-  assert_equals_helper 'Expected user' "$LINENO" "${remote_parameters['REMOTE_USER']}" 'juca'
+  assert_equals_helper 'Expected localhost' "$LINENO" 'localhost' "${remote_parameters['REMOTE_IP']}"
+  assert_equals_helper 'Expected port 33' "$LINENO" 33 "${remote_parameters['REMOTE_PORT']}"
+  assert_equals_helper 'Expected user' "$LINENO" 'juca' "${remote_parameters['REMOTE_USER']}"
 
   # 2) Parser remote with config file
 
@@ -329,16 +329,16 @@ function test_parser_debug_options_remote()
 
   # 2.1) We have a config file, with origin set as host, and user request it
   parser_debug_options --remote 'origin'
-  assert_equals_helper 'Expected origin' "$LINENO" "${remote_parameters['REMOTE_FILE_HOST']}" 'origin'
+  assert_equals_helper 'Expected origin' "$LINENO" 'origin' "${remote_parameters['REMOTE_FILE_HOST']}"
 
   # 2.2) We have a config file, with --remote NAME, but we don't have NAME in the
   #      config file.
   parser_debug_options --remote 'debian-test-dns'
-  assert_equals_helper 'Expected empty' "$LINENO" "${remote_parameters['REMOTE_FILE_HOST']}" ''
-  assert_equals_helper 'Expected debian-test-dns' "$LINENO" "${remote_parameters['REMOTE_IP']}" 'debian-test-dns'
+  assert_equals_helper 'Expected empty' "$LINENO" '' "${remote_parameters['REMOTE_FILE_HOST']}"
+  assert_equals_helper 'Expected debian-test-dns' "$LINENO" 'debian-test-dns' "${remote_parameters['REMOTE_IP']}"
 
   parser_debug_options --remote '192.0.2.0'
-  assert_equals_helper 'Expected 192.0.2.0' "$LINENO" "${remote_parameters['REMOTE_IP']}" '192.0.2.0'
+  assert_equals_helper 'Expected 192.0.2.0' "$LINENO" '192.0.2.0' "${remote_parameters['REMOTE_IP']}"
 
   cd "$original_dir" || {
     fail "($LINENO) It was not possible to move back to original directory"
@@ -353,62 +353,62 @@ function test_parser_debug_options()
 
   # Validate list option
   parser_debug_options --list
-  assert_equals_helper 'Expected list' "$LINENO" "${options_values['LIST']}" 1
+  assert_equals_helper 'Expected list' "$LINENO" 1 "${options_values['LIST']}"
 
   parser_debug_options --list --event 'amdgpu_dm'
-  assert_equals_helper 'Expected amdgpu_dm' "$LINENO" "${options_values['EVENT']}" 'amdgpu_dm'
+  assert_equals_helper 'Expected amdgpu_dm' "$LINENO" 'amdgpu_dm' "${options_values['EVENT']}"
 
   # Validate history option
   parser_debug_options --history
-  assert_equals_helper 'Expected history' "$LINENO" "${options_values['HISTORY']}" 1
+  assert_equals_helper 'Expected history' "$LINENO" 1 "${options_values['HISTORY']}"
 
   # Validate follow
   parser_debug_options --follow
-  assert_equals_helper 'Expected follow' "$LINENO" "${options_values['FOLLOW']}" 1
+  assert_equals_helper 'Expected follow' "$LINENO" 1 "${options_values['FOLLOW']}"
 
   # Validate event
   event_str='amdgpu_dm:dc_something[x>3]'
   parser_debug_options --event "$event_str"
-  assert_equals_helper 'Expected event' "$LINENO" "${options_values['EVENT']}" "$event_str"
+  assert_equals_helper 'Expected event' "$LINENO" "$event_str" "${options_values['EVENT']}"
 
   # Validate disable event
   parser_debug_options --event "$event_str" --disable
-  assert_equals_helper 'Expected event' "$LINENO" "${options_values['DISABLE']}" 1
+  assert_equals_helper 'Expected event' "$LINENO" 1 "${options_values['DISABLE']}"
 
   # Validate disable event
   parser_debug_options --event "$event_str" --cmd "$fake_cmd"
-  assert_equals_helper 'Expected event' "$LINENO" "${options_values['CMD']}" "$fake_cmd"
+  assert_equals_helper 'Expected event' "$LINENO" "$fake_cmd" "${options_values['CMD']}"
 
   # Check local option
   parser_debug_options --local --event "$event_str" --disable
-  assert_equals_helper 'Expected event' "$LINENO" "${options_values['TARGET']}" 2
+  assert_equals_helper 'Expected event' "$LINENO" 2 "${options_values['TARGET']}"
 
   # Check test_mode
   parser_debug_options test_mode
-  assert_equals_helper 'Expected event' "$LINENO" "${options_values['TEST_MODE']}" 'TEST_MODE'
+  assert_equals_helper 'Expected event' "$LINENO" 'TEST_MODE' "${options_values['TEST_MODE']}"
 
   # Validate dmesg
   parser_debug_options --dmesg
-  assert_equals_helper 'Expected dmesg' "$LINENO" "${options_values['DMESG']}" 1
+  assert_equals_helper 'Expected dmesg' "$LINENO" 1 "${options_values['DMESG']}"
 
   # Validate ftrace
   parser_debug_options --ftrace
-  assert_equals_helper 'Expected ftrace failure' "$LINENO" "$?" 22
+  assert_equals_helper 'Expected ftrace failure' "$LINENO" 22 "$?"
 
   parser_debug_options --list --ftrace
-  assert_equals_helper 'Expected ftrace failure' "$LINENO" "$?" 22
+  assert_equals_helper 'Expected ftrace failure' "$LINENO" 22 "$?"
 
   ftrace_str='something:another,thing'
   parser_debug_options --ftrace="$ftrace_str"
-  assert_equals_helper 'Expected ftrace syntax' "$LINENO" "${options_values['FTRACE']}" "$ftrace_str"
+  assert_equals_helper 'Expected ftrace syntax' "$LINENO" "$ftrace_str" "${options_values['FTRACE']}"
 
   ftrace_str='something:'
   parser_debug_options --ftrace="$ftrace_str"
-  assert_equals_helper 'Expected ftrace setup' "$LINENO" "${options_values['FTRACE']}" "$ftrace_str"
+  assert_equals_helper 'Expected ftrace setup' "$LINENO" "$ftrace_str" "${options_values['FTRACE']}"
 
   ftrace_str='something:  la, llu,    xpto'
   parser_debug_options --ftrace="$ftrace_str"
-  assert_equals_helper 'Expected ftrace string' "$LINENO" "${options_values['FTRACE']}" "$ftrace_str"
+  assert_equals_helper 'Expected ftrace string' "$LINENO" "$ftrace_str" "${options_values['FTRACE']}"
 }
 
 function test_build_ftrace_command_string()
@@ -423,10 +423,10 @@ function test_build_ftrace_command_string()
   # function_graph
   output=$(build_ftrace_command_string 'function_graph')
   expected_cmd="$disable_trace && printf '%s' 'function_graph' > $current_tracer && $enable_trace"
-  assert_equals_helper 'Expected to enable function_graph' "$LINENO" "$output" "$expected_cmd"
+  assert_equals_helper 'Expected to enable function_graph' "$LINENO" "$expected_cmd" "$output"
 
   output=$(build_ftrace_command_string '    function_graph        ')
-  assert_equals_helper 'Expected to enable function_graph' "$LINENO" "$output" "$expected_cmd"
+  assert_equals_helper 'Expected to enable function_graph' "$LINENO" "$expected_cmd" "$output"
 
   # function_graph: -> Should fail
   output=$(build_ftrace_command_string 'function_graph:  ')
@@ -443,7 +443,7 @@ function test_build_ftrace_command_string()
   expected_cmd="$disable_trace && printf '%s' 'function_graph' > $current_tracer"
   expected_cmd+=" && printf '%s' 'amdgpu_dm*' >> $ftracer_filter"
   expected_cmd+=" && $enable_trace"
-  assert_equals_helper 'Expected amdgpu_dm filters' "$LINENO" "$output" "$expected_cmd"
+  assert_equals_helper 'Expected amdgpu_dm filters' "$LINENO" "$expected_cmd" "$output"
 
   # function_graph:amdgpu_dm*,dc_*,drm_test
   output=$(build_ftrace_command_string 'function_graph:amdgpu_dm*,dc_*,drm_test')
@@ -452,7 +452,7 @@ function test_build_ftrace_command_string()
   expected_cmd+=" && printf '%s' 'dc_*' >> $ftracer_filter"
   expected_cmd+=" && printf '%s' 'drm_test' >> $ftracer_filter"
   expected_cmd+=" && $enable_trace"
-  assert_equals_helper 'Expected to find multiple filters' "$LINENO" "$output" "$expected_cmd"
+  assert_equals_helper 'Expected to find multiple filters' "$LINENO" "$expected_cmd" "$output"
 
   # function_graph: amdgpu_dm*,   dc_*
   output=$(build_ftrace_command_string 'function_graph: amdgpu_dm*,   dc_*')
@@ -460,7 +460,7 @@ function test_build_ftrace_command_string()
   expected_cmd+=" && printf '%s' 'amdgpu_dm*' >> $ftracer_filter"
   expected_cmd+=" && printf '%s' 'dc_*' >> $ftracer_filter"
   expected_cmd+=" && $enable_trace"
-  assert_equals_helper 'Expected to find multiple filters' "$LINENO" "$output" "$expected_cmd"
+  assert_equals_helper 'Expected to find multiple filters' "$LINENO" "$expected_cmd" "$output"
 
   # Empty
   output=$(build_ftrace_command_string '')
@@ -470,7 +470,7 @@ function test_build_ftrace_command_string()
   # Disable
   output=$(build_ftrace_command_string 'function_graph:amdgpu_dm*' 1)
   expected_cmd="$disable_trace && printf '' > $ftracer_filter && printf 'nop' > $FTRACE_CURRENT_PATH"
-  assert_equals_helper 'Expected disable command' "$LINENO" "$output" "$expected_cmd"
+  assert_equals_helper 'Expected disable command' "$LINENO" "$expected_cmd" "$output"
 }
 
 function test_ftrace_debug()
@@ -491,7 +491,7 @@ function test_ftrace_debug()
   output=$(ftrace_debug 2 'TEST_MODE' 'function_graph:amdgpu_dm*')
   expected_cmd="$disable_trace && printf '%s' 'function_graph' > $current_tracer"
   expected_cmd+=" && printf '%s' 'amdgpu_dm*' >> $ftracer_filter && $enable_trace"
-  assert_equals_helper 'Expected command' "$LINENO" "$output" "$expected_cmd"
+  assert_equals_helper 'Expected command' "$LINENO" "$expected_cmd" "$output"
 
   expected_cmd_base="$expected_cmd"
 
@@ -502,12 +502,12 @@ function test_ftrace_debug()
 
   output=$(ftrace_debug 3 'TEST_MODE' 'function_graph:amdgpu_dm*')
   expected_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"$expected_cmd_base\""
-  assert_equals_helper 'Expected remote command' "$LINENO" "$output" "$expected_cmd"
+  assert_equals_helper 'Expected remote command' "$LINENO" "$expected_cmd" "$output"
 
   # Follow
   output=$(ftrace_debug 3 'TEST_MODE' 'function_graph:amdgpu_dm*' '' 1)
   expected_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"$expected_cmd_base && cat $trace_pipe\""
-  assert_equals_helper 'Expected follow' "$LINENO" "$output" "$expected_cmd"
+  assert_equals_helper 'Expected follow' "$LINENO" "$expected_cmd" "$output"
 
   # History
   cd "$SHUNIT_TMPDIR" || {
@@ -763,7 +763,7 @@ function test_event_debug()
   # Failure case
   output=$(event_debug 3 'TEST_MODE' 'lala;:')
   ret="$?"
-  assert_equals_helper 'Invalid syntax' "$LINENO" "$ret" 22
+  assert_equals_helper 'Invalid syntax' "$LINENO" 22 "$ret"
 
   # List
   output=$(event_debug 2 'TEST_MODE' 'amdgpu_dm' '' '' '' 1)

--- a/tests/unit/diff_test.sh
+++ b/tests/unit/diff_test.sh
@@ -30,7 +30,7 @@ function test_diff_folders()
 
   # TODO: We need to investigate this LANG part. Ideally, we don't want it here
   output=$(LANG=en_US.UTF-8 diff_folders "$folder_1" "$folder_2")
-  assertEquals "$output" "Only in ${folder_1}: get_maintainer.pl"
+  assertEquals "Only in ${folder_1}: get_maintainer.pl" "$output"
 }
 
 function test_diff_folders_no_difference()
@@ -39,7 +39,7 @@ function test_diff_folders_no_difference()
   local folder_2="${SAMPLES_DIR}/db_files"
 
   output=$(diff_folders "$folder_1" "$folder_2")
-  assertEquals "$output" ""
+  assertEquals "" "$output"
 }
 
 function test_diff_folders_invalid_path()

--- a/tests/unit/drm_plugin_test.sh
+++ b/tests/unit/drm_plugin_test.sh
@@ -396,7 +396,7 @@ function test_convert_module_info()
   assertEquals "$LINENO" "$expected" "$output"
 
   output=$(convert_module_info "LOAD" "")
-  assertEquals "$LINENO" "$?" "22"
+  assertEquals "$LINENO" 22 "$?"
 }
 
 invoke_shunit

--- a/tests/unit/help_test.sh
+++ b/tests/unit/help_test.sh
@@ -28,7 +28,7 @@ function test_kworkflow_man()
   expect="Couldn't find the man page for kw-error!"
   output=$(kworkflow_man 'error' 'TEST_MODE')
   ret="$?"
-  assertEquals "($LINENO) We expected an error." "$ret" 2
+  assertEquals "($LINENO) We expected an error." 2 "$ret"
   assertEquals "($LINENO) We expected an error message." "$expect" "$output"
 }
 

--- a/tests/unit/kw_env_test.sh
+++ b/tests/unit/kw_env_test.sh
@@ -44,19 +44,19 @@ function test_create_new_env_create_multiple_envs_from_current_configs()
 
   options_values['CREATE']='xpto'
   create_new_env
-  assertEquals "($LINENO) We should nota have errors" "$?" 0
+  assertEquals "($LINENO) We should nota have errors" 0 "$?"
 
   options_values['CREATE']='abc'
   create_new_env
-  assertEquals "($LINENO) We should nota have errors" "$?" 0
+  assertEquals "($LINENO) We should nota have errors" 0 "$?"
 
   # Other checks
   # 1. Do we have the env folder?
   new_env_name=$(find ".kw/${ENV_DIR}" -type d -name 'xpto')
-  assertEquals "($LINENO) We did not find the new folder name" "$new_env_name" ".kw/${ENV_DIR}/xpto"
+  assertEquals "($LINENO) We did not find the new folder name" ".kw/${ENV_DIR}/xpto" "$new_env_name"
 
   new_env_name=$(find ".kw/${ENV_DIR}" -type d -name 'abc')
-  assertEquals "($LINENO) We did not find the new folder name" "$new_env_name" ".kw/${ENV_DIR}/abc"
+  assertEquals "($LINENO) We did not find the new folder name" ".kw/${ENV_DIR}/abc" "$new_env_name"
 
   # 2. Check for config files
   for config in "${config_file_list[@]}"; do
@@ -74,7 +74,7 @@ function test_create_new_env_outside_of_a_repo_without_init()
 
   options_values['CREATE']='farofa'
   output=$(create_new_env)
-  assertEquals "($LINENO) We should hit a fail condition" "$?" 22
+  assertEquals "($LINENO) We should hit a fail condition" 22 "$?"
 }
 
 function test_create_new_env_missing_config()
@@ -98,7 +98,7 @@ function test_create_new_env_check_if_target_env_name_already_exists()
 
   # Try to create the same env twice
   output=$(create_new_env)
-  assertEquals "($LINENO) We should be able to create two env with the same name" "$?" 22
+  assertEquals "($LINENO) We should be able to create two env with the same name" 22 "$?"
 }
 
 function test_show_available_envs()
@@ -129,7 +129,7 @@ function test_show_available_envs_when_we_dont_kw_folder()
   assertTrue "${LINENO}: Something went wrong when we tried to remove .kw folder" 'rm -rf .kw'
 
   output=$(list_env_available_envs)
-  assertEquals "($LINENO) We should hit a fail condition" "$?" 22
+  assertEquals "($LINENO) We should hit a fail condition" 22 "$?"
 }
 
 function test_show_available_envs_when_there_is_no_env()
@@ -166,7 +166,7 @@ function test_use_target_env()
   real_path=$(readlink "${PWD}/.kw/build.config")
   expected_path="${PWD}/.kw/${ENV_DIR}/farofa/build.config"
 
-  assertEquals "($LINENO) It looks like that the env did not switch" "$real_path" "$expected_path"
+  assertEquals "($LINENO) It looks like that the env did not switch" "$expected_path" "$real_path"
 
   # Switch env
   options_values['USE']='tapioca'
@@ -175,7 +175,7 @@ function test_use_target_env()
   real_path=$(readlink "${PWD}/.kw/build.config")
   expected_path="${PWD}/.kw/${ENV_DIR}/tapioca/build.config"
 
-  assertEquals "($LINENO) It looks like that the env did not switch" "$real_path" "$expected_path"
+  assertEquals "($LINENO) It looks like that the env did not switch" "$expected_path" "$real_path"
 }
 
 function test_use_target_env_invalid_env()
@@ -194,7 +194,7 @@ function test_use_target_env_invalid_env()
   # Switch env
   options_values['USE']='lala'
   output=$(use_target_env)
-  assertEquals "($LINENO) Env does not exists" "$?" 22
+  assertEquals "($LINENO) Env does not exists" 22 "$?"
 }
 
 function test_validate_env_before_switch_invalid_case_with_config()
@@ -242,11 +242,11 @@ function test_parse_env_options()
 
   # Check help
   output=$(parse_env_options -h)
-  assertEquals "($LINENO)" "$?" 0
+  assertEquals "($LINENO)" 0 "$?"
 
   # Check verbose
   output=$(parse_env_options --verbose)
-  assertEquals "($LINENO)" "$?" 0
+  assertEquals "($LINENO)" 0 "$?"
 
   # Check create
   parse_env_options --create abc
@@ -254,10 +254,10 @@ function test_parse_env_options()
     "($LINENO)" 'abc' "${options_values['CREATE']}"
 
   output=$(parse_env_options --create 'abc la')
-  assertEquals "($LINENO) Invalid name" "$?" 22
+  assertEquals "($LINENO) Invalid name" 22 "$?"
 
   output=$(parse_env_options --create 'Weird_n@m#')
-  assertEquals "($LINENO) Invalid name" "$?" 22
+  assertEquals "($LINENO) Invalid name" 22 "$?"
 
   # Check use option
   parse_env_options --use abc
@@ -266,10 +266,10 @@ function test_parse_env_options()
 
   # Check use option
   parse_env_options --an-invalid-option
-  assertEquals "($LINENO) Invalid option" "$?" 22
+  assertEquals "($LINENO) Invalid option" 22 "$?"
 
   parse_env_options --use
-  assertEquals "($LINENO) Invalid option" "$?" 22
+  assertEquals "($LINENO) Invalid option" 22 "$?"
 }
 
 function test_exit_env_checking_files()

--- a/tests/unit/kw_remote_test.sh
+++ b/tests/unit/kw_remote_test.sh
@@ -46,15 +46,15 @@ function test_add_new_remote_wrong_number_of_parameters()
 
   options_values['PARAMETERS']=''
   output=$(add_new_remote)
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 
   options_values['PARAMETERS']='xpto'
   output=$(add_new_remote)
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 
   options_values['PARAMETERS']='xpto lala uuu'
   output=$(add_new_remote)
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 }
 
 function test_add_new_remote_no_kw_folder()
@@ -67,7 +67,7 @@ function test_add_new_remote_no_kw_folder()
   options_values['PARAMETERS']='origin u'
   output=$(add_new_remote)
 
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 }
 
 function test_add_new_remote_with_no_config_file()
@@ -213,11 +213,11 @@ function test_remove_remote_wrong_parameters()
   options_values['PARAMETERS']=''
 
   output=$(remove_remote)
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 
   options_values['PARAMETERS']='one two'
   output=$(remove_remote)
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 }
 
 function test_remove_remote_only_one_entry()
@@ -235,7 +235,7 @@ function test_remove_remote_only_one_entry()
   options_values['PARAMETERS']='origin'
   output=$(remove_remote)
   mapfile -t final_result < "${BASE_PATH_KW}/remote.config"
-  assertEquals "($LINENO)" "${final_result[*]}" ''
+  assertEquals "($LINENO)" '' "${final_result[*]}"
 }
 
 function test_remove_remote_try_to_remove_something_from_an_empty_file()
@@ -247,7 +247,7 @@ function test_remove_remote_try_to_remove_something_from_an_empty_file()
   options_values['PARAMETERS']='origin'
   output=$(remove_remote)
   mapfile -t final_result < "${BASE_PATH_KW}/remote.config"
-  assertEquals "($LINENO)" "${final_result[*]}" ''
+  assertEquals "($LINENO)" '' "${final_result[*]}"
 }
 
 function test_remove_remote_drop_guard_between_others()
@@ -316,7 +316,7 @@ function test_remove_remote_try_to_drop_something_that_does_not_exists()
   # Remove a remote option in the middle
   options_values['PARAMETERS']='uva'
   output=$(remove_remote)
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 }
 
 function test_rename_remote_wrong_number_of_parameters()
@@ -325,15 +325,15 @@ function test_rename_remote_wrong_number_of_parameters()
 
   options_values['PARAMETERS']=''
   output=$(rename_remote)
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 
   options_values['PARAMETERS']='xpto'
   output=$(rename_remote)
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 
   options_values['PARAMETERS']='xpto la lu'
   output=$(rename_remote)
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 }
 
 function test_rename_remote_try_to_rename_something_that_does_not_exists()
@@ -344,7 +344,7 @@ function test_rename_remote_try_to_rename_something_that_does_not_exists()
 
   options_values['PARAMETERS']='ko uva'
   output=$(rename_remote)
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 }
 
 function test_rename_remote_rename_to_something_that_already_exists()
@@ -355,7 +355,7 @@ function test_rename_remote_rename_to_something_that_already_exists()
 
   options_values['PARAMETERS']='fedora-test arch-test'
   output=$(rename_remote)
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 }
 
 function test_rename_remote_change_a_valid_remote()
@@ -429,7 +429,7 @@ function test_set_default_remote_try_to_set_an_invalid_remote()
 
   options_values['DEFAULT_REMOTE']='palmares'
   output=$(set_default_remote)
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 }
 
 function test_set_default_remote_we_already_have_the_default_remote()
@@ -468,18 +468,18 @@ function test_parse_remote_options()
 {
   # Add option
   parse_remote_options --add origin 'root@la:3333'
-  assert_equals_helper 'Request add' "($LINENO)" "${options_values['ADD']}" 1
-  assert_equals_helper 'Remote options' "($LINENO)" "${options_values['PARAMETERS']}" 'origin root@la:3333 '
+  assert_equals_helper 'Request add' "($LINENO)" 1 "${options_values['ADD']}"
+  assert_equals_helper 'Remote options' "($LINENO)" 'origin root@la:3333 ' "${options_values['PARAMETERS']}"
 
   # Remove
   parse_remote_options --remove origin
-  assert_equals_helper 'Request remove' "($LINENO)" "${options_values['REMOVE']}" 1
-  assert_equals_helper 'Remote options' "($LINENO)" "${options_values['PARAMETERS']}" 'origin '
+  assert_equals_helper 'Request remove' "($LINENO)" 1 "${options_values['REMOVE']}"
+  assert_equals_helper 'Remote options' "($LINENO)" 'origin ' "${options_values['PARAMETERS']}"
 
   # Rename
   parse_remote_options --rename origin xpto
-  assert_equals_helper 'Request rename' "($LINENO)" "${options_values['RENAME']}" 1
-  assert_equals_helper 'Remote options' "($LINENO)" "${options_values['PARAMETERS']}" 'origin xpto '
+  assert_equals_helper 'Request rename' "($LINENO)" 1 "${options_values['RENAME']}"
+  assert_equals_helper 'Remote options' "($LINENO)" 'origin xpto ' "${options_values['PARAMETERS']}"
 }
 
 function test_list_remotes()
@@ -508,23 +508,23 @@ function test_list_remotes_invalid()
 {
   rm "${local_remote_config_file}"
   output=$(list_remotes)
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 
   rm -rf "${BASE_PATH_KW}"
   rm "${global_remote_config_file}"
   output=$(list_remotes)
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 }
 
 function test_kw_remote_without_valid_option()
 {
   # kw remote (no option nor parameter)
   parse_remote_options
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 
   # kw remote <params>[...] (no options)
   parse_remote_options
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 }
 
 function test_remove_remote_that_is_prefix_of_other_remote()
@@ -760,7 +760,7 @@ function test_global_option_list_remote_invalid()
   rm "${global_remote_config_file}"
   options_values['GLOBAL']='1'
   output=$(list_remotes)
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 }
 
 function setup_for_symbolic_link_test()

--- a/tests/unit/kw_test.sh
+++ b/tests/unit/kw_test.sh
@@ -11,7 +11,7 @@ function test_validate_global_variables()
   VARS=(KWORKFLOW KW_LIB_DIR)
   for v in "${VARS[@]}"; do
     test -z ${!v+x}
-    assertEquals "Variable $v should exist." $? 1
+    assertEquals "Variable ${v} should exist." 1 $?
   done
 }
 

--- a/tests/unit/lib/dialog_ui_test.sh
+++ b/tests/unit/lib/dialog_ui_test.sh
@@ -107,7 +107,7 @@ function test_create_simple_checklist_rely_on_some_default_options()
   expected_cmd+=" $'Checklist 1' '' 'on' $'Checklist 2' '' 'off'"
 
   output=$(create_simple_checklist "$menu_title" "$menu_message_box" 'menu_list_string_array' 'check_statuses' '' '' '' '' '' 'TEST_MODE')
-  assert_equals_helper 'Expected simple checklist' "$LINENO" "${output}" "${expected_cmd}"
+  assert_equals_helper 'Expected simple checklist' "$LINENO" "${expected_cmd}" "${output}"
 }
 
 function test_create_simple_checklist_use_all_options()
@@ -126,7 +126,7 @@ function test_create_simple_checklist_use_all_options()
   expected_cmd+=" $'Checklist 1' '' 'on' $'Checklist 2' '' 'off'"
 
   output=$(create_simple_checklist "$menu_title" "$menu_message_box" 'menu_list_string_array' 'check_statuses' 1 'Nop' '442' '244' '3' 'TEST_MODE')
-  assert_equals_helper 'Expected simple checklist' "$LINENO" "${output}" "${expected_cmd}"
+  assert_equals_helper 'Expected simple checklist' "$LINENO" "${expected_cmd}" "${output}"
 }
 
 function test_create_loading_screen_notification_rely_on_some_default_options()
@@ -139,7 +139,7 @@ function test_create_loading_screen_notification_rely_on_some_default_options()
   expected_cmd+=" '8' '60'"
 
   output=$(create_loading_screen_notification "$loading_message" '' '' 'TEST_MODE')
-  assert_equals_helper 'Expected loading screen with some default options' "$LINENO" "${output}" "${expected_cmd}"
+  assert_equals_helper 'Expected loading screen with some default options' "$LINENO" "${expected_cmd}" "${output}"
 }
 
 function test_create_loading_screen_notification_use_all_options()
@@ -152,7 +152,7 @@ function test_create_loading_screen_notification_use_all_options()
   expected_cmd+=" '1234' '4321'"
 
   output=$(create_loading_screen_notification "$loading_message" '1234' '4321' 'TEST_MODE')
-  assert_equals_helper 'Expected loading screen with some default options' "$LINENO" "${output}" "${expected_cmd}"
+  assert_equals_helper 'Expected loading screen with some default options' "$LINENO" "${expected_cmd}" "${output}"
 }
 
 function test_create_async_loading_screen_notification_rely_on_some_default_options()
@@ -177,7 +177,7 @@ function test_create_async_loading_screen_notification_rely_on_some_default_opti
   stop_async_loading_screen_notification "$pid"
 
   output=$(< "$output_path")
-  assert_equals_helper 'Expected async loading screen with some default options' "$LINENO" "$output" "$expected_cmd"
+  assert_equals_helper 'Expected async loading screen with some default options' "$LINENO" "$expected_cmd" "$output"
 }
 
 function test_create_async_loading_screen_notification_use_all_options()
@@ -202,7 +202,7 @@ function test_create_async_loading_screen_notification_use_all_options()
   stop_async_loading_screen_notification "$pid"
 
   output=$(< "$output_path")
-  assert_equals_helper 'Expected async loading screen with some default options' "$LINENO" "$output" "$expected_cmd"
+  assert_equals_helper 'Expected async loading screen with some default options' "$LINENO" "$expected_cmd" "$output"
 }
 
 function test_create_message_box_rely_on_some_default_options()
@@ -216,7 +216,7 @@ function test_create_message_box_rely_on_some_default_options()
   expected_cmd+=" --msgbox $'There\'re no bookmarked patches...'"
   expected_cmd+=" '15' '40'"
   output=$(create_message_box "${box_title}" "${message_box}" '' '' 'TEST_MODE')
-  assert_equals_helper 'Expected message box with some default options' "$LINENO" "$output" "${expected_cmd}"
+  assert_equals_helper 'Expected message box with some default options' "$LINENO" "${expected_cmd}" "$output"
 }
 
 function test_create_message_box_use_all_options()
@@ -230,7 +230,7 @@ function test_create_message_box_use_all_options()
   expected_cmd+=" --msgbox $'There\'re no bookmarked patches...'"
   expected_cmd+=" '1234' '4321'"
   output=$(create_message_box "${box_title}" "${message_box}" '1234' '4321' 'TEST_MODE')
-  assert_equals_helper 'Expected message box with all custom options' "$LINENO" "$output" "${expected_cmd}"
+  assert_equals_helper 'Expected message box with all custom options' "$LINENO" "${expected_cmd}" "$output"
 }
 
 function test_create_directory_selection_screen_rely_on_some_default_options()
@@ -569,10 +569,10 @@ function test_build_dialog_command_preamble()
 function test_prettify_string_failures()
 {
   prettify_string
-  assert_equals_helper 'Expected failure' "$LINENO" "$?" 22
+  assert_equals_helper 'Expected failure' "$LINENO" 22 "$?"
 
   prettify_string 'Something'
-  assert_equals_helper 'Expected failure' "$LINENO" "$?" 22
+  assert_equals_helper 'Expected failure' "$LINENO" 22 "$?"
 }
 
 function test_prettify_string()
@@ -581,7 +581,7 @@ function test_prettify_string()
   local expected_string='\Zb\Z6Series:\ZnSomething\n'
 
   output=$(prettify_string 'Series:' 'Something')
-  assert_equals_helper 'Expected pretty string' "$LINENO" "$output" "$expected_string"
+  assert_equals_helper 'Expected pretty string' "$LINENO" "$expected_string" "$output"
 }
 
 invoke_shunit

--- a/tests/unit/lib/kw_config_loader_test.sh
+++ b/tests/unit/lib/kw_config_loader_test.sh
@@ -73,16 +73,16 @@ function test_parse_configuration_config_with_spaces_and_comments()
   parse_configuration 'kworkflow_space_comments.config'
   assertEquals "($LINENO): Kw failed to load a regular config file" 0 "$?"
 
-  assertEquals "($LINENO)" "${configurations['ssh_user']}" 'juca'
-  assertEquals "($LINENO)" "${configurations['mount_point']}" '/home/lala'
-  assertEquals "($LINENO)" "${configurations['virtualizer']}" 'libvirt'
-  assertEquals "($LINENO)" "${configurations['reboot_after_deploy']}" 'no'
+  assertEquals "($LINENO)" 'juca' "${configurations['ssh_user']}"
+  assertEquals "($LINENO)" '/home/lala' "${configurations['mount_point']}"
+  assertEquals "($LINENO)" 'libvirt' "${configurations['virtualizer']}"
+  assertEquals "($LINENO)" 'no' "${configurations['reboot_after_deploy']}"
 }
 
 function test_parser_configuration_failed_exit_code()
 {
   parse_configuration 'tests/unit/foobarpotato'
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 }
 
 # Helper function used to compare expected config agaist the populated data.
@@ -270,13 +270,13 @@ function test_load_configuration()
 
   # No to updating kworkflow.config to .kw/kworkflow.config
   output="$(printf '%s\n' 'n' | load_kworkflow_config)"
-  assertEquals "($LINENO): There should have been a warning" "$output" "$msg"
+  assertEquals "($LINENO): There should have been a warning" "$msg" "$output"
   assertTrue 'kworkflow.config was moved' '[[ -f "$PWD/$CONFIG_FILENAME" ]]'
 
   # Yes to updating kworkflow.config to .kw/kworkflow.config
   output="$(printf '%s\n' 'y' | load_configuration)"
 
-  assertEquals "($LINENO): There should have been a warning" "$output" "$msg"
+  assertEquals "($LINENO): There should have been a warning" "$msg" "$output"
 
   assertTrue '.kw was not created' '[[ -d "$PWD/$KW_DIR/" ]]'
   assertTrue 'kworkflow.config is not inside .kw' '[[ -f "$PWD/$KW_DIR/$CONFIG_FILENAME" ]]'

--- a/tests/unit/lib/kw_include_test.sh
+++ b/tests/unit/lib/kw_include_test.sh
@@ -80,8 +80,8 @@ function test_include_similar_paths()
   test1_expected='output of test1'
   test2_expected='output of test2'
 
-  assertEquals "($LINENO)" "$test1_output" "$test1_expected"
-  assertEquals "($LINENO)" "$test2_output" "$test2_expected"
+  assertEquals "($LINENO)" "$test1_expected" "$test1_output"
+  assertEquals "($LINENO)" "$test2_expected" "$test2_output"
 }
 
 invoke_shunit

--- a/tests/unit/lib/kw_string_test.sh
+++ b/tests/unit/lib/kw_string_test.sh
@@ -294,20 +294,20 @@ function test_concatenate_with_commas()
   output=$(concatenate_with_commas)
   ret="$?"
   expected=''
-  assert_equals_helper 'No error expected' "$LINENO" "$ret" 0
-  assert_equals_helper 'Expected empty string' "$LINENO" "$output" "$expected"
+  assert_equals_helper 'No error expected' "$LINENO" 0 "$ret"
+  assert_equals_helper 'Expected empty string' "$LINENO" "$expected" "$output"
 
   output=$(concatenate_with_commas 'single')
   ret="$?"
   expected='single'
-  assert_equals_helper 'No error expected' "$LINENO" "$ret" 0
-  assert_equals_helper 'Wrong output' "$LINENO" "$output" "$expected"
+  assert_equals_helper 'No error expected' "$LINENO" 0 "$ret"
+  assert_equals_helper 'Wrong output' "$LINENO" "$expected" "$output"
 
   output=$(concatenate_with_commas 'first' 'second' 'third')
   ret="$?"
   expected='first,second,third'
-  assert_equals_helper 'No error expected' "$LINENO" "$ret" 0
-  assert_equals_helper 'Wrong output' "$LINENO" "$output" "$expected"
+  assert_equals_helper 'No error expected' "$LINENO" 0 "$ret"
+  assert_equals_helper 'Wrong output' "$LINENO" "$expected" "$output"
 }
 
 function test_str_has_special_characters()
@@ -317,10 +317,10 @@ function test_str_has_special_characters()
   local ret
 
   output=$(str_has_special_characters 'no special char here')
-  assert_equals_helper 'No error expected' "$LINENO" "$?" 1
+  assert_equals_helper 'No error expected' "$LINENO" 1 "$?"
 
   output=$(str_has_special_characters 'We have a special char!')
-  assert_equals_helper 'We expected a special char here' "$LINENO" "$?" 0
+  assert_equals_helper 'We expected a special char here' "$LINENO" 0 "$?"
 }
 
 function test_str_get_value_under_double_quotes()
@@ -329,18 +329,18 @@ function test_str_get_value_under_double_quotes()
   local expected='value under quotes'
 
   output=$(str_get_value_under_double_quotes 'This is a "value under quotes", right?')
-  assert_equals_helper 'Wrong values under quotes' "$LINENO" "$output" "$expected"
+  assert_equals_helper 'Wrong values under quotes' "$LINENO" "$expected" "$output"
 
   expected='Nothing around quotes'
   output=$(str_get_value_under_double_quotes '"Nothing around quotes"')
-  assert_equals_helper 'Wrong values under quotes' "$LINENO" "$output" "$expected"
+  assert_equals_helper 'Wrong values under quotes' "$LINENO" "$expected" "$output"
 
   expected='Two'
   output=$(str_get_value_under_double_quotes '"Two" and "Nothing around quotes" and "xpto"')
-  assert_equals_helper 'Wrong values under quotes' "$LINENO" "$output" "$expected"
+  assert_equals_helper 'Wrong values under quotes' "$LINENO" "$expected" "$output"
 
   output=$(str_get_value_under_double_quotes '')
-  assert_equals_helper 'Empty string' "$LINENO" "$?" 22
+  assert_equals_helper 'Empty string' "$LINENO" 22 "$?"
 
 }
 

--- a/tests/unit/lib/kw_time_and_date_test.sh
+++ b/tests/unit/lib/kw_time_and_date_test.sh
@@ -13,16 +13,16 @@ function setUp()
 function test_sec_to_format()
 {
   formatted_time=$(sec_to_format "$pre_total_sec")
-  assertEquals "($LINENO)" "$formatted_time" "$pre_formated_sec"
+  assertEquals "($LINENO)" "$pre_formated_sec" "$formatted_time"
 
   formatted_time=$(sec_to_format "")
-  assertEquals "($LINENO)" "$formatted_time" '00:00:00'
+  assertEquals "($LINENO)" '00:00:00' "$formatted_time"
 
   formatted_time=$(sec_to_format "$pre_total_sec" '+%M:%S')
-  assertEquals "($LINENO)" "$formatted_time" '30:46'
+  assertEquals "($LINENO)" '30:46' "$formatted_time"
 
   formatted_time=$(sec_to_format "$pre_total_sec" '+%S')
-  assertEquals "($LINENO)" "$formatted_time" '46'
+  assertEquals "($LINENO)" '46' "$formatted_time"
 }
 
 function test_secs_to_arbitrarily_long_hours_mins_secs()
@@ -152,14 +152,14 @@ function test_date_to_format()
   local formatted_date
 
   formatted_date=$(date_to_format '2020/3/1')
-  assert_equals_helper 'Today' "$LINENO" "$formatted_date" '2020/03/01'
+  assert_equals_helper 'Today' "$LINENO" '2020/03/01' "$formatted_date"
 
   formatted_date=$(date_to_format '2020/3/1' '+%Y/%m')
-  assert_equals_helper 'Today' "$LINENO" "$formatted_date" '2020/03'
+  assert_equals_helper 'Today' "$LINENO" '2020/03' "$formatted_date"
 
   formatted_date=$(date_to_format)
   today=$(date '+%Y/%m/%d')
-  assert_equals_helper 'Today' "$LINENO" "$formatted_date" "$today"
+  assert_equals_helper 'Today' "$LINENO" "$today" "$formatted_date"
 }
 
 function test_days_in_the_month()
@@ -171,57 +171,57 @@ function test_days_in_the_month()
   local ret
 
   total_days=$(days_in_the_month 2 2021)
-  assert_equals_helper 'We expect 28 days' "$LINENO" "$total_days" 28
+  assert_equals_helper 'We expect 28 days' "$LINENO" 28 "$total_days"
 
   total_days=$(days_in_the_month 02 2021)
-  assert_equals_helper 'We expect 28 days' "$LINENO" "$total_days" 28
+  assert_equals_helper 'We expect 28 days' "$LINENO" 28 "$total_days"
 
   # Leap year, February has 29 days
   total_days=$(days_in_the_month 2 2016)
-  assert_equals_helper 'We expect 29 days' "$LINENO" "$total_days" 29
+  assert_equals_helper 'We expect 29 days' "$LINENO" 29 "$total_days"
 
   total_days=$(days_in_the_month 2 300)
-  assert_equals_helper 'We expect 28 days' "$LINENO" "$total_days" 28
+  assert_equals_helper 'We expect 28 days' "$LINENO" 28 "$total_days"
 
   # Leap year, February has 29 days
   total_days=$(days_in_the_month 2 1600)
-  assert_equals_helper 'We expect 29 days' "$LINENO" "$total_days" 29
+  assert_equals_helper 'We expect 29 days' "$LINENO" 29 "$total_days"
 
   total_days=$(days_in_the_month 1 2016)
-  assert_equals_helper 'We expect 31 days' "$LINENO" "$total_days" 31
+  assert_equals_helper 'We expect 31 days' "$LINENO" 31 "$total_days"
 
   total_days=$(days_in_the_month 6 2021)
-  assert_equals_helper 'We expect 30 days' "$LINENO" "$total_days" 30
+  assert_equals_helper 'We expect 30 days' "$LINENO" 30 "$total_days"
 
   total_days=$(days_in_the_month 9 2021)
-  assert_equals_helper 'We expect 30 days' "$LINENO" "$total_days" 30
+  assert_equals_helper 'We expect 30 days' "$LINENO" 30 "$total_days"
 
   total_days=$(days_in_the_month 09 2021)
-  assert_equals_helper 'We expect 30 days' "$LINENO" "$total_days" 30
+  assert_equals_helper 'We expect 30 days' "$LINENO" 30 "$total_days"
 
   total_days=$(days_in_the_month 8 2021)
-  assert_equals_helper 'We expect 31 days' "$LINENO" "$total_days" 31
+  assert_equals_helper 'We expect 31 days' "$LINENO" 31 "$total_days"
 
   # Empty year should be converted to the present year
   total_days=$(days_in_the_month 8)
-  assert_equals_helper 'Use this year' "$LINENO" "$total_days" 31
+  assert_equals_helper 'Use this year' "$LINENO" 31 "$total_days"
 
   # An invalid month
   days_in_the_month 333
   ret="$?"
-  assert_equals_helper 'Invalid month' "$LINENO" "$ret" 22
+  assert_equals_helper 'Invalid month' "$LINENO" 22 "$ret"
 
   days_in_the_month -5
   ret="$?"
-  assert_equals_helper 'Invalid month' "$LINENO" "$ret" 22
+  assert_equals_helper 'Invalid month' "$LINENO" 22 "$ret"
 
   days_in_the_month -09
   ret="$?"
-  assert_equals_helper 'Invalid month' "$LINENO" "$ret" 22
+  assert_equals_helper 'Invalid month' "$LINENO" 22 "$ret"
 
   days_in_the_month -009
   ret="$?"
-  assert_equals_helper 'Invalid month' "$LINENO" "$ret" 22
+  assert_equals_helper 'Invalid month' "$LINENO" 22 "$ret"
 }
 
 function test_timebox_to_sec()

--- a/tests/unit/lib/kwlib_test.sh
+++ b/tests/unit/lib/kwlib_test.sh
@@ -230,10 +230,10 @@ function test_cmd_manager_check_test_mode_option()
   local ret
 
   ret=$(cmd_manager 'TEST_MODE' 'pwd')
-  assertEquals "Expected pwd, but we got $ret" "$ret" "pwd"
+  assertEquals "Expected pwd, but we got ${ret}" "pwd" "$ret"
 
   ret=$(cmd_manager 'TEST_MODE' 'ls -lah')
-  assertEquals "Expected ls -lah, but we got $ret" "$ret" "ls -lah"
+  assertEquals "Expected ls -lah, but we got ${ret}" "ls -lah" "$ret"
 }
 
 function test_detect_distro_root_path_only()
@@ -243,47 +243,47 @@ function test_detect_distro_root_path_only()
 
   root_path="${SAMPLES_DIR}/os/arch"
   output=$(detect_distro "$root_path")
-  assert_equals_helper '' "$LINENO" "$output" 'arch'
+  assert_equals_helper '' "$LINENO" 'arch' "$output"
 
   root_path="${SAMPLES_DIR}/os/manjaro"
   output=$(detect_distro "$root_path")
-  assert_equals_helper '' "$LINENO" "$output" 'arch'
+  assert_equals_helper '' "$LINENO" 'arch' "$output"
 
   root_path="${SAMPLES_DIR}/os/ubuntu"
   output=$(detect_distro "$root_path")
-  assert_equals_helper '' "$LINENO" "$output" 'debian'
+  assert_equals_helper '' "$LINENO" 'debian' "$output"
 
   root_path="${SAMPLES_DIR}/os/debian"
   output=$(detect_distro "$root_path")
-  assert_equals_helper '' "$LINENO" "$output" 'debian'
+  assert_equals_helper '' "$LINENO" 'debian' "$output"
 
   root_path="${SAMPLES_DIR}/os/raspbian"
   output=$(detect_distro "$root_path")
-  assert_equals_helper '' "$LINENO" "$output" 'debian'
+  assert_equals_helper '' "$LINENO" 'debian' "$output"
 
   root_path="${SAMPLES_DIR}/os/fedora"
   output=$(detect_distro "$root_path")
-  assert_equals_helper '' "$LINENO" "$output" 'fedora'
+  assert_equals_helper '' "$LINENO" 'fedora' "$output"
 
   root_path="${SAMPLES_DIR}/os/arch-linux-arm"
   output=$(detect_distro "$root_path")
-  assert_equals_helper '' "$LINENO" "$output" 'arch'
+  assert_equals_helper '' "$LINENO" 'arch' "$output"
 
   root_path="${SAMPLES_DIR}/os/endeavouros"
   output=$(detect_distro "$root_path")
-  assert_equals_helper '' "$LINENO" "$output" 'arch'
+  assert_equals_helper '' "$LINENO" 'arch' "$output"
 
   root_path="${SAMPLES_DIR}/os/steamos"
   output=$(detect_distro "$root_path")
-  assert_equals_helper '' "$LINENO" "$output" 'arch'
+  assert_equals_helper '' "$LINENO" 'arch' "$output"
 
   root_path="${SAMPLES_DIR}/os/popos"
   output=$(detect_distro "$root_path")
-  assert_equals_helper '' "$LINENO" "$output" 'debian'
+  assert_equals_helper '' "$LINENO" 'debian' "$output"
 
   root_path="${SAMPLES_DIR}/os/none"
   output=$(detect_distro "$root_path")
-  assert_equals_helper '' "$LINENO" "$output" 'none'
+  assert_equals_helper '' "$LINENO" 'none' "$output"
 }
 
 function test_detect_distro_str_check()
@@ -292,22 +292,22 @@ function test_detect_distro_str_check()
   local output
 
   output=$(detect_distro '/' 'arch')
-  assert_equals_helper '' "$LINENO" "$output" 'arch'
+  assert_equals_helper '' "$LINENO" 'arch' "$output"
 
   output=$(detect_distro '' 'debian')
-  assert_equals_helper '' "$LINENO" "$output" 'debian'
+  assert_equals_helper '' "$LINENO" 'debian' "$output"
 
   output=$(detect_distro '' 'fedora')
-  assert_equals_helper '' "$LINENO" "$output" 'fedora'
+  assert_equals_helper '' "$LINENO" 'fedora' "$output"
 
   output=$(detect_distro '' 'ubuntu')
-  assert_equals_helper '' "$LINENO" "$output" 'none'
+  assert_equals_helper '' "$LINENO" 'none' "$output"
 
   output=$(detect_distro '' 'ubuntu debian')
-  assert_equals_helper '' "$LINENO" "$output" 'debian'
+  assert_equals_helper '' "$LINENO" 'debian' "$output"
 
   output=$(detect_distro '' 'manjaro steamos lala arch')
-  assert_equals_helper '' "$LINENO" "$output" 'arch'
+  assert_equals_helper '' "$LINENO" 'arch' "$output"
 }
 
 function test_detect_distro_from_raw_data()
@@ -319,57 +319,57 @@ function test_detect_distro_from_raw_data()
   root_path="${SAMPLES_DIR}/os/arch/etc/os-release"
   os_release_data=$(< "$root_path")
   output=$(detect_distro '' '' "$os_release_data")
-  assert_equals_helper '' "$LINENO" "$output" 'arch'
+  assert_equals_helper '' "$LINENO" 'arch' "$output"
 
   root_path="${SAMPLES_DIR}/os/manjaro/etc/os-release"
   os_release_data=$(< "$root_path")
   output=$(detect_distro '' '' "$os_release_data")
-  assert_equals_helper '' "$LINENO" "$output" 'arch'
+  assert_equals_helper '' "$LINENO" 'arch' "$output"
 
   root_path="${SAMPLES_DIR}/os/ubuntu/etc/os-release"
   os_release_data=$(< "$root_path")
   output=$(detect_distro '' '' "$os_release_data")
-  assert_equals_helper '' "$LINENO" "$output" 'debian'
+  assert_equals_helper '' "$LINENO" 'debian' "$output"
 
   root_path="${SAMPLES_DIR}/os/debian/etc/os-release"
   os_release_data=$(< "$root_path")
   output=$(detect_distro '' '' "$os_release_data")
-  assert_equals_helper '' "$LINENO" "$output" 'debian'
+  assert_equals_helper '' "$LINENO" 'debian' "$output"
 
   root_path="${SAMPLES_DIR}/os/raspbian/etc/os-release"
   os_release_data=$(< "$root_path")
   output=$(detect_distro '' '' "$os_release_data")
-  assert_equals_helper '' "$LINENO" "$output" 'debian'
+  assert_equals_helper '' "$LINENO" 'debian' "$output"
 
   root_path="${SAMPLES_DIR}/os/fedora/etc/os-release"
   os_release_data=$(< "$root_path")
   output=$(detect_distro '' '' "$os_release_data")
-  assert_equals_helper '' "$LINENO" "$output" 'fedora'
+  assert_equals_helper '' "$LINENO" 'fedora' "$output"
 
   root_path="${SAMPLES_DIR}/os/arch-linux-arm/etc/os-release"
   os_release_data=$(< "$root_path")
   output=$(detect_distro '' '' "$os_release_data")
-  assert_equals_helper '' "$LINENO" "$output" 'arch'
+  assert_equals_helper '' "$LINENO" 'arch' "$output"
 
   root_path="${SAMPLES_DIR}/os/endeavouros/etc/os-release"
   os_release_data=$(< "$root_path")
   output=$(detect_distro '' '' "$os_release_data")
-  assert_equals_helper '' "$LINENO" "$output" 'arch'
+  assert_equals_helper '' "$LINENO" 'arch' "$output"
 
   root_path="${SAMPLES_DIR}/os/steamos/etc/os-release"
   os_release_data=$(< "$root_path")
   output=$(detect_distro '' '' "$os_release_data")
-  assert_equals_helper '' "$LINENO" "$output" 'arch'
+  assert_equals_helper '' "$LINENO" 'arch' "$output"
 
   root_path="${SAMPLES_DIR}/os/popos/etc/os-release"
   os_release_data=$(< "$root_path")
   output=$(detect_distro '' '' "$os_release_data")
-  assert_equals_helper '' "$LINENO" "$output" 'debian'
+  assert_equals_helper '' "$LINENO" 'debian' "$output"
 
   root_path="${SAMPLES_DIR}/os/none/etc/os-release"
   os_release_data=$(< "$root_path")
   output=$(detect_distro '' '' "$os_release_data")
-  assert_equals_helper '' "$LINENO" "$output" 'none'
+  assert_equals_helper '' "$LINENO" 'none' "$output"
 }
 
 function test_join_path()
@@ -378,19 +378,19 @@ function test_join_path()
   local ret
 
   ret=$(join_path "/lala" "///xpto")
-  assertEquals "Expect /lala/xpto" "$ret" "$base"
+  assertEquals "Expect /lala/xpto" "$base" "$ret"
 
   ret=$(join_path "/lala" "/xpto////")
-  assertEquals "Expect /lala/xpto" "$ret" "$base"
+  assertEquals "Expect /lala/xpto" "$base" "$ret"
 
   ret=$(join_path "/lala" "////xpto////")
-  assertEquals "Expect /lala/xpto" "$ret" "$base"
+  assertEquals "Expect /lala/xpto" "$base" "$ret"
 
   ret=$(join_path "/lala" "//test///xpto////")
-  assertEquals "Expect /lala/test/xpto" "$ret" "/lala/test/xpto"
+  assertEquals "Expect /lala/test/xpto" "/lala/test/xpto" "$ret"
 
   ret=$(join_path "/lala/")
-  assertEquals "Expect /lala/" "$ret" "/lala/"
+  assertEquals "Expect /lala/" "/lala/" "$ret"
 }
 
 function test_find_kernel_root()
@@ -401,13 +401,13 @@ function test_find_kernel_root()
   mkdir -p "$fake_path"
 
   kernel_path=$(find_kernel_root "$fake_path")
-  assertEquals "We expected to find a kernel path" "$kernel_path" "$SHUNIT_TMPDIR"
+  assertEquals "We expected to find a kernel path" "$SHUNIT_TMPDIR" "$kernel_path"
 
   kernel_path=$(find_kernel_root "/tmp")
-  assertEquals "We should not find a path" "$kernel_path" ""
+  assertEquals "We should not find a path" "" "$kernel_path"
 
   kernel_path=$(find_kernel_root "test/")
-  assertEquals "We should not find a path" "$kernel_path" ""
+  assertEquals "We should not find a path" "" "$kernel_path"
 }
 
 function test_is_a_patch()

--- a/tests/unit/lib/lore_test.sh
+++ b/tests/unit/lib/lore_test.sh
@@ -66,12 +66,12 @@ function test_retrieve_available_mailing_lists()
 
   for index in "${!expected_lists[@]}"; do
     assert_equals_helper "We expected '$index' to be a valid key" "($LINENO)" \
-      "${available_lore_mailing_lists["$index"]}" "${expected_lists["$index"]}"
+      "${expected_lists["$index"]}" "${available_lore_mailing_lists["$index"]}"
   done
 
   for index in "${!available_lore_mailing_lists[@]}"; do
     assert_equals_helper "We didn't expect '$index' to be a valid key" "($LINENO)" \
-      "${available_lore_mailing_lists["$index"]}" "${expected_lists["$index"]}"
+      "${expected_lists["$index"]}" "${available_lore_mailing_lists["$index"]}"
   done
 }
 
@@ -406,15 +406,15 @@ function test_process_name()
   local expected='First Second'
 
   output=$(process_name 'Second, First')
-  assertEquals "($LINENO)" "$output" "$expected"
+  assertEquals "($LINENO)" "$expected" "$output"
 
   output=$(process_name 'Second Third, First')
   expected='First Second Third'
-  assertEquals "($LINENO)" "$output" "$expected"
+  assertEquals "($LINENO)" "$expected" "$output"
 
   output=$(process_name 'First Second')
   expected='First Second'
-  assertEquals "($LINENO)" "$output" "$expected"
+  assertEquals "($LINENO)" "$expected" "$output"
 }
 
 function test_delete_series_from_local_storage()

--- a/tests/unit/lib/statistics_test.sh
+++ b/tests/unit/lib/statistics_test.sh
@@ -64,10 +64,10 @@ function test_calculate_total_of_data()
 function test_max_value()
 {
   max=$(max_value "0")
-  assertEquals "($LINENO)" "$max" "0"
+  assertEquals "($LINENO)" 0 "$max"
 
   max=$(max_value "")
-  assertEquals "($LINENO)" "$max" "0"
+  assertEquals "($LINENO)" 0 "$max"
 
   max=$(max_value "$pre_values")
   assertEquals "($LINENO)" "$pre_max" "$max"
@@ -76,13 +76,13 @@ function test_max_value()
 function test_min_value()
 {
   min=$(min_value "0" "0")
-  assertEquals "($LINENO)" "$min" "0"
+  assertEquals "($LINENO)" 0 "$min"
 
   min=$(min_value "" "")
-  assertEquals "($LINENO)" "$min" ""
+  assertEquals "($LINENO)" "" "$min"
 
   min=$(min_value "$pre_values" "$pre_max")
-  assertEquals "($LINENO)" "$min" "$pre_min"
+  assertEquals "($LINENO)" "$pre_min" "$min"
 }
 
 # Note: The weekly, monthly, and yearly calculation uses `basic_data_process`.
@@ -98,11 +98,11 @@ function test_basic_data_process()
 
   basic_data_process "$data"
   build="${shared_data["build"]}"
-  assertEquals "($LINENO)" "$build_output" "$build"
+  assertEquals "($LINENO)" "$build" "$build_output"
 
   basic_data_process "$data"
   deploy="${shared_data["deploy"]}"
-  assertEquals "($LINENO)" "$deploy_output" "$deploy"
+  assertEquals "($LINENO)" "$deploy" "$deploy_output"
 
   basic_data_process "$data"
   deploy="${shared_data["list"]}"

--- a/tests/unit/lib/web_test.sh
+++ b/tests/unit/lib/web_test.sh
@@ -37,20 +37,20 @@ function test_download()
   output=$(download '' '' '' 'TEST_MODE')
   ret="$?"
   expected='URL must not be empty.'
-  assert_equals_helper 'We expected to get an error for an empty URL' "($LINENO)" "$ret" 22
-  assert_equals_helper 'We expected an error message' "($LINENO)" "$output" "$expected"
+  assert_equals_helper 'We expected to get an error for an empty URL' "($LINENO)" 22 "$ret"
+  assert_equals_helper 'We expected an error message' "($LINENO)" "$expected" "$output"
 
   output=$(download 'http://some-url.com' '' '' 'TEST_MODE')
   expected="curl --silent 'http://some-url.com' --output 'fake_cache/page.xml'"
-  assert_equals_helper 'We expected the correct curl command' "($LINENO)" "$output" "$expected"
+  assert_equals_helper 'We expected the correct curl command' "($LINENO)" "$expected" "$output"
 
   output=$(download 'http://some-url.com' 'some-file.html' '' 'TEST_MODE')
   expected="curl --silent 'http://some-url.com' --output 'fake_cache/some-file.html'"
-  assert_equals_helper 'We expected a custom file name' "($LINENO)" "$output" "$expected"
+  assert_equals_helper 'We expected a custom file name' "($LINENO)" "$expected" "$output"
 
   output=$(download 'http://some-url.com' 'some-file.html' 'alt_path' 'TEST_MODE')
   expected="curl --silent 'http://some-url.com' --output 'alt_path/some-file.html'"
-  assert_equals_helper 'We expected a custom file name and path' "($LINENO)" "$output" "$expected"
+  assert_equals_helper 'We expected a custom file name and path' "($LINENO)" "$expected" "$output"
 }
 
 function test_replace_http_by_https()
@@ -59,15 +59,15 @@ function test_replace_http_by_https()
   local expected='https://lore.kernel.org/'
 
   output=$(replace_http_by_https 'http://lore.kernel.org/')
-  assert_equals_helper 'Expected https' "($LINENO)" "$output" "$expected"
+  assert_equals_helper 'Expected https' "($LINENO)" "$expected" "$output"
 
   output=$(replace_http_by_https 'https://lore.kernel.org/')
-  assert_equals_helper 'Expected https' "($LINENO)" "$output" "$expected"
+  assert_equals_helper 'Expected https' "($LINENO)" "$expected" "$output"
 
   expected='lore.kernel.org/'
   output=$(replace_http_by_https 'lore.kernel.org/')
-  assert_equals_helper 'No http prefix' "($LINENO)" "$?" 1
-  assert_equals_helper 'Expected https' "($LINENO)" "$output" "$expected"
+  assert_equals_helper 'No http prefix' "($LINENO)" 1 "$?"
+  assert_equals_helper 'Expected https' "($LINENO)" "$expected" "$output"
 }
 
 function test_is_html_file_with_non_html_files()

--- a/tests/unit/mail_test.sh
+++ b/tests/unit/mail_test.sh
@@ -963,7 +963,7 @@ function test_mail_verify()
 
   output=$(mail_verify)
   ret="$?"
-  assert_equals_helper 'Failed verify expected an error' "$LINENO" "$ret" 22
+  assert_equals_helper 'Failed verify expected an error' "$LINENO" 22 "$ret"
   compare_command_sequence '' "$LINENO" 'expected_results' "$output"
 
   unset options_values
@@ -988,7 +988,7 @@ function test_mail_verify()
 
   output=$(mail_verify)
   ret="$?"
-  assert_equals_helper 'Expected a success' "$LINENO" "$ret" 0
+  assert_equals_helper 'Expected a success' "$LINENO" 0 "$ret"
   compare_command_sequence '' "$LINENO" 'expected_results' "$output"
 
   unset options_values

--- a/tests/unit/maintainers_test.sh
+++ b/tests/unit/maintainers_test.sh
@@ -81,13 +81,13 @@ function oneTimeTearDown()
 function test_print_files_authors()
 {
   local -r ret=$(print_files_authors "tests/unit/samples/print_file_author_test_dir/code1.c")
-  multilineAssertEquals "$ret" "$CORRECT_FILE_MSG"
+  multilineAssertEquals "$CORRECT_FILE_MSG" "$ret"
 }
 
 function test_print_files_authors_from_dir()
 {
   local -r ret=$(print_files_authors "tests/unit/samples/print_file_author_test_dir")
-  multilineAssertEquals "$ret" "$CORRECT_DIR_MSG"
+  multilineAssertEquals "$CORRECT_DIR_MSG" "$ret"
 }
 
 function test_maintainers_main()
@@ -103,20 +103,20 @@ function test_maintainers_main()
     return
   }
   ret="$(maintainers_main .)"
-  multilineAssertEquals "$ret" "$CORRECT_TMP_MSG"
+  multilineAssertEquals "$CORRECT_TMP_MSG" "$ret"
 
   ret="$(maintainers_main fs)"
-  multilineAssertEquals "$ret" "$CORRECT_TMP_FS_MSG"
+  multilineAssertEquals "$CORRECT_TMP_FS_MSG" "$ret"
 
   cd fs || {
     fail "($LINENO) It was not possible to move to fs directory"
     return
   }
   ret="$(maintainers_main ..)"
-  multilineAssertEquals "$ret" "$CORRECT_TMP_MSG"
+  multilineAssertEquals "$CORRECT_TMP_MSG" "$ret"
 
   ret="$(maintainers_main .)"
-  multilineAssertEquals "$ret" "$CORRECT_TMP_FS_MSG"
+  multilineAssertEquals "$CORRECT_TMP_FS_MSG" "$ret"
   cd "$original_dir" || {
     fail "($LINENO) It was not possible to move back from temp directory"
     return
@@ -132,28 +132,28 @@ function test_maintainers_main_patch()
   }
 
   ret="$(maintainers_main update_patch_test.patch)"
-  multilineAssertEquals "$ret" "$CORRECT_TMP_MSG"
+  multilineAssertEquals "$CORRECT_TMP_MSG" "$ret"
 
   # test -u
   cp -f update_patch_test.patch{,.bak}
   ret="$(maintainers_main -u update_patch_test.patch)"
-  multilineAssertEquals "$ret" "$CORRECT_TMP_PATCH_MSG"
+  multilineAssertEquals "$CORRECT_TMP_PATCH_MSG" "$ret"
   assertFileEquals update_patch_test{,_model}.patch
   cp -f update_patch_test.patch{.bak,}
 
   # test --update-patch
   ret="$(maintainers_main --update-patch update_patch_test.patch)"
-  multilineAssertEquals "$ret" "$CORRECT_TMP_PATCH_MSG"
+  multilineAssertEquals "$CORRECT_TMP_PATCH_MSG" "$ret"
   assertFileEquals update_patch_test{,_model}.patch
 
   # test for already existing maintainers
   ret="$(maintainers_main -u update_patch_test.patch)"
-  multilineAssertEquals "$ret" "$CORRECT_TMP_PATCH_ALREADY_IN_MSG"
+  multilineAssertEquals "$CORRECT_TMP_PATCH_ALREADY_IN_MSG" "$ret"
   assertFileEquals update_patch_test{,_model}.patch
 
   # test for already existing "To:" field without maintainers
   ret="$(maintainers_main -u update_patch_test2.patch)"
-  multilineAssertEquals "$ret" "$CORRECT_TMP_PATCH2_MSG"
+  multilineAssertEquals "$CORRECT_TMP_PATCH2_MSG" "$ret"
   assertFileEquals update_patch_test{,_model}2.patch
 
   cd "$original_dir" || {

--- a/tests/unit/plugins/kernel_install/arch_test.sh
+++ b/tests/unit/plugins/kernel_install/arch_test.sh
@@ -128,7 +128,7 @@ function test_generate_arch_temporary_root_file_system_remote_and_not_supported(
     generate_arch_temporary_root_file_system 'TEST_MODE' "$name" 'remote' 'GRUB'
   )"
 
-  assertEquals "($LINENO)" "$?" 22
+  assertEquals "($LINENO)" 22 "$?"
 }
 
 function test_generate_arch_temporary_root_file_system_remote_preferred_root_fs()

--- a/tests/unit/plugins/kernel_install/utils_test.sh
+++ b/tests/unit/plugins/kernel_install/utils_test.sh
@@ -455,7 +455,7 @@ function test_install_modules()
   local lib_modules_path_bkp="$LIB_MODULES_PATH"
 
   output=$(install_modules "$module_target" 'TEST_MODE')
-  assert_equals_helper 'We did not find required files' "$LINENO" "$?" 2
+  assert_equals_helper 'We did not find required files' "$LINENO" 2 "$?"
 
   cd "$test_tmp_file" || {
     fail "($LINENO) It was not possible to move to temporary directory"
@@ -532,10 +532,12 @@ function test_install_kernel_remote()
   mk_fake_tar_file_to_deploy "$PWD" "$KW_DEPLOY_TMP_FILE" "$name"
   mkdir -p "${KW_DEPLOY_TMP_FILE}/kw_pkg"
   touch "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
-  printf 'kernel_name=%s\n' "$name" > "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
-  printf 'kernel_binary_image_file=%s\n' "$kernel_image_name" >> "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
-  printf 'architecture=%s\n' "$architecture" >> "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
-  printf 'previous_kernel_backup=yes\n' >> "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
+  {
+    printf 'kernel_name=%s\n' "$name"
+    printf 'kernel_binary_image_file=%s\n' "$kernel_image_name"
+    printf 'architecture=%s\n' "$architecture"
+    printf 'previous_kernel_backup=yes\n'
+  } > "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
   touch "${PWD}/boot/vmlinuz-${name}"
 
   output=$(install_kernel 'debian' "$reboot" "$target" 'TEST_MODE')
@@ -575,9 +577,11 @@ function test_install_kernel_local()
   mk_fake_tar_file_to_deploy "$PWD" "$KW_DEPLOY_TMP_FILE"
   mkdir -p "${KW_DEPLOY_TMP_FILE}/kw_pkg"
   touch "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
-  printf 'kernel_name=%s\n' "$name" > "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
-  printf 'kernel_binary_image_file=%s\n' "$kernel_image_name" >> "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
-  printf 'architecture=%s\n' "$architecture" >> "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
+  {
+    printf 'kernel_name=%s\n' "$name"
+    printf 'kernel_binary_image_file=%s\n' "$kernel_image_name"
+    printf 'architecture=%s\n' "$architecture"
+  } > "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
 
   # Check standard remote kernel installation
   declare -a cmd_sequence=(
@@ -659,19 +663,19 @@ function test_is_filesystem_writable()
   local expected_cmd
 
   output=$(is_filesystem_writable 'ext4' 'TEST_MODE')
-  assert_equals_helper 'Expected nothing' "$LINENO" "$?" 0
+  assert_equals_helper 'Expected nothing' "$LINENO" 0 "$?"
 
   output=$(is_filesystem_writable 'xpto-lala' 'TEST_MODE')
-  assert_equals_helper 'Expected EOPNOTSUPP error' "$LINENO" "$?" 95
+  assert_equals_helper 'Expected EOPNOTSUPP error' "$LINENO" 95 "$?"
 
   output=$(is_filesystem_writable 'btrfs' 'TEST_MODE')
   expected_cmd='btrfs property get / ro | grep "ro=false" --silent'
-  assert_equals_helper 'Expected btrfs property get command' "$LINENO" "$output" "$expected_cmd"
+  assert_equals_helper 'Expected btrfs property get command' "$LINENO" "$expected_cmd" "$output"
 
   AB_ROOTFS_PARTITION="${PWD}/kw"
   output=$(is_filesystem_writable 'ext4' 'TEST_MODE')
   expected_cmd="tune2fs -l '$AB_ROOTFS_PARTITION' | grep -q '^Filesystem features: .*read-only.*$'"
-  assert_equals_helper 'Expected tune2fs command' "$LINENO" "$output" "$expected_cmd"
+  assert_equals_helper 'Expected tune2fs command' "$LINENO" "$expected_cmd" "$output"
 }
 
 function test_make_root_partition_writable()
@@ -686,7 +690,7 @@ function test_make_root_partition_writable()
     }
     make_root_partition_writable 'TEST_MODE'
   )"
-  assert_equals_helper 'It is writable, do nothing' "$LINENO" "$?" 0
+  assert_equals_helper 'It is writable, do nothing' "$LINENO" 0 "$?"
 
   # Check ext4
   AB_ROOTFS_PARTITION='/xpto/la'

--- a/tests/unit/plugins/kw_mail/to_cc_cmd_test.sh
+++ b/tests/unit/plugins/kw_mail/to_cc_cmd_test.sh
@@ -35,11 +35,11 @@ function test_to_cc_main()
 
   bash "$to_cc_cmd" "$FAKE_CACHE" 'to' ''
   ret="$?"
-  assert_equals_helper 'Empty patch path should return an error' "$LINENO" "$ret" 22
+  assert_equals_helper 'Empty patch path should return an error' "$LINENO" 22 "$ret"
 
   bash "$to_cc_cmd" "$FAKE_CACHE" '' 'to_list'
   ret="$?"
-  assert_equals_helper 'Empty to_cc should return an error' "$LINENO" "$ret" 22
+  assert_equals_helper 'Empty to_cc should return an error' "$LINENO" 22 "$ret"
 
   output="$(bash "$to_cc_cmd" "$FAKE_CACHE" to to_list)"
   expected="$TO_LIST"

--- a/tests/unit/pomodoro_test.sh
+++ b/tests/unit/pomodoro_test.sh
@@ -118,63 +118,63 @@ function test_parse_pomodoro()
   local output
 
   parse_pomodoro '-t' '10m'
-  assert_equals_helper 'Time parser failed (minutes)' "$LINENO" "${options_values['TIMER']}" '10m'
+  assert_equals_helper 'Time parser failed (minutes)' "$LINENO" '10m' "${options_values['TIMER']}"
 
   parse_pomodoro '-t' '333h'
-  assert_equals_helper 'Time parser failed (hour)' "$LINENO" "${options_values['TIMER']}" '333h'
+  assert_equals_helper 'Time parser failed (hour)' "$LINENO" '333h' "${options_values['TIMER']}"
 
   parse_pomodoro '--set-timer' '234s'
-  assert_equals_helper 'Time parser failed (sec)' "$LINENO" "${options_values['TIMER']}" '234s'
+  assert_equals_helper 'Time parser failed (sec)' "$LINENO" '234s' "${options_values['TIMER']}"
 
   output=$(parse_pomodoro '--set-timer' '23 s')
-  assert_equals_helper 'No space' "$LINENO" "$?" '22'
+  assert_equals_helper 'No space' "$LINENO" 22 "$?"
 
   output=$(parse_pomodoro '--set-timer' '234')
-  assert_equals_helper 'No suffix' "$LINENO" "$?" '22'
+  assert_equals_helper 'No suffix' "$LINENO" 22 "$?"
 
   output=$(parse_pomodoro '--set-timer' 'uum')
-  assert_equals_helper 'No a number' "$LINENO" "$?" '22'
+  assert_equals_helper 'No a number' "$LINENO" 22 "$?"
 
   parse_pomodoro '--check-timer'
-  assert_equals_helper 'Show current timebox' "$LINENO" "${options_values['SHOW_TIMER']}" '1'
+  assert_equals_helper 'Show current timebox' "$LINENO" 1 "${options_values['SHOW_TIMER']}"
 
   parse_pomodoro '--tag' 'Something is here'
-  assert_equals_helper 'Tag requires set timer' "$LINENO" "$?" 22
+  assert_equals_helper 'Tag requires set timer' "$LINENO" 22 "$?"
 
   parse_pomodoro '--set-timer' '1234s' '--tag' 'Something is here'
-  assert_equals_helper 'Get tag' "$LINENO" "${options_values['TAG']}" 'Something is here'
+  assert_equals_helper 'Get tag' "$LINENO" 'Something is here' "${options_values['TAG']}"
 
   parse_pomodoro '--set-timer' '1234s' '--tag' '   Extra space   '
-  assert_equals_helper 'Handle extra space failed' "$LINENO" "${options_values['TAG']}" 'Extra space'
+  assert_equals_helper 'Handle extra space failed' "$LINENO" 'Extra space' "${options_values['TAG']}"
 
   str_sample='com ç -u ^ xpo-la ¬ x--bl'
   parse_pomodoro '--set-timer' '1234s' '--tag' "$str_sample"
-  assert_equals_helper 'Handle diverse chars' "$LINENO" "${options_values['TAG']}" "$str_sample"
+  assert_equals_helper 'Handle diverse chars' "$LINENO" "$str_sample" "${options_values['TAG']}"
 
   output=$(parse_pomodoro '--description' 'lala lalala')
-  assert_equals_helper 'Description requires tag' "$LINENO" "$?" 22
+  assert_equals_helper 'Description requires tag' "$LINENO" 22 "$?"
 
   output=$(parse_pomodoro '-g' 'Some tag' '--description' 'lala lalala')
-  assert_equals_helper 'Description requires set timer' "$LINENO" "$?" 22
+  assert_equals_helper 'Description requires set timer' "$LINENO" 22 "$?"
 
   str_sample='This is just a simple description'
   parse_pomodoro '--set-timer' '1234s' '--tag' 'Some tag' '-d' "$str_sample"
-  assert_equals_helper 'Wrong description' "$LINENO" "${options_values['DESCRIPTION']}" "$str_sample"
+  assert_equals_helper 'Wrong description' "$LINENO" "$str_sample" "${options_values['DESCRIPTION']}"
 
   str_sample_spaces='            This is just a simple description    '
   parse_pomodoro '--set-timer' '1234s' '--tag' 'Some tag' '-d' "$str_sample_spaces"
-  assert_equals_helper 'Wrong description' "$LINENO" "${options_values['DESCRIPTION']}" "$str_sample"
+  assert_equals_helper 'Wrong description' "$LINENO" "$str_sample" "${options_values['DESCRIPTION']}"
 
   str_sample='Does --comment --lal -u -x xpto-bla and xpto--blablbal'
   parse_pomodoro '--set-timer' '1234s' '--tag' 'Some tag' '-d' "$str_sample"
-  assert_equals_helper 'Wrong description' "$LINENO" "${options_values['DESCRIPTION']}" "$str_sample"
+  assert_equals_helper 'Wrong description' "$LINENO" "$str_sample" "${options_values['DESCRIPTION']}"
 
   apostrophe="Let's try something with apostrophe (I'm, you're, we're)"
   parse_pomodoro '--set-timer' '1234s' '--tag' 'apostrophe' '--description' "$apostrophe"
-  assert_equals_helper 'Wrong description' "$LINENO" "${options_values['DESCRIPTION']}" "$apostrophe"
+  assert_equals_helper 'Wrong description' "$LINENO" "$apostrophe" "${options_values['DESCRIPTION']}"
 
   parse_pomodoro '--verbose'
-  assert_equals_helper 'Show a detailed output' "$LINENO" "${options_values['VERBOSE']}" '1'
+  assert_equals_helper 'Show a detailed output' "$LINENO" 1 "${options_values['VERBOSE']}"
 }
 
 function test_register_data_for_report()
@@ -246,7 +246,7 @@ function test_is_tag_already_registered()
 
   sqlite3 "${KW_DATA_DIR}/kw.db" -batch "INSERT INTO tag ('name') VALUES ('Tag 0') ;"
   is_tag_already_registered '' 'Tag 0'
-  assertEquals "$LINENO: We expect to find Tag 0" "$?" 0
+  assertEquals "$LINENO: We expect to find Tag 0" 0 "$?"
 }
 
 function test_get_tag_name()
@@ -255,7 +255,7 @@ function test_get_tag_name()
   local expected
 
   get_tag_name ''
-  assert_equals_helper 'Empty string should be detected' "$LINENO" '22' "$?"
+  assert_equals_helper 'Empty string should be detected' "$LINENO" 22 "$?"
 
   output=$(get_tag_name 'Some tag')
   expected='Some tag'
@@ -274,10 +274,10 @@ function test_get_tag_name()
 
   # Try to get an ID out of range
   get_tag_name 65
-  assert_equals_helper 'Out of range' "$LINENO" '22' "$?"
+  assert_equals_helper 'Out of range' "$LINENO" 22 "$?"
 
   get_tag_name -2
-  assert_equals_helper 'Out of range' "$LINENO" '22' "$?"
+  assert_equals_helper 'Out of range' "$LINENO" 22 "$?"
 }
 
 function test_is_valid_argument()

--- a/tests/unit/report_test.sh
+++ b/tests/unit/report_test.sh
@@ -65,62 +65,62 @@ function test_parse_report_options()
   # Default values
   parse_report_options '--day'
   expected_result=$(get_today_info '+%Y/%m/%d')
-  assert_equals_helper 'Get today info' "$LINENO" "${options_values['DAY']}" "$expected_result"
+  assert_equals_helper 'Get today info' "$LINENO" "$expected_result" "${options_values['DAY']}"
 
   parse_report_options '--week'
   expected_result=$(get_days_of_week)
-  assert_equals_helper 'Get this week info' "$LINENO" "${options_values['WEEK']}" "$expected_result"
+  assert_equals_helper 'Get this week info' "$LINENO" "$expected_result" "${options_values['WEEK']}"
 
   parse_report_options '--month'
   expected_result=$(get_today_info '+%Y/%m')
-  assert_equals_helper 'Get this month info' "$LINENO" "${options_values['MONTH']}" "$expected_result"
+  assert_equals_helper 'Get this month info' "$LINENO" "$expected_result" "${options_values['MONTH']}"
 
   parse_report_options '--year'
   expected_result=$(get_today_info '+%Y')
-  assert_equals_helper 'Get this year info' "$LINENO" "${options_values['YEAR']}" "$expected_result"
+  assert_equals_helper 'Get this year info' "$LINENO" "$expected_result" "${options_values['YEAR']}"
 
   parse_report_options '--verbose'
-  assert_equals_helper 'Show a detailed output' "$LINENO" "${options_values['VERBOSE']}" '1'
+  assert_equals_helper 'Show a detailed output' "$LINENO" 1 "${options_values['VERBOSE']}"
 
   # Values with parameters
   ## Days
   ref_date='1999/03/03'
   parse_report_options "--day=$ref_date"
   expected_result=$(date_to_format "$ref_date" '+%Y/%m/%d')
-  assert_equals_helper "$ref_date is a valid date" "$LINENO" "${options_values['DAY']}" "$expected_result"
+  assert_equals_helper "$ref_date is a valid date" "$LINENO" "$expected_result" "${options_values['DAY']}"
 
   ref_date='2022/04/32'
   output=$(parse_report_options "--day=$ref_date" 2> /dev/null)
   ret="$?"
-  assert_equals_helper "$ref_date is an invalid date" "$LINENO" "$ret" 22
+  assert_equals_helper "$ref_date is an invalid date" "$LINENO" 22 "$ret"
 
   ## Weeks
   ref_date='1990/04/10'
   parse_report_options "--week=$ref_date"
   expected_result=$(get_days_of_week "$ref_date")
-  assert_equals_helper 'We expected all days of week' "$LINENO" "${options_values['WEEK']}" "$expected_result"
+  assert_equals_helper 'We expected all days of week' "$LINENO" "$expected_result" "${options_values['WEEK']}"
 
   ref_date='2022/04/32'
   output=$(parse_report_options "--week=$ref_date" 2> /dev/null)
   ret="$?"
-  assert_equals_helper "$ref_date is invalid" "$LINENO" "$ret" 22
+  assert_equals_helper "$ref_date is invalid" "$LINENO" 22 "$ret"
 
   ## Month
   ref_date='1990/04'
   parse_report_options "--month=$ref_date"
   expected_result=$(date_to_format "$ref_date/01" '+%Y/%m')
-  assert_equals_helper 'We expected 1990/04' "$LINENO" "${options_values['MONTH']}" "$expected_result"
+  assert_equals_helper 'We expected 1990/04' "$LINENO" "$expected_result" "${options_values['MONTH']}"
 
   ref_date='1990/30'
   output=$(parse_report_options "--month=$ref_date" 2> /dev/null)
   ret="$?"
-  assert_equals_helper 'Invalid date' "$LINENO" "$ret" 22
+  assert_equals_helper 'Invalid date' "$LINENO" 22 "$ret"
 
   # Invalid parameter
   ref_date='2022/04/12'
   output=$(parse_report_options "--month=$ref_date --day=$ref_date" 2> /dev/null)
   ret="$?"
-  assert_equals_helper 'Invalid date' "$LINENO" "$ret" 22
+  assert_equals_helper 'Invalid date' "$LINENO" 22 "$ret"
 }
 
 function test_statistics()
@@ -558,7 +558,7 @@ function test_save_data_to()
   # Try to use an invalid root directory path.
   output=$(save_data_to '/lala/do/not')
   ret="$?"
-  assert_equals_helper 'We expect a root path to be invalid' "$LINENO" "$ret" 1
+  assert_equals_helper 'We expect a root path to be invalid' "$LINENO" 1 "$ret"
 
   # Try to use an invalid folder path error.
   output=$(save_data_to '/tmp/folder_not_created/')

--- a/tests/unit/ui/patch_hub/patch_hub_core_test.sh
+++ b/tests/unit/ui/patch_hub/patch_hub_core_test.sh
@@ -36,7 +36,7 @@ function test_show_dashboard()
   }
 
   show_dashboard
-  assert_equals_helper 'Expected register screen' "$LINENO" "${screen_sequence['SHOW_SCREEN']}" 'registered_mailing_lists'
+  assert_equals_helper 'Expected register screen' "$LINENO" 'registered_mailing_lists' "${screen_sequence['SHOW_SCREEN']}"
 
   # Mock bookmarked
   # shellcheck disable=SC2317
@@ -46,7 +46,7 @@ function test_show_dashboard()
   }
 
   show_dashboard
-  assert_equals_helper 'Expected register screen' "$LINENO" "${screen_sequence['SHOW_SCREEN']}" 'bookmarked_patches'
+  assert_equals_helper 'Expected register screen' "$LINENO" 'bookmarked_patches' "${screen_sequence['SHOW_SCREEN']}"
 }
 
 function test_list_patches_with_patches()
@@ -98,10 +98,10 @@ function test_list_patches_without_patches()
   target_array_list=()
 
   list_patches 'Message test' target_array_list 'show_new_patches_in_the_mailing_list' ''
-  assert_equals_helper 'Expected screen' "$LINENO" "${screen_sequence['SHOW_SCREEN']}" 'dashboard'
+  assert_equals_helper 'Expected screen' "$LINENO" 'dashboard' "${screen_sequence['SHOW_SCREEN']}"
 
   list_patches 'Message test' target_array_list 'bookmarked_patches' ''
-  assert_equals_helper 'Expected screen' "$LINENO" "${screen_sequence['SHOW_SCREEN']}" 'dashboard'
+  assert_equals_helper 'Expected screen' "$LINENO" 'dashboard' "${screen_sequence['SHOW_SCREEN']}"
 }
 
 invoke_shunit


### PR DESCRIPTION
I continued to fix the reverse argument order of 'asset_equals_helper' and 'assetEquals' that began in the commit https://github.com/kworkflow/kworkflow/commit/48cecf15485d2e7be176855754380d9303358daa

Closes: #1091 

Signed-off-by: Bruna Bispo <blbispo1@gmail.com>