### PR TITLE
src: handle-trailer: Add new feature 'kw handle-trailer'

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -180,6 +180,7 @@ man_pages = [
     ('man/features/kw-vm', 'kw-vm', 'commands to work with QEMU VMs', [author], 1),
     ('man/features/kw-self-update', 'kw-self-update', 'kw self-update mechanism', ['David Tadokoro, Everaldo Junior'], 1),
     ('man/features/kw-patch-hub', 'kw-patch-hub', 'UI with lore.kernel.org archives', ['David Tadokoro, Rodrigo Siqueira'], 1),
+    ('man/features/kw-handle-trailer', 'kw-handle-trailer', 'handle trailer lines', ['Lincoln Yuji, Luiza Soezima, Sabrina Araujo'], 1),
 ]
 
 

--- a/documentation/man/features/kw-handle-trailer.rst
+++ b/documentation/man/features/kw-handle-trailer.rst
@@ -1,0 +1,86 @@
+=========================================================
+kw-handle-trailer - Handle commit and patch trailer lines
+=========================================================
+
+.. _handle-trailer-doc:
+
+SYNOPSIS
+========
+*kw* *commit-trailer* ([-r(<string>) | \--add-reviewed-by=(<string>)]
+                      [-a(<string>) | \--add-acked-by=(<string>)]
+                      [-f(<sha>) | \--add-fixes=(<sha>)])
+                      [\--verbose] [<sha> | <patch>]...
+
+DESCRIPTION
+===========
+This is a wrapper to some useful usage of the 'git commit --amend',
+'git rebase' and the 'git interpret-trailers' commands. This kw's command
+is able to perform usual operations over trailer lines of commits and patches
+such as adding **Reviewed-by**, **Acked-by** or **Fixes** tags. By default,
+it uses the commit currently pointed by ``HEAD`` as the target of the
+operation if user does not specify one. Also, no operation is used by
+default. At least one operation option must be given.
+
+A behavior this command has is that the last option given will override
+all the previous ones. For example, the following command only adds the
+**Acked-by** line::
+
+  $ kw handle-trailer -r "Reviewer Name <mail>" -a "Some Name <mail>"
+
+To perform both operations, the user has to call this command 2 times
+using different options.
+
+OPTIONS
+=======
+-r, \--add-reviewed-by:
+  Adds a **Reviewed-by** trailer line to either commits or patch files.
+  It requires an argument to define the name of the reviewer that will
+  be written.
+
+-a, \--add-acked-by:
+  Adds a **Acked-by** trailer line to either commits or patch files.
+  It requires an argument to define the name of the one responsible for
+  acking the changes.
+
+-f, \--add-fixes:
+  Adds a **Fixes** trailer line to either commits or patch files.
+  It requires an argument, which must be a valid commit reference, to
+  define the fixed commit's hash that follows this tag.
+
+\--verbose:
+  Display commands executed under the hood.
+
+EXAMPLES
+========
+To add a **Reviewed-by** line to commit pointed by ``HEAD``::
+
+  $ kw handle-trailer --add-reviewed-by "Reviewer Name <reviewer@mail.org>"
+
+To add a **Acked-by** line to last 3 commits starting from ``HEAD``::
+
+  $ kw handle-trailer --acked-by "Some Name <example@mail.com>" HEAD~3
+
+To add **Fixes** line to commit pointed by ``HEAD``, which fixes another
+previous commit ``90a7ba23340d``::
+
+  $ kw handle-trailer --add-fixes 90a7ba23340d
+
+All the above options can be used to perform operations over patch files
+as well::
+
+  $ kw handle-trailer -r "Reviewer Name <reviewer@mail.org>" example.patch
+
+  $ kw handle-trailer -a "Some Name <example@mail.com>" example.patch
+
+  $ kw handle-trailer -f 90a7ba23340d example.patch
+
+This command accepts multiples arguments, which means that multiple files
+(both names and globs) and commits can be passed with one single command.
+
+To add **Acked-by** line to multiple patches::
+
+  $ kw handle-trailer -a "Some Name <example@mail.com>" file1.patch file2.patch
+
+To add **Reviewed-by** line to all patch files in current working directory::
+
+  $ kw handle-trailer -r "Reviewer Name <reviewer@mail.org>" *.patch

--- a/kw
+++ b/kw
@@ -287,6 +287,13 @@ function kw()
         vm_main "$@"
       )
       ;;
+    handle-trailer)
+      (
+        include "${KW_LIB_DIR}/handle_trailer.sh"
+
+        handle_trailer_main "$@"
+      )
+      ;;
     version | --version | -v)
       (
         include "${KW_LIB_DIR}/help.sh"

--- a/src/_kw
+++ b/src/_kw
@@ -30,6 +30,7 @@ _kw()
     'drm:Set of commands to work with DRM drivers '
     'env:Handle kw envs'
     'explore:Explore string patterns'
+    'handle-trailer:Handle trailers in commits or patches'
     'h:Displays this help message'
     'help:Show kw man page'
     'init:Initialize kworkflow config file'
@@ -285,6 +286,16 @@ _kw_explore()
     '(-C --show-context)'{-C-,--show-context=-}'[set the context value]' \
     '1: : ' \
     '2: :_files'
+}
+
+_kw_handle_trailer()
+{
+  _arguments: \
+    '(--verbose)--verbose[enable verbose mode]' \
+    '(-r --add-reviewed-by -a --add-acked-by -f --add-fixes)'{-r,--add-reviewed-by}'[add Reviewed-by trailer line]: : ' \
+    '(-a --add-acked-by -r --add-reviewed-by -f --add-fixes)'{-a,--add-acked-by}'[add Acked-by trailer line]: : ' \
+    '(-f --add-fixes -r --add-reviewed-by -a --add-acked-by)'{-f,--add-fixes}'[add Fixes trailer line]: : ' \
+    '1: :_files'
 }
 
 _kw_h()

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -16,7 +16,7 @@ function _kw_autocomplete()
   kw_options['kw']='init build deploy bd diff ssh codestyle self-update
                     maintainers kernel-config-manager config remote explore
                     pomodoro report device backup debug mail env patch-hub
-                    clear-cache drm vm version man help'
+                    clear-cache drm vm handle-trailer version man help'
 
   kw_options['init']='--arch --remote --target --force --template --verbose'
 
@@ -82,6 +82,8 @@ function _kw_autocomplete()
                      --unload-module --conn-available --modes --verbose --help'
 
   kw_options['vm']='--mount --umount --up --alert --help'
+
+  kw_options['handle-trailer']='--add-reviewed-by --add-acked-by --add-fixes --verbose'
 
   kw_options['clear-cache']='--verbose'
 

--- a/src/handle_trailer.sh
+++ b/src/handle_trailer.sh
@@ -1,0 +1,166 @@
+include "${KW_LIB_DIR}/lib/kw_config_loader.sh"
+include "${KW_LIB_DIR}/lib/kwlib.sh"
+
+declare -gA options_values
+
+# This fnuction performs operations over trailers in
+# either patches or commits. It checks if given argument
+# is a valid commit reference or patch path and uses the
+# correct command to perform the task.
+# If that's not the case, a warning message will tell
+# the user this argument was ignored.
+#
+# Also, if no operation option is given, then an error message
+# followed by a helper message is printed to the user.
+#
+# @PATCH_OR_SHA Holds a patch path or commit reference.
+# @TRAILER_TAG Holds the key of the operation's trailer.
+# @TRAILER_VALUE Holds the value of the operation's trailer.
+# @flag Defines the type of output this function will have.
+# @cmd Holds the command used to perform the trailer operation.
+function handle_trailer_main()
+{
+  local PATCH_OR_SHA
+  local TRAILER_TAG
+  local TRAILER_VALUE
+  local flag
+  local cmd
+
+  if [[ "$1" =~ -h|--help ]]; then
+    handle_trailer_help "$1"
+    exit 0
+  fi
+
+  parse_handle_trailer_options "$@"
+  if [[ "$?" -gt 0 ]]; then
+    complain "${options_values['ERROR']}"
+    return 22 # EINVAL
+  fi
+
+  [[ -n "${options_values['VERBOSE']}" ]] && flag='VERBOSE'
+  flag=${flag:-'SILENT'}
+
+  read -ra PATCH_OR_SHA <<< "${options_values['PATCH_OR_SHA']}"
+  TRAILER_TAG=${options_values['TRAILER_TAG']}
+  TRAILER_VALUE=${options_values['TRAILER_VALUE']}
+
+  if [[ -z "$TRAILER_TAG" ]]; then
+    complain 'An option is required to use this command.'
+    handle_trailer_help
+    return 22 # EINVAL
+  fi
+
+  for arg in "${PATCH_OR_SHA[@]}"; do
+    # Check if given argument is either a patch or valid commit reference,
+    # then build the correct command.
+    if [[ $(git cat-file -t "$arg" 2> /dev/null) == 'commit' ]]; then
+      cmd="git commit --quiet --amend --no-edit --trailer \"${TRAILER_TAG} ${TRAILER_VALUE}\""
+      # Only call 'git rebase' if user is trying to handle multiple commits
+      if [[ "$(git rev-parse "$arg")" != "$(git rev-parse HEAD)" ]]; then
+        cmd="git rebase ${arg} --exec '${cmd}' 2> /dev/null"
+      fi
+    elif is_a_patch "$arg"; then
+      cmd="git interpret-trailers ${arg} --in-place --trailer"
+      cmd+=" \"${TRAILER_TAG} ${TRAILER_VALUE}\""
+    else
+      warning "Neither a patch nor a valid commit. Ignoring ${arg}"
+      continue
+    fi
+    cmd_manager "$flag" "$cmd"
+  done
+}
+
+# This function gets raw data and based on that fill out the options values to
+# be used in another function.
+#
+# Return:
+# In case of successful return 0, otherwise, return 22.
+function parse_handle_trailer_options()
+{
+  local long_options='add-reviewed-by:,add-acked-by:,add-fixes:,verbose'
+  local short_options='r:,a:,f:'
+
+  options="$(kw_parse "$short_options" "$long_options" "$@")"
+
+  if [[ "$?" != 0 ]]; then
+    options_values['ERROR']="$(kw_parse_get_errors 'kw commit-trailer' \
+      "$short_options" "$long_options" "$@")"
+    return 22 # EINVAL
+  fi
+
+  options_values['TRAILER_TAG']=''
+  options_values['TRAILER_VALUE']=''
+  options_values['PATCH_OR_SHA']='HEAD'
+  options_values['VERBOSE']=''
+
+  eval "set -- ${options}"
+
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --add-reviewed-by | -r)
+        options_values['TRAILER_TAG']='Reviewed-by:'
+        options_values['TRAILER_VALUE']="$(str_strip "$2")"
+        shift 2
+        ;;
+      --add-acked-by | -a)
+        options_values['TRAILER_TAG']='Acked-by:'
+        options_values['TRAILER_VALUE']="$(str_strip "$2")"
+        shift 2
+        ;;
+      --add-fixes | -f)
+        options_values['TRAILER_TAG']='Fixes:'
+        options_values['TRAILER_VALUE']="$(str_strip "$2")"
+
+        # Check if given value is a valid commit reference
+        if [[ $(git cat-file -t "${options_values['TRAILER_VALUE']}" 2> /dev/null) != 'commit' ]]; then
+          options_values['ERROR']='Invalid commit reference with --add-fixes option: '
+          options_values['ERROR']+="${options_values['TRAILER_VALUE']}"
+          return 22 # EINVAL
+        fi
+
+        # The 'Fixes:' trailer line must follow a format defined by
+        # Linux Kernel developers. Example:
+        # Fixes: e21d2170f366 ("video: remove unnecessary platform_set_drvdata()")
+        options_values['TRAILER_VALUE']=$(git log -1 "${options_values['TRAILER_VALUE']}" \
+          --oneline --format="%h (\\\"%s\\\")" \
+          --abbrev-commit --abbrev=12)
+        shift 2
+        ;;
+      --verbose)
+        options_values['VERBOSE']=1
+        shift
+        ;;
+      --)
+        # End of options, beginning of arguments
+        if [[ -n "$2" ]]; then
+          # Overwrite default value
+          options_values['PATCH_OR_SHA']="$2"
+          shift
+        fi
+        shift
+        ;;
+      *)
+        # Get all passed arguments each loop
+        options_values['PATCH_OR_SHA']+=" $1"
+        shift
+        ;;
+    esac
+  done
+}
+
+function handle_trailer_help()
+{
+  if [[ "$1" == --help ]]; then
+    include "$KW_LIB_DIR/help.sh"
+    kworkflow_man 'handle-trailer'
+    return
+  fi
+  printf '%s\n' 'kw handle-trailer:' \
+    'Every (--add-*) option adds trailer to a single <patch> or <sha> and its successors' \
+    '  handle-trailer (--add-reviewed-by | -r) [<name>] [<patch> | <sha>] - Add Reviewed-by' \
+    '  handle-trailer (--add-acked-by | -a) [<name>] [<patch> | <sha>] - Add Acked-by' \
+    '  handle-trailer (--add-fixes | -f) [<fixed-sha>] [<patch> | <sha>] - Add Fixes' \
+    '  handle-trailer (--verbose) - Show a detailed output'
+}
+
+load_kworkflow_config

--- a/tests/unit/handle_trailer_test.sh
+++ b/tests/unit/handle_trailer_test.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+
+include './src/handle_trailer.sh'
+include './tests/unit/utils.sh'
+
+# Correct trailers for --add-reviewed-by and -r
+CORRECT_REVIEWED_COMMIT="Signed-off-by: kw <kw@kw>
+Reviewed-by: John Doe <johndoe@community.com>
+
+Signed-off-by: kw <kw@kw>"
+
+CORRECT_REVIEWED_LOG="Signed-off-by: kw <kw@kw>
+Reviewed-by: John Doe <johndoe@community.com>
+
+Signed-off-by: kw <kw@kw>
+Reviewed-by: John Doe <johndoe@community.com>
+
+Signed-off-by: kw <kw@kw>
+Reviewed-by: John Doe <johndoe@community.com>
+
+Signed-off-by: kw <kw@kw>"
+
+# Correct trailers for --add-acked-by and -a
+CORRECT_ACKED_COMMIT="Signed-off-by: kw <kw@kw>
+Acked-by: Michael Doe <michaeldoe@community.com>
+
+Signed-off-by: kw <kw@kw>"
+
+CORRECT_ACKED_LOG="Signed-off-by: kw <kw@kw>
+Acked-by: Michael Doe <michaeldoe@community.com>
+
+Signed-off-by: kw <kw@kw>
+Acked-by: Michael Doe <michaeldoe@community.com>
+
+Signed-off-by: kw <kw@kw>
+Acked-by: Michael Doe <michaeldoe@community.com>
+
+Signed-off-by: kw <kw@kw>"
+
+# Correct trailers for --add-fixes and -f
+# Appending the correct hash is needed. This has
+# to be done during test runs, since hashes
+# are randomly generated.
+CORRECT_FIXED_COMMIT="Signed-off-by: kw <kw@kw>
+Fixes: <hash>
+
+Signed-off-by: kw <kw@kw>"
+
+# Correct trailers when using adding Acked-by, then
+# adding Reviewed-by and then adding Fixes.
+# This also requires a hash while running tests.
+CORRECT_COMPLETE_LOG="Signed-off-by: kw <kw@kw>
+Acked-by: Michael Doe <michaeldoe@community.com>
+Reviewed-by: John Doe <johndoe@community.com>
+Fixes: <hash>
+
+Signed-off-by: kw <kw@kw>
+Acked-by: Michael Doe <michaeldoe@community.com>
+Reviewed-by: John Doe <johndoe@community.com>
+
+Signed-off-by: kw <kw@kw>
+Acked-by: Michael Doe <michaeldoe@community.com>
+Reviewed-by: John Doe <johndoe@community.com>
+
+Signed-off-by: kw <kw@kw>"
+
+function setUp()
+{
+  local -r current_path="$PWD"
+
+  cp -r tests/unit/samples/handle_trailer_patch_samples/*.patch "$SHUNIT_TMPDIR"/
+
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
+  # Setup git repository for test
+  mk_fake_git
+
+  # Start repository
+  git config user.name kw
+  git config user.email kw@kw
+  mkdir fs
+  touch fs/some_file
+  git add fs/
+  git commit --quiet -s -m "fs: some_file: Fill file" -m "First"
+
+  # Simulate wrong change
+  echo 'Wrong text' > fs/some_file
+  git add fs/some_file
+  git commit --quiet -s -m "fs: some_file: Fill file" -m "First"
+
+  # Regular change
+  touch fs/new_driver
+  git add fs/new_driver
+  git commit --quiet -s -m "fs: new_driver: Add new driver" -m "Second"
+
+  # Bug fix
+  echo 'Correct text' > fs/some_file
+  git add fs/some_file
+  git commit --quiet -s -m "fs: some_file: Fix bug" -m "Third"
+
+  cd "$current_path" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
+}
+
+function tearDown()
+{
+  rm -rf "$SHUNIT_TMPDIR"
+  mkdir -p "$SHUNIT_TMPDIR"
+}
+
+# This function tests 'handle_trailer_main' for
+# cases where the given argument is a patch.
+function test_handle_trailer_main_patch()
+{
+  local original_dir="$PWD"
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
+
+  # Testing --add-reviewed-by and -r with patch
+  handle_trailer_main --add-reviewed-by "John Doe <johndoe@community.com>" patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_reviewed.patch'
+  git restore patch_model.patch
+
+  handle_trailer_main -r "John Doe <johndoe@community.com>" patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_reviewed.patch'
+  git restore patch_model.patch
+
+  # Testing --add-acked-by and -a with patch
+  handle_trailer_main --add-acked-by "Michael Doe <michaeldoe@community.com>" patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_acked.patch'
+  git restore patch_model.patch
+
+  handle_trailer_main -a "Michael Doe <michaeldoe@community.com>" patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_acked.patch'
+  git restore patch_model.patch
+
+  # Testing --add-fixed and -f with patch
+  head2_msg="$(git rev-parse --short=12 HEAD~2) (\"fs: some_file: Fill file\")"
+
+  handle_trailer_main --add-fixes HEAD~2 patch_model.patch
+  sed -i "s/<hash>/$head2_msg/g" patch_model_fixes.patch # Write trailer value with correct hash
+  assertFileEquals 'patch_model.patch' 'patch_model_fixes.patch'
+  git restore patch_model.patch patch_model_fixes.patch
+
+  handle_trailer_main -f HEAD~2 patch_model.patch
+  sed -i "s/<hash>/$head2_msg/g" patch_model_fixes.patch # Write trailer value with correct hash
+  assertFileEquals 'patch_model.patch' 'patch_model_fixes.patch'
+  git restore patch_model.patch patch_model_fixes.patch
+
+  # Testing for multiple calls of handle_trailer_main with patch
+  handle_trailer_main --add-reviewed-by "John Doe <johndoe@community.com>" patch_model.patch
+  handle_trailer_main --add-acked-by "Michael Doe <michaeldoe@community.com>" patch_model.patch
+  handle_trailer_main --add-fixes HEAD~2 patch_model.patch
+  sed -i "s/<hash>/$head2_msg/g" patch_model_complete.patch # Write trailer value with correct hash
+  assertFileEquals 'patch_model.patch' 'patch_model_complete.patch'
+  git restore patch_model.patch patch_model_complete.patch
+
+  cd "$original_dir" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
+}
+
+# This function tests 'handle_trailer_main' for
+# cases where the given argument is either empty
+# (default behavior) or a valid commit reference.
+function test_handle_trailer_main_commit()
+{
+  local original_dir="$PWD"
+  local original_commit
+
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move to temporary directory"
+    return
+  }
+  # Save SHA from current commit allowing tests to reset the repository
+  original_commit="$(git rev-parse HEAD)"
+
+  # Testing --add-reviewed-by and -r for commits
+  handle_trailer_main --add-reviewed-by "John Doe <johndoe@community.com>"
+  current_log="$(git log -n 2 --format="%(trailers)")"
+  assertEquals "($LINENO)" "$CORRECT_REVIEWED_COMMIT" "$current_log"
+  git reset --hard "$original_commit" > /dev/null
+
+  handle_trailer_main -r "John Doe <johndoe@community.com>"
+  current_log="$(git log -n 2 --format="%(trailers)")"
+  assertEquals "($LINENO)" "$CORRECT_REVIEWED_COMMIT" "$current_log"
+  git reset --hard "$original_commit" > /dev/null
+
+  handle_trailer_main --add-reviewed-by "John Doe <johndoe@community.com>" HEAD~3
+  current_log="$(git log -n 4 --format="%(trailers)")"
+  assertEquals "($LINENO)" "$CORRECT_REVIEWED_LOG" "$current_log"
+  git reset --hard "$original_commit" > /dev/null
+
+  handle_trailer_main -r "John Doe <johndoe@community.com>" HEAD~3
+  current_log="$(git log -n 4 --format="%(trailers)")"
+  assertEquals "($LINENO)" "$CORRECT_REVIEWED_LOG" "$current_log"
+  git reset --hard "$original_commit" > /dev/null
+
+  # Testing add-acked-by and -a for commits
+  handle_trailer_main --add-acked-by "Michael Doe <michaeldoe@community.com>"
+  current_log="$(git log -n 2 --format="%(trailers)")"
+  assertEquals "($LINENO)" "$CORRECT_ACKED_COMMIT" "$current_log"
+  git reset --hard "$original_commit" > /dev/null
+
+  handle_trailer_main -a "Michael Doe <michaeldoe@community.com>"
+  current_log="$(git log -n 2 --format="%(trailers)")"
+  assertEquals "($LINENO)" "$CORRECT_ACKED_COMMIT" "$current_log"
+  git reset --hard "$original_commit" > /dev/null
+
+  handle_trailer_main --add-acked-by "Michael Doe <michaeldoe@community.com>" HEAD~3
+  current_log="$(git log -n 4 --format="%(trailers)")"
+  assertEquals "($LINENO)" "$CORRECT_ACKED_LOG" "$current_log"
+  git reset --hard "$original_commit" > /dev/null
+
+  handle_trailer_main -a "Michael Doe <michaeldoe@community.com>" HEAD~3
+  current_log="$(git log -n 4 --format="%(trailers)")"
+  assertEquals "($LINENO)" "$CORRECT_ACKED_LOG" "$current_log"
+  git reset --hard "$original_commit" > /dev/null
+
+  # Testing --add-fixes and -f for commits
+  handle_trailer_main --add-fixes HEAD~2
+  current_log="$(git log -n 2 --format="%(trailers)")"
+  correct_fixed_value="$(git rev-parse --short=12 HEAD~2) (\"fs: some_file: Fill file\")"
+  correct_output="$(sed "s/<hash>/$correct_fixed_value/g" <<< "$CORRECT_FIXED_COMMIT")"
+  assertEquals "($LINENO)" "$correct_output" "$current_log"
+  git reset --hard "$original_commit" > /dev/null
+
+  handle_trailer_main -f HEAD~2
+  current_log="$(git log -n 2 --format="%(trailers)")"
+  correct_fixed_value="$(git rev-parse --short=12 HEAD~2) (\"fs: some_file: Fill file\")"
+  correct_output="$(sed "s/<hash>/$correct_fixed_value/g" <<< "$CORRECT_FIXED_COMMIT")"
+  assertEquals "($LINENO)" "$correct_output" "$current_log"
+  git reset --hard "$original_commit" > /dev/null
+
+  # Testing for multiple calls of handle_trailer_main with commits
+  handle_trailer_main --add-acked-by "Michael Doe <michaeldoe@community.com>" HEAD~3
+  handle_trailer_main --add-reviewed-by "John Doe <johndoe@community.com>" HEAD~3
+  handle_trailer_main --add-fixes HEAD~2
+  current_log="$(git log -n 4 --format="%(trailers)")"
+  correct_fixed_value="$(git rev-parse --short=12 HEAD~2) (\"fs: some_file: Fill file\")"
+  correct_output="$(sed "s/<hash>/$correct_fixed_value/g" <<< "$CORRECT_COMPLETE_LOG")"
+  assertEquals "($LINENO)" "$correct_output" "$current_log"
+  git reset --hard "$original_commit" > /dev/null
+
+  cd "$original_dir" || {
+    fail "($LINENO) It was not possible to move back from temp directory"
+    return
+  }
+
+  tearDown
+}
+
+invoke_shunit

--- a/tests/unit/samples/handle_trailer_patch_samples/patch_model.patch
+++ b/tests/unit/samples/handle_trailer_patch_samples/patch_model.patch
@@ -1,0 +1,33 @@
+From f0440260c76695e874af21a45e3156d3ba7a817b Mon Sep 17 00:00:00 2001
+From: kw <kw@example.net>
+Date: Thu, 24 May 2024 13:26:52 -0300
+To: Jane Doe <jane@email.com>,kernel@list.org
+Subject: [PATCH] handle_trailer test
+
+Lorem ipsum dolor sit amet, consectetur adipisci elit,
+sed eiusmod tempor incidunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrum exercitationem
+ullam corporis suscipit laboriosam, nisi ut aliquid ex ea
+commodi consequatur.
+
+Signed-off-by: kw <kw@example.net>
+---
+ sound/core/init.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sound/core/init.c b/sound/core/init.c
+index b02a99766351..fa769ff80e09 100644
+--- a/sound/core/init.c
++++ b/sound/core/init.c
+@@ -19,6 +19,8 @@
+ #include <sound/control.h>
+ #include <sound/info.h>
+
++/* Testing... */
++
+ /* monitor files for graceful shutdown (hotplug) */
+ struct snd_monitor_file {
+ 	struct file *file;
+--
+2.30.0
+

--- a/tests/unit/samples/handle_trailer_patch_samples/patch_model_acked.patch
+++ b/tests/unit/samples/handle_trailer_patch_samples/patch_model_acked.patch
@@ -1,0 +1,34 @@
+From f0440260c76695e874af21a45e3156d3ba7a817b Mon Sep 17 00:00:00 2001
+From: kw <kw@example.net>
+Date: Thu, 24 May 2024 13:26:52 -0300
+To: Jane Doe <jane@email.com>,kernel@list.org
+Subject: [PATCH] handle_trailer test
+
+Lorem ipsum dolor sit amet, consectetur adipisci elit,
+sed eiusmod tempor incidunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrum exercitationem
+ullam corporis suscipit laboriosam, nisi ut aliquid ex ea
+commodi consequatur.
+
+Signed-off-by: kw <kw@example.net>
+Acked-by: Michael Doe <michaeldoe@community.com>
+---
+ sound/core/init.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sound/core/init.c b/sound/core/init.c
+index b02a99766351..fa769ff80e09 100644
+--- a/sound/core/init.c
++++ b/sound/core/init.c
+@@ -19,6 +19,8 @@
+ #include <sound/control.h>
+ #include <sound/info.h>
+
++/* Testing... */
++
+ /* monitor files for graceful shutdown (hotplug) */
+ struct snd_monitor_file {
+ 	struct file *file;
+--
+2.30.0
+

--- a/tests/unit/samples/handle_trailer_patch_samples/patch_model_complete.patch
+++ b/tests/unit/samples/handle_trailer_patch_samples/patch_model_complete.patch
@@ -1,0 +1,36 @@
+From f0440260c76695e874af21a45e3156d3ba7a817b Mon Sep 17 00:00:00 2001
+From: kw <kw@example.net>
+Date: Thu, 24 May 2024 13:26:52 -0300
+To: Jane Doe <jane@email.com>,kernel@list.org
+Subject: [PATCH] handle_trailer test
+
+Lorem ipsum dolor sit amet, consectetur adipisci elit,
+sed eiusmod tempor incidunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrum exercitationem
+ullam corporis suscipit laboriosam, nisi ut aliquid ex ea
+commodi consequatur.
+
+Signed-off-by: kw <kw@example.net>
+Reviewed-by: John Doe <johndoe@community.com>
+Acked-by: Michael Doe <michaeldoe@community.com>
+Fixes: <hash>
+---
+ sound/core/init.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sound/core/init.c b/sound/core/init.c
+index b02a99766351..fa769ff80e09 100644
+--- a/sound/core/init.c
++++ b/sound/core/init.c
+@@ -19,6 +19,8 @@
+ #include <sound/control.h>
+ #include <sound/info.h>
+
++/* Testing... */
++
+ /* monitor files for graceful shutdown (hotplug) */
+ struct snd_monitor_file {
+ 	struct file *file;
+--
+2.30.0
+

--- a/tests/unit/samples/handle_trailer_patch_samples/patch_model_fixes.patch
+++ b/tests/unit/samples/handle_trailer_patch_samples/patch_model_fixes.patch
@@ -1,0 +1,34 @@
+From f0440260c76695e874af21a45e3156d3ba7a817b Mon Sep 17 00:00:00 2001
+From: kw <kw@example.net>
+Date: Thu, 24 May 2024 13:26:52 -0300
+To: Jane Doe <jane@email.com>,kernel@list.org
+Subject: [PATCH] handle_trailer test
+
+Lorem ipsum dolor sit amet, consectetur adipisci elit,
+sed eiusmod tempor incidunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrum exercitationem
+ullam corporis suscipit laboriosam, nisi ut aliquid ex ea
+commodi consequatur.
+
+Signed-off-by: kw <kw@example.net>
+Fixes: <hash>
+---
+ sound/core/init.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sound/core/init.c b/sound/core/init.c
+index b02a99766351..fa769ff80e09 100644
+--- a/sound/core/init.c
++++ b/sound/core/init.c
+@@ -19,6 +19,8 @@
+ #include <sound/control.h>
+ #include <sound/info.h>
+
++/* Testing... */
++
+ /* monitor files for graceful shutdown (hotplug) */
+ struct snd_monitor_file {
+ 	struct file *file;
+--
+2.30.0
+

--- a/tests/unit/samples/handle_trailer_patch_samples/patch_model_reviewed.patch
+++ b/tests/unit/samples/handle_trailer_patch_samples/patch_model_reviewed.patch
@@ -1,0 +1,34 @@
+From f0440260c76695e874af21a45e3156d3ba7a817b Mon Sep 17 00:00:00 2001
+From: kw <kw@example.net>
+Date: Thu, 24 May 2024 13:26:52 -0300
+To: Jane Doe <jane@email.com>,kernel@list.org
+Subject: [PATCH] handle_trailer test
+
+Lorem ipsum dolor sit amet, consectetur adipisci elit,
+sed eiusmod tempor incidunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrum exercitationem
+ullam corporis suscipit laboriosam, nisi ut aliquid ex ea
+commodi consequatur.
+
+Signed-off-by: kw <kw@example.net>
+Reviewed-by: John Doe <johndoe@community.com>
+---
+ sound/core/init.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sound/core/init.c b/sound/core/init.c
+index b02a99766351..fa769ff80e09 100644
+--- a/sound/core/init.c
++++ b/sound/core/init.c
+@@ -19,6 +19,8 @@
+ #include <sound/control.h>
+ #include <sound/info.h>
+
++/* Testing... */
++
+ /* monitor files for graceful shutdown (hotplug) */
+ struct snd_monitor_file {
+ 	struct file *file;
+--
+2.30.0
+


### PR DESCRIPTION
### Purpose
Often a kernel developer has to perform some operations over commit or patch trailer lines. Adding tags such as 'Reviewed-by' or 'Acked-by' is a common task and sometimes it might be required to do this over multiple commits or patches. Also another common one is the 'Fixes' tag, that must follow a specific format.

This feature helps on these cases. It uses 'git rebase', 'git commit --amend' and 'git interpret-trailers' as its backend in order to make these tasks quicker to complete.

### Inspiration
Both #1049 and #1051 represent similar issues, regarding trailer line manipulation of commits and patches. The idea is to deliver a new feature that can make such tasks easier and quicker to deal with.

### Some known limitations
There is no way to "revert" any change made by this command through kw. For example, if the commit log changes, there is no command to undo the previous operation. User will have to manually use `git reset --hard` if changes are not what they expected.

This feature currently does not provide ways to configure conditional actions, which is possible via `git config` as shown by Melissa here: #1049 