### PR TITLE
src: signature: Add new feature 'kw signature'

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -181,6 +181,7 @@ man_pages = [
     ('man/features/kw-self-update', 'kw-self-update', 'kw self-update mechanism', ['David Tadokoro, Everaldo Junior'], 1),
     ('man/features/kw-patch-hub', 'kw-patch-hub', 'UI with lore.kernel.org archives', ['David Tadokoro, Rodrigo Siqueira'], 1),
     ('man/features/kw-bd', 'kw-bd', 'build and then deploy the kernel', ['Briza Mel de Sousa, Lorenzo Salvador'], 1),
+    ('man/features/kw-signature', 'kw-signature', 'write trailer lines', ['Lincoln Yuji, Luiza Soezima, Sabrina Araujo'], 1),
 ]
 
 

--- a/documentation/man/features/kw-signature.rst
+++ b/documentation/man/features/kw-signature.rst
@@ -1,0 +1,172 @@
+===================================================
+kw-signature - Write commit and patch trailer lines
+===================================================
+
+.. _signature-doc:
+
+SYNOPSIS
+========
+| *kw* *signature* (-s(<string>) | \--add-signed-off-by=(<string>)) [\--verbose] [<sha> | <patch>]
+| *kw* *signature* (-r(<string>) | \--add-reviewed-by=(<string>)) [\--verbose] [<sha> | <patch>]
+| *kw* *signature* (-a(<string>) | \--add-acked-by=(<string>)) [\--verbose] [<sha> | <patch>]
+| *kw* *signature* (-t(<string>) | \--add-tested-by=(<string>)) [\--verbose] [<sha> | <patch>]
+| *kw* *signature* (-C(<string>) | \--add-co-developed-by=(<string>)) [\--verbose] [<sha> | <patch>]
+| *kw* *signature* (-R(<string>) | \--add-reported-by=(<string>)) [\--verbose] [<sha> | <patch>]
+| *kw* *signature* (-f(<sha>) | \--add-fixes=(<sha>)) [\--verbose] [<sha> | <patch>]
+
+DESCRIPTION
+===========
+This feature adds Linux kernel tags to either commits or patches and helps
+to make this kind of task quicker to complete. It's a wrapper to some useful
+usage of the ``git commit --amend``, ``git rebase`` and ``git interpret-trailers``
+commands. By default, it uses the commit currently pointed by `HEAD`
+as the target of the operation if user does not specify one. At least one **--add**
+option is required.
+
+Most kernel tags contain a signature like:
+
+.. code-block:: text
+
+  TAG: NAME <EMAIL>
+
+By default, options that add these types of tags will use your current `user.name`
+and `user.email` from git configuration if nothing is specified in the command line.
+
+Using multiple options combined is possible. For instance, the following
+command will add **Tested-by** and **Signed-off-by**, in this order,
+to the commit's trailers pointed by `HEAD` using `user.name` and
+`user.email` from git config::
+
+  $ kw signature -t -s
+
+The order the trailer lines are added follows the general sequence:
+
+.. code-block:: text
+
+   Reported-by
+   Co-developed-by
+   Acked-by
+   Tested-by
+   Reviewed-by
+   Signed-off-by
+   Fixes
+
+At the same time, new lines are grouped by their signatures. For example:
+
+.. code-block:: text
+
+   $ kw signature -s'Joe Doe <joe@mail.xyz>' -s -t -t'Joe Doe <joe@mail.xyz>'
+
+   Tested-by: Some Name <some@mail.xyz>
+   Signed-off-by: Some Name <some@mail.xyz>
+   Tested-by: Joe Doe <joe@mail.xyz>
+   Signed-off-by: Joe Doe <joe@mail.xyz>
+
+However, it's important to note that every new tag is added **after** the old ones
+that were already present in the commit or patch message.
+
+Another important aspect of this command is that, since it uses ``git rebase``
+as a part of its backend, if we run it using a SHA like ``kw signature -s HEAD~3``
+then only commits refered by ``HEAD~2``, ``HEAD~1`` and ``HEAD`` will be affected.
+This has the same behavior when you execute ``git rebase --interactive HEAD~3``.
+
+OPTIONS
+=======
+-s, \--add-signed-off-by:
+  Adds a **Signed-off-by** kernel tag line to either commits or patchsets.
+  By default it uses `user.name` and `user.email` from git config to
+  write these lines if no argument is given to this option.
+  
+-r, \--add-reviewed-by:
+  Adds a **Reviewed-by** kernel tag  line to either commits or patchsets.
+  By default it uses `user.name` and `user.email` from git config to
+  write these lines if no argument is given to this option.
+
+-a, \--add-acked-by:
+  Adds a **Acked-by** kernel tagline to either commits or patchsets.
+  By default it uses `user.name` and `user.email` from git config to
+  write these lines if no argument is given to this option.
+
+-t, \--add-tested-by:
+  Adds a **Tested-by** kernel tag line to either commits or patchsets.
+  By default it uses `user.name` and `user.email` from git config to
+  write these lines if no argument is given to this option.
+
+-C, \--add-co-developed-by:
+  Adds a **Co-developed-by** immediately followed by a **Signed-off-by**
+  kernel tag line to either commits or patchsets. By default it uses
+  `user.name` and `user.email` from git config to write these lines if
+  no argument is given to this option.
+
+-R, \--add-reported-by:
+  Adds a **Reported-by** kernel tag line to either commits or patchsets.
+  By default it uses `user.name` and `user.email` from git config to
+  write these lines if no argument is given to this option. Also, the
+  user has the option to pass a **Closes** or **Link** as an additional
+  tag that will be added immediately after for cases when the bug report
+  is available in the web.
+
+-f, \--add-fixes:
+  Adds a **Fixes** kernel tag line to either commits or patchsets.
+  It requires an argument, which must be a valid commit reference, to
+  define the fixed commit's hash that follows this tag.
+
+\--verbose:
+  Displays commands executed under the hood.
+
+EXAMPLES
+========
+Adding a **Reviewed-by** line to commit pointed by ``HEAD``::
+
+  $ kw signature --add-reviewed-by='Reviewer Name <reviewer@mail.org>'
+
+Adding an **Acked-by** line starting from ``HEAD~2`` until ``HEAD``::
+
+  $ kw signature --acked-by='Some Name <example@mail.com>' HEAD~3
+
+Adding **Fixes** line to commit pointed by ``HEAD``, which fixes another
+previous commit ``90a7ba23340d``::
+
+  $ kw signature --add-fixes='90a7ba23340d'
+
+All the above options can be used to perform operations over `.patch` files as well::
+
+  $ kw signature -r'Reviewer Name <reviewer@mail.org>' example.patch
+
+  $ kw signature -a'Some Name <example@mail.org>' example.patch
+
+  $ kw signature -f'90a7ba23340d' example.patch
+
+This command accepts multiples arguments, which means that multiple files
+(both names and globs) and commits can be passed with one single command.
+
+Adding **Signed-off-by** line to multiple `.patch` files::
+
+  $ kw signature -s'Some Name <example@mail.org>' file1.patch file2.patch
+
+This command also accepts globs to reference multiple `.patch` files::
+
+  $ kw signature -s'Some Name <example@mail.org>' *.patch
+
+One more complex example than the one seen in **DESCRIPTION** is::
+
+  $ kw signature -s'Jane Doe <janedoe@mail.xyz>' \
+    -t'Jane Doe <janedoe@mail.xyz>' \
+    -R'Michael Doe <michaeldoe@mail.xyz>;Closes=https://link-to-bug.xyz' \
+    -C'John Doe <johndoe@mail.xyz>' \
+    -C'Michael Doe <michaeldoe@mail.xyz>' \
+    -r'Jane Doe <janedoe@mail.xyz>'
+
+That will write these trailers like so:
+
+.. code-block:: text
+
+  Reported-by: Michael Doe <michaeldoe@mail.xyz>
+  Closes: https://link-to-bug.xyz
+  Co-developed-by: Michael Doe <michaeldoe@mail.xyz>
+  Signed-off-by: Michael Doe <michaeldoe@mail.xyz>
+  Co-developed-by: John Doe <johndoe@mail.xyz>
+  Signed-off-by: John Doe <johndoe@mail.xyz>
+  Tested-by: Jane Doe <janedoe@mail.xyz>
+  Reviewed-by: Jane Doe <janedoe@mail.xyz>
+  Signed-off-by: Jane Doe <janedoe@mail.xyz>

--- a/kw
+++ b/kw
@@ -286,6 +286,13 @@ function kw()
         vm_main "$@"
       )
       ;;
+    signature)
+      (
+        include "${KW_LIB_DIR}/signature.sh"
+
+        signature_main "$@"
+      )
+      ;;
     version | --version | -v)
       (
         include "${KW_LIB_DIR}/help.sh"

--- a/src/_kw
+++ b/src/_kw
@@ -41,6 +41,7 @@ _kw()
     'remote:Manage the set of test machines ("remotes")'
     'report:Show kw pomodoro reports and kw usage statistics'
     'self-update:kw self-update mechanism'
+    'signature:Write trailers in commits or patches'
     'ssh:SSH support'
     'patch-hub: Open UI with lore.kernel.org archives'
     'version:Show kw version'
@@ -407,8 +408,8 @@ _kw_man()
 {
   _values 'kw commands' \
     'backup' 'bd' 'build' 'codestyle' 'config' 'debug' 'deploy' 'device' 'diff' 'drm' 'env' \
-    'explore' 'init' 'send-patch' 'maintainers' 'pomodoro' 'remote' 'report' 'self-update' 'ssh' \
-    'patch-hub' 
+    'explore' 'init' 'send-patch' 'maintainers' 'pomodoro' 'remote' 'report' 'self-update' \
+    'signature' 'ssh' 'patch-hub' 
 }
 
 _kw_p() { _kw_pomodoro }
@@ -484,6 +485,20 @@ _kw_self-update()
   _arguments : \
     '(--verbose)--verbose[enable verbose mode]' \
     '(-u --unstable)'{-u,--unstable}'[update kw based on the unstable branch]'
+}
+
+_kw_signature()
+{
+  _arguments : \
+    '(--verbose)--verbose[enable verbose mode]' \
+    {-s-,--add-signed-off-by=-}'[add Signed-off-by tag line]' \
+    {-r-,--add-reviewed-by=-}'[add Reviewed-by tag line]' \
+    {-a-,--add-acked-by=-}'[add Acked-by tag line]' \
+    {-t-,--add-tested-by=-}'[add Tested-by tag line]' \
+    {-C-,--add-co-developed-by=-}'[add Co-developed-by and Signed-off-by tag lines]' \
+    {-R-,--add-reported-by=-}'[add Reported-by and optional Closes|Link tag lines]' \
+    {-f-,--add-fixes=-}'[add Fixes tag line]' \
+    '1: :_files'
 }
 
 _kw_s() { _kw_ssh }

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -16,7 +16,7 @@ function _kw_autocomplete()
   kw_options['kw']='init build deploy bd diff ssh codestyle self-update
                     maintainers kernel-config-manager config remote explore
                     pomodoro report device backup debug send-patch env patch-hub
-                    clear-cache drm vm version man help'
+                    clear-cache drm vm signature version man help'
 
   kw_options['init']='--arch --remote --target --force --template --verbose'
 
@@ -82,6 +82,9 @@ function _kw_autocomplete()
                      --load-module --unload-module --conn-available --modes --verbose --help'
 
   kw_options['vm']='--mount --umount --up --alert --help'
+
+  kw_options['signature']='--add-signed-off-by --add-reviewed-by --add-acked-by --add-fixes
+                           --add-tested-by --add-co-developed-by --add-reported-by --verbose --help'
 
   kw_options['clear-cache']='--verbose'
 

--- a/src/send_patch.sh
+++ b/src/send_patch.sh
@@ -18,8 +18,6 @@ declare -ga essential_config_options=('user.name' 'user.email'
   'sendemail.smtpuser' 'sendemail.smtpserver' 'sendemail.smtpserverport')
 declare -ga optional_config_options=('sendemail.smtpencryption' 'sendemail.smtppass')
 
-declare -gr email_regex='[A-Za-z0-9_\.-]+@[A-Za-z0-9_-]+(\.[A-Za-z0-9]+)+'
-
 #shellcheck disable=SC2119
 function send_patch_main()
 {
@@ -134,35 +132,6 @@ function mail_send()
   [[ -n "$extra_opts" ]] && cmd+=" $extra_opts"
 
   cmd_manager "$flag" "$cmd"
-}
-
-# Validates the recipient list given by the user to the options `--to` and
-# `--cc` to make sure the all the recipients are valid.
-#
-# @raw: The list of email recipients to be validated
-#
-# Return:
-# 22 if there are invalid entries; 0 otherwise
-function validate_email_list()
-{
-  local raw="$1"
-  local -a list
-  local value
-  local error=0
-
-  IFS=',' read -ra list <<< "$raw"
-
-  for value in "${list[@]}"; do
-    if [[ ! "$value" =~ ${email_regex} ]]; then
-      warning -n 'The given recipient: '
-      printf '%s' "$value"
-      warning ' does not contain a valid e-mail.'
-      error=1
-    fi
-  done
-
-  [[ "$error" == 1 ]] && return 22 # EINVAL
-  return 0
 }
 
 # This function generates the patches beforehand, these are used to count the
@@ -442,26 +411,6 @@ function validate_encryption()
   warning 'Empty value defaults to plain smtp.'
 
   return 22 # EINVAL
-}
-
-# This function validates the encryption. If the passed encryption is not valid
-# this will warn the user and clear the option.
-#
-# @option: The option to determine if it should be an email
-# @value:  The value being passed
-#
-# Return:
-# Returns 0 if valid; 22 if invalid
-function validate_email()
-{
-  local value="$1"
-
-  if [[ ! "$value" =~ ^${email_regex}$ ]]; then
-    complain "Invalid email: $value"
-    return 22 #EINVAL
-  fi
-
-  return 0
 }
 
 # Gets the values associated to a certain config option and puts them in the

--- a/src/signature.sh
+++ b/src/signature.sh
@@ -1,0 +1,639 @@
+include "${KW_LIB_DIR}/lib/kw_config_loader.sh"
+include "${KW_LIB_DIR}/lib/kwlib.sh"
+
+declare -gA options_values
+
+# Define a constant to store all kernel tags
+declare -gA KERNEL_TAGS
+
+KERNEL_TAGS['REPORTED_BY']='Reported-by:'
+KERNEL_TAGS['CO_DEVELOPED_BY']='Co-developed-by:'
+KERNEL_TAGS['ACKED_BY']='Acked-by:'
+KERNEL_TAGS['TESTED_BY']='Tested-by:'
+KERNEL_TAGS['REVIEWED_BY']='Reviewed-by:'
+KERNEL_TAGS['SIGNED_OFF_BY']='Signed-off-by:'
+KERNEL_TAGS['FIXES']='Fixes:'
+
+# This structure organizes all the parsed trailer lines by their tags.
+# For example, TRAILER_BUFFERS['SIGNED_OFF_BY'] contains all trailers
+# tagged with 'Signed-off-by'. It's a string where trailers are separated
+# by commas like:
+# "Signed-off-by: Joe Doe <joedoe@mail.xyz>,Signed-off-by: Jane Doe <janedoe@mail.xyz>"
+#
+# It acts as an auxiliary variable to sort the trailers that will be written later
+declare -gA grouped_trailers_by_tag
+
+# This structure groups different tags based on unique signatures.
+# For example, grouped_tags['blabla@mail.xyz'] is a string which contains
+# trailer lines associated to this email and separated by commas like:
+# "Reviewed-by: Joe Doe <joedoe@mail.xyz>,Signed-off-by: Joe Doe <joedoe@mail.xyz>"
+#
+# It acts as an auxiliary variable to sort the trailers that will be written later
+declare -gA grouped_trailers_by_email
+
+# This variable holds all the emails from signatures. The order of such emails
+# represent the order each email entry in `grouped_trailers_by_email` was created
+# during this feature's execution.
+declare -ga sorted_emails
+
+# Variable to store all trailers that will be added. If `sort_all_trailers`
+# function is used, then the order obeys the following general sequence:
+# - Reported-by
+# - Co-developed-by
+# - Acked-by
+# - Tested-by
+# - Reviewed-by
+# - Signed-off-by
+# - Fixes
+# As trailer lines with the same signature are grouped together. Example:
+# Reviewed-by: Joe Doe <joedoe@mail.xyz>
+# Signed-off-by: Joe Doe <joedoe@mail.xyz>
+# Reviewed-by: Bob Doe <bobdoe@mail.xyz>
+# Signed-off-by: Bob Doe <boobdoe@mail.xyz>
+declare -g all_trailers
+
+# This function performs operations over trailers in
+# either patches or commits. It checks if given argument
+# is a valid commit reference or patch path and uses the
+# correct command to perform the task.
+# If that's not the case, a warning message will tell
+# the user this argument was ignored.
+#
+# Also, if no operation option is given, then an error message
+# followed by a helper message is printed to the user.
+#
+# @patch_or_sha_args Holds either patch paths or commit references.
+function signature_main()
+{
+  local patch_or_sha_args
+  local flag
+
+  if [[ "$1" =~ -h|--help ]]; then
+    signature_help "$1"
+    exit 0
+  fi
+
+  # Ensure all trailer arrays are empty
+  for key in "${!grouped_trailers_by_tag[@]}"; do
+    unset "grouped_trailers_by_tag[$key]"
+  done
+  for key in "${!grouped_trailers_by_email[@]}"; do
+    unset "grouped_trailers_by_email[$key]"
+  done
+  sorted_emails=()
+  all_trailers=''
+
+  # Parse all command line options
+  parse_signature_options "$@"
+  if [[ "$?" -gt 0 ]]; then
+    complain "${options_values['ERROR']}"
+    return 22 # EINVAL
+  fi
+
+  [[ -n "${options_values['VERBOSE']}" ]] && flag='VERBOSE'
+  flag=${flag:-'SILENT'}
+
+  read -ra patch_or_sha_args <<< "${options_values['PATCH_OR_SHA']}"
+
+  if [[ -n "${options_values['NO_ADD_OPTION']}" ]]; then
+    complain 'At least one --add option is required to use this command'
+    signature_help
+    return 22 # EINVAL
+  fi
+
+  sort_all_trailers
+
+  for arg in "${patch_or_sha_args[@]}"; do
+    write_all_trailers "$arg" "$flag"
+  done
+}
+
+# This function validates the signature. If the passed signature
+# does not follow the format 'NAME <EMAIL>' with a valid EMAIL, then
+# it returns an error.
+#
+# @signature Holds the string that is validated
+#
+# Return:
+# Returns 0 if signature is valid; returns 22 otherwise.
+function is_valid_signature()
+{
+  local signature="$1"
+
+  if [[ "$signature" =~ ^[^\<]+\ [^\<]+\<([^\>]+)\>$ ]]; then
+    validate_email "${BASH_REMATCH[1]}"
+    if [[ "$?" -gt 0 ]]; then
+      return 22 # EINVAL
+    fi
+  else
+    return 22 # EINVAL
+  fi
+}
+
+# This functions extracts the NAME from a trailer line with a valid signature.
+# Valid signatures can be verified with `is_valid_signature`.
+#
+# @trailer A string that follows the pattern "TRAILER_TAG: NAME <EMAIL>"
+function extract_name_from_trailer()
+{
+  local trailer="$1"
+  printf '%s' "$trailer" | grep --only-matching --perl-regexp '(?<=: ).*?(?= <)'
+}
+
+# This functions extracts the EMAIL from a trailer line with a valid signature.
+# Valid signatures can be verified with `is_valid_signature`.
+#
+# @trailer A string that follows the pattern "TRAILER_TAG: NAME <EMAIL>"
+function extract_email_from_trailer()
+{
+  local trailer="$1"
+  printf '%s' "$trailer" | grep --only-matching --perl-regexp '<\K[^>]+'
+}
+
+# # TODO: To move this function to a 'gitlib' library
+#
+# This function validates if a commit reference is valid.
+#
+# @sha Holds a string that can be a commit hash or pointer.
+#
+# Returns:
+# True if given argument is a valid commit reference and false otherwise.
+function is_valid_commit_reference()
+{
+  local sha="$1"
+
+  if [[ $(git cat-file -t "$sha" 2> /dev/null) != 'commit' ]]; then
+    return 1 # EPERM
+  fi
+}
+
+# This function parses and adds a new trailer line into
+# @all_trailers that will be properly written later, however
+# the trailer isn't added if there's another identical one.
+# It attempts to use the user's name and email configured
+# if a signature is not passed as argument and gives
+# an error if they are not properly set with git config.
+#
+# @keyword Holds a string that is a keyword for a specific operation.
+# @signature Holds a string like 'NAME <EMAIL>' defining the signature.
+#
+# Return:
+# In case of successful return 0 adding the parsed operation;
+# It returns 61 if either user.name or user.email are not configured properly;
+# It returns 22 if the signature does not follow 'NAME <EMAIL>' format;
+function parse_and_add_trailer()
+{
+  local keyword="$1"
+  local signature="$2"
+  local formated_output
+  local parsed_trailer
+  local parsed_trailer_name
+  local parsed_trailer_email
+  local trailer_name
+  local trailer_email
+  local repeated_trailer=false
+  local duplicated_email=false
+
+  parsed_trailer="${KERNEL_TAGS[$keyword]} "
+
+  # Use default from git config if no argument was given
+  if [[ ! "$signature" ]]; then
+    formated_output="$(format_name_email_from_user)"
+    if [[ "$?" -gt 0 ]]; then
+      return 61 # ENODATA
+    fi
+    parsed_trailer+="$formated_output"
+  else
+    signature="$(str_strip "$signature")"
+    if [[ "$keyword" != 'FIXES' ]] && ! is_valid_signature "$signature"; then
+      return 22 # EINVAL
+    fi
+    parsed_trailer+="$signature"
+  fi
+
+  # Check if this trailer has the same email, but a different name compared to
+  # others already read and saved in `all_trailers`.
+  while read -d ',' -r trailer; do
+    # If it's a (Closes|Link) trailer, then there is no need to check email duplication.
+    if [[ "${trailer}" =~ ^(Closes|Link) ]]; then
+      continue
+    fi
+    parsed_trailer_name=$(extract_name_from_trailer "$parsed_trailer")
+    parsed_trailer_email=$(extract_email_from_trailer "$parsed_trailer")
+    trailer_name=$(extract_name_from_trailer "$trailer")
+    trailer_email=$(extract_email_from_trailer "$trailer")
+    if [[ "$trailer_email" == "$parsed_trailer_email" && "$trailer_name" != "$parsed_trailer_name" ]]; then
+      duplicated_email=true
+      warning "Same email used with different names: ${trailer_name}, ${parsed_trailer_name}, ${trailer_email}"
+      warning "Skipping the following trailer line: '${parsed_trailer}'"
+      break
+    fi
+  done <<< "$all_trailers"
+
+  # Check for trailer duplication
+  while read -d ',' -r item; do
+    if [[ "$item" == "$parsed_trailer" ]]; then
+      repeated_trailer=true
+      warning "Skipping duplicated trailer line: '${parsed_trailer}'"
+      break
+    fi
+  done <<< "${grouped_trailers_by_tag[$keyword]}"
+
+  if [[ "$repeated_trailer" = false ]] && [[ "$duplicated_email" = false ]]; then
+    grouped_trailers_by_tag["$keyword"]+="${parsed_trailer},"
+    all_trailers+="${parsed_trailer},"
+  fi
+}
+
+# This function receives a commit SHA and verifies if it's
+# a valid commit reference. If it is, then it outputs the
+# appropriate formatted message. Else it returns an error code.
+#
+# @sha Holds either a commit hash or pointer
+#
+# Return:
+# In case of successful return 0 and prints the formatted message,
+# otherwise, return 22.
+function format_fixes_message()
+{
+  local sha="$1"
+  local formatted_message
+
+  # Check if given value is a valid commit reference
+  if ! is_valid_commit_reference "$sha"; then
+    return 22 # EINVAL
+  fi
+
+  # The 'Fixes:' trailer line must follow a format defined by Linux Kernel developers.
+  # Fixes: e21d2170f366 ("video: remove unnecessary platform_set_drvdata()")
+  formatted_message=$(git log -1 "$sha" --oneline --abbrev-commit --abbrev=12 \
+    --format="%h (\\\"%s\\\")")
+
+  printf '%s' "$formatted_message"
+}
+
+# It gets user.name and user.email from git's configuration.
+# If either the name or email are not configured then this
+# function will return an error code. Otherwise it will output
+# the formatted name and email.
+#
+# Return:
+# In case of successful return 0 and prints a properly formatted
+# output, otherwise, return 61.
+function format_name_email_from_user()
+{
+  local user_name
+  local user_email
+
+  user_name="$(git config user.name)"
+  user_email="$(git config user.email)"
+
+  # If user doesn't have either a name or email configured with
+  # git then they must provide an argument
+  if [[ -z "$user_name" || -z "$user_email" ]]; then
+    return 61 # ENODATA
+  fi
+
+  printf '%s' "${user_name} <${user_email}>"
+}
+
+# This function gets all trailers saved in a `grouped_trailers_by_tag`
+# entry and associates each trailer to a `grouped_trailers_by_email` entry.
+#
+# @specified_tag Holds the tag group that will be re-grouped by their emails.
+function group_by_email()
+{
+  local specified_tag="$1"
+  local email
+
+  while read -d ',' -r trailer; do
+    # Extract email from trailer
+    email=$(extract_email_from_trailer "$trailer")
+    # Save email if no signature with it was saved so far
+    if [[ -z "${grouped_trailers_by_email[$email]}" ]]; then
+      sorted_emails+=("$email")
+    fi
+    # Remove the associative email from (Closes|Link) trailer lines
+    if [[ "${trailer}" =~ ^(Closes|Link) ]]; then
+      trailer=$(printf '%s' "$trailer" | sed --regexp-extended 's/ <[^>]*>$//')
+    fi
+    # Append the signature to the associative array based on the email
+    grouped_trailers_by_email["$email"]+="${trailer},"
+  done <<< "${grouped_trailers_by_tag[$specified_tag]}"
+}
+
+# This function adds every parsed trailer in `grouped_trailers_by_tag`
+# entries to `all_trailers`, following the general order proposed at the
+# `all_trailers` declaration.
+#
+# The strategy to achieve that is to sort all trailers by their tags first,
+# then sort them by their emails. By doing so, this function can enforce that
+# general order, and additionally it forces signatures from the same person
+# to be together, avoiding multiple disconnected tags like 'Co-developed-by',
+# 'Reviewed-by' or 'Signed-off-by' from the person in commits or patches.
+function sort_all_trailers()
+{
+  all_trailers=''
+
+  # Group all trailers by email. The order of this grouping process
+  # follows the same order of the next `group_by_email` calls, sorting
+  # the trailers by their tags.
+  group_by_email 'REPORTED_BY'
+  group_by_email 'CO_DEVELOPED_BY'
+  group_by_email 'ACKED_BY'
+  group_by_email 'TESTED_BY'
+  group_by_email 'REVIEWED_BY'
+  group_by_email 'SIGNED_OFF_BY'
+
+  # Concatanate all email groups following the order in `sorted_emails`,
+  # sorting the trailers by their emails.
+  for email in "${sorted_emails[@]}"; do
+    all_trailers+="${grouped_trailers_by_email[$email]}"
+  done
+
+  # Concatanate every 'Fixes' tag at the end of `all_trailers`, which means
+  # they will be the last written trailers when `write_all_trailers` is called.
+  while read -d ',' -r trailer; do
+    all_trailers+="${trailer},"
+  done <<< "${grouped_trailers_by_tag['FIXES']}"
+}
+
+# This function writes all the trailer lines stored in `all_trailers`
+# into either a patch file or commit.
+#
+# @patch_or_sha Holds either a patch path or commit SHA
+# @flag Used to specify how `cmd_manager` will be executed
+function write_all_trailers()
+{
+  local patch_or_sha="$1"
+  local flag="$2"
+  local cmd
+
+  while read -d ',' -r trailer; do
+    # Check if given argument is either a patch or valid commit reference,
+    # then build the correct command.
+    if is_valid_commit_reference "$patch_or_sha"; then
+      cmd="git commit --quiet --amend --no-edit --trailer \"${trailer}\""
+      # Only call 'git rebase' if user is trying to write multiple commits
+      if [[ "$(git rev-parse "$patch_or_sha")" != "$(git rev-parse HEAD)" ]]; then
+        cmd="git rebase ${patch_or_sha} --exec '${cmd}' 2> /dev/null"
+      fi
+    else
+      cmd="git interpret-trailers ${patch_or_sha} --in-place --trailer \"${trailer}\""
+    fi
+    cmd_manager "$flag" "$cmd"
+  done <<< "$all_trailers"
+}
+
+# This function gets raw data and based on that fill out the options values to
+# be used in another function.
+#
+# Return:
+# In case of successful return 0, otherwise, return 22.
+function parse_signature_options()
+{
+  local long_options='add-signed-off-by::,add-reviewed-by::,add-acked-by::,add-fixes::'
+  long_options+=',add-tested-by::,add-reported-by::,add-co-developed-by::,verbose'
+  local short_options='s::,r::,a::,f::,t::,R::,C::'
+
+  options="$(kw_parse "$short_options" "$long_options" "$@")"
+
+  if [[ "$?" -gt 0 ]]; then
+    options_values['ERROR']="$(kw_parse_get_errors 'kw signature' \
+      "$short_options" "$long_options" "$@")"
+    return 22 # EINVAL
+  fi
+
+  options_values['PATCH_OR_SHA']='HEAD'
+
+  options_values['VERBOSE']=''
+  options_values['NO_ADD_OPTION']=1
+
+  eval "set -- ${options}"
+
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --add-signed-off-by | -s)
+        options_values['NO_ADD_OPTION']=''
+
+        while read -d ',' -r signature; do
+          parse_and_add_trailer 'SIGNED_OFF_BY' "$signature"
+          return_status="$?"
+
+          if [[ "$return_status" -eq 61 ]]; then
+            options_values['ERROR']='You must configure your user.name and user.email with git '
+            options_values['ERROR']+='to use --add-signed-off-by | -s without an argument'
+            return 22 # EINVAL
+          elif [[ "$return_status" -eq 22 ]]; then
+            options_values['ERROR']="Invalid signature format: ${signature}"
+            return 22 # EINVAL
+          fi
+        done <<< "${2},"
+
+        [[ ! "$2" ]] || shift
+        shift
+        ;;
+
+      --add-reviewed-by | -r)
+        options_values['NO_ADD_OPTION']=''
+
+        while read -d ',' -r signature; do
+          parse_and_add_trailer 'REVIEWED_BY' "$signature"
+          return_status="$?"
+
+          if [[ "$return_status" -eq 61 ]]; then
+            options_values['ERROR']='You must configure your user.name and user.email with git '
+            options_values['ERROR']+='to use --add-reviewed-by | -r without an argument'
+            return 22 # EINVAL
+          elif [[ "$return_status" -eq 22 ]]; then
+            options_values['ERROR']="Invalid signature format: ${signature}"
+            return 22 # EINVAL
+          fi
+        done <<< "${2},"
+
+        [[ ! "$2" ]] || shift
+        shift
+        ;;
+
+      --add-acked-by | -a)
+        options_values['NO_ADD_OPTION']=''
+
+        while read -d ',' -r signature; do
+          parse_and_add_trailer 'ACKED_BY' "$signature"
+          return_status="$?"
+
+          if [[ "$return_status" -eq 61 ]]; then
+            options_values['ERROR']='You must configure your user.name and user.email with git '
+            options_values['ERROR']+='to use --add-acked-by | -a without an argument'
+            return 22 # EINVAL
+          elif [[ "$return_status" -eq 22 ]]; then
+            options_values['ERROR']="Invalid signature format: ${signature}"
+            return 22 # EINVAL
+          fi
+        done <<< "${2},"
+
+        [[ ! "$2" ]] || shift
+        shift
+        ;;
+
+      --add-tested-by | -t)
+        options_values['NO_ADD_OPTION']=''
+
+        while read -d ',' -r signature; do
+          parse_and_add_trailer 'TESTED_BY' "$signature"
+          return_status="$?"
+
+          if [[ "$return_status" -eq 61 ]]; then
+            options_values['ERROR']='You must configure your user.name and user.email with git '
+            options_values['ERROR']+='to use --add-tested-by | -t without an argument'
+            return 22 # EINVAL
+          elif [[ "$return_status" -eq 22 ]]; then
+            options_values['ERROR']="Invalid signature format: ${signature}"
+            return 22 # EINVAL
+          fi
+        done <<< "${2},"
+
+        [[ ! "$2" ]] || shift
+        shift
+        ;;
+
+      --add-co-developed-by | -C)
+        options_values['NO_ADD_OPTION']=''
+
+        while read -d ',' -r signature; do
+          parse_and_add_trailer 'CO_DEVELOPED_BY' "$signature"
+          return_status="$?"
+
+          if [[ "$return_status" -eq 61 ]]; then
+            options_values['ERROR']='You must configure your user.name and user.email with git '
+            options_values['ERROR']+='to use --add-co-developed-by | -C without an argument'
+            return 22 # EINVAL
+          elif [[ "$return_status" -eq 22 ]]; then
+            options_values['ERROR']="Invalid signature format: ${signature}"
+            return 22 # EINVAL
+          fi
+
+          parse_and_add_trailer 'SIGNED_OFF_BY' "$signature"
+        done <<< "${2},"
+
+        [[ ! "$2" ]] || shift
+        shift
+        ;;
+
+      --add-reported-by | -R)
+        options_values['NO_ADD_OPTION']=''
+
+        while read -d ',' -r arg; do
+          IFS=';' read -r signature tag_and_link <<< "$arg"
+
+          parse_and_add_trailer 'REPORTED_BY' "$signature"
+          return_status="$?"
+
+          if [[ "$return_status" -eq 61 ]]; then
+            options_values['ERROR']='You must configure your user.name and user.email with git '
+            options_values['ERROR']+='to use --add-reported-by | -R without an argument'
+            return 22 # EINVAL
+          elif [[ "$return_status" -eq 22 ]]; then
+            options_values['ERROR']="Invalid signature format: ${signature}"
+            return 22 # EINVAL
+          fi
+
+          if [[ -n "$tag_and_link" ]]; then
+            if ! [[ "$tag_and_link" =~ ^(Closes|Link)=[^[:space:]]+$ ]]; then
+              options_values['ERROR']="Bad REPORTED_BY argument: ${tag_and_link}"
+              return 22 # EINVAL
+            fi
+            # Extract the last email in `grouped_trailers_by_tag` and add it to the
+            # (Closes|Link) trailer line. This is important to associate this trailer
+            # line with the correct Reported-by tag when all trailers get sorted.
+            # This email is removed from this (Closes|Link) line before writting it.
+            IFS='=' read -r tag link <<< "$tag_and_link"
+            email=$(extract_email_from_trailer "${grouped_trailers_by_tag['REPORTED_BY']}" |
+              awk 'END {print}')
+            grouped_trailers_by_tag['REPORTED_BY']+="${tag}: ${link} <$email>,"
+            all_trailers+="${tag}: ${link} <$email>,"
+          fi
+        done <<< "${2},"
+
+        [[ ! "$2" ]] || shift
+        shift
+        ;;
+
+      --add-fixes | -f)
+        options_values['NO_ADD_OPTION']=''
+
+        if [[ ! "$2" ]]; then
+          options_values['ERROR']='The option --add-fixes | -f demands an argument'
+          return 22 # EINVAL
+        fi
+
+        formatted_message="$(format_fixes_message "$(str_strip "$2")")"
+        if [[ "$?" -gt 0 ]]; then
+          options_values['ERROR']="Invalid commit reference with --add-fixes | -f: ${2}"
+          return 22 # EINVAL
+        fi
+
+        parse_and_add_trailer 'FIXES' "$formatted_message"
+        shift 2
+        ;;
+
+      --verbose)
+        options_values['VERBOSE']=1
+        shift
+        ;;
+
+      --)
+        # End of options, beginning of arguments.
+        # Overwrite default value if at least one argument is given.
+        [[ -n "$2" ]] && options_values['PATCH_OR_SHA']=''
+        shift
+        ;;
+      *)
+        # Ignore empty argument. No need to validate it.
+        if [[ -z "$1" ]]; then
+          shift
+          continue
+        fi
+
+        # Get all passed arguments each loop
+        if [[ "$1" == *"*"* ]]; then
+          # Expand the glob and loop through each resulting file
+          for arg in $1; do
+            if ! is_valid_commit_reference "$arg" && ! is_a_patch "$arg"; then
+              options_values['ERROR']="Neither a patch nor a valid commit reference: ${arg}"
+              return 22 # EINVAL
+            fi
+            options_values['PATCH_OR_SHA']+=" ${arg}"
+          done
+        else
+          if ! is_valid_commit_reference "$1" && ! is_a_patch "$1"; then
+            options_values['ERROR']="Neither a patch nor a valid commit reference: ${1}"
+            return 22 # EINVAL
+          fi
+          options_values['PATCH_OR_SHA']+=" ${1}"
+        fi
+        shift
+        ;;
+    esac
+  done
+}
+
+function signature_help()
+{
+  if [[ "$1" == --help ]]; then
+    include "${KW_LIB_DIR}/help.sh"
+    kworkflow_man 'signature'
+    return
+  fi
+  printf '%s\n' 'kw signature:' \
+    '  signature (--add-signed-off-by | -s) (<name>,...) [<patchset> | <sha>] - Add Signed-off-by' \
+    '  signature (--add-reviewed-by | -r) (<name>,...) [<patchset> | <sha>] - Add Reviewed-by' \
+    '  signature (--add-acked-by | -a) (<name>,...) [<patchset> | <sha>] - Add Acked-by' \
+    '  signature (--add-tested-by | -t) (<name>,...) [<patchset> | <sha>] - Add Tested-by' \
+    '  signature (--add-co-developed-by | -C) (<name>,...) [<patchset> | <sha>] - Add Co-developed-by and Signed-off-by' \
+    '  signature (--add-reported-by | -R) (<name>;Closes|Link=<link>,...) [<patchset> | <sha>] - Add Reported-by' \
+    '  signature (--add-fixes | -f) [<fixed-sha>] [<patchset> | <sha>] - Add Fixes' \
+    '  signature (--verbose) - Show a detailed output'
+}
+
+load_kworkflow_config

--- a/tests/unit/lib/kwlib_test.sh
+++ b/tests/unit/lib/kwlib_test.sh
@@ -1016,4 +1016,67 @@ function test_check_if_create_shared_memory_dir_creates_dir_in_default_mktemp_di
   assertTrue "${LINENO}: Did not create directory at /tmp/ dir" '[[ $output =~ /tmp/ ]]'
 }
 
+function test_validate_email()
+{
+  local expected
+  local output
+  local ret
+
+  # invalid values
+  output="$(validate_email 'invalid email')"
+  ret="$?"
+  expected='Invalid email: invalid email'
+  assert_equals_helper 'Invalid email was passed' "$LINENO" "$expected" "$output"
+  assert_equals_helper 'Expected an error' "$LINENO" 22 "$ret"
+
+  output="$(validate_email 'lalala')"
+  ret="$?"
+  expected='Invalid email: lalala'
+  assert_equals_helper 'Invalid email was passed' "$LINENO" "$expected" "$output"
+  assert_equals_helper 'Expected an error' "$LINENO" 22 "$ret"
+
+  # valid values
+  validate_email 'test@email.com'
+  ret="$?"
+  assert_equals_helper 'Expected a success' "$LINENO" 0 "$ret"
+
+  validate_email 'test123@serious.gov'
+  ret="$?"
+  assert_equals_helper 'Expected a success' "$LINENO" 0 "$ret"
+}
+
+function test_validate_email_list()
+{
+  local expected
+  local output
+  local ret
+
+  # invalid values
+  output="$(validate_email_list 'invalid email')"
+  ret="$?"
+  expected='The given recipient: invalid email does not contain a valid e-mail.'
+  assert_equals_helper 'Invalid email was passed' "$LINENO" "$expected" "$output"
+  assert_equals_helper 'Expected an error' "$LINENO" 22 "$ret"
+
+  output="$(validate_email_list 'lalala')"
+  ret="$?"
+  expected='The given recipient: lalala does not contain a valid e-mail.'
+  assert_equals_helper 'Invalid email was passed' "$LINENO" "$expected" "$output"
+  assert_equals_helper 'Expected an error' "$LINENO" 22 "$ret"
+
+  output="$(validate_email_list 'name1@lala.com,name2@lala.xpto,LastName, FirstName <last.first@lala.com>,test123@serious.gov')"
+  ret="$?"
+  expected='The given recipient: LastName does not contain a valid e-mail.'
+  assert_equals_helper 'Expected an error' "$LINENO" 22 "$ret"
+
+  # valid values
+  validate_email_list 'test@email.com'
+  ret="$?"
+  assert_equals_helper 'Expected a success' "$LINENO" 0 "$ret"
+
+  validate_email_list 'name1@lala.com,name2@lala.xpto,name3 second <name3second@lala.com>,test123@serious.gov'
+  ret="$?"
+  assert_equals_helper 'Expected a success' "$LINENO" 0 "$ret"
+}
+
 invoke_shunit

--- a/tests/unit/mail_test.sh
+++ b/tests/unit/mail_test.sh
@@ -89,35 +89,6 @@ function test_validate_encryption()
   assert_equals_helper 'Expected no error for tls' "$LINENO" 0 "$ret"
 }
 
-function test_validate_email()
-{
-  local expected
-  local output
-  local ret
-
-  # invalid values
-  output="$(validate_email 'invalid email')"
-  ret="$?"
-  expected='Invalid email: invalid email'
-  assert_equals_helper 'Invalid email was passed' "$LINENO" "$expected" "$output"
-  assert_equals_helper 'Expected an error' "$LINENO" 22 "$ret"
-
-  output="$(validate_email 'lalala')"
-  ret="$?"
-  expected='Invalid email: lalala'
-  assert_equals_helper 'Invalid email was passed' "$LINENO" "$expected" "$output"
-  assert_equals_helper 'Expected an error' "$LINENO" 22 "$ret"
-
-  # valid values
-  validate_email 'test@email.com'
-  ret="$?"
-  assert_equals_helper 'Expected a success' "$LINENO" 0 "$ret"
-
-  validate_email 'test123@serious.gov'
-  ret="$?"
-  assert_equals_helper 'Expected a success' "$LINENO" 0 "$ret"
-}
-
 function test_find_commit_references()
 {
   local output
@@ -168,40 +139,6 @@ function test_find_commit_references()
     fail "($LINENO): Failed to move back to original dir"
     exit "$ret"
   }
-}
-
-function test_validate_email_list()
-{
-  local expected
-  local output
-  local ret
-
-  # invalid values
-  output="$(validate_email_list 'invalid email')"
-  ret="$?"
-  expected='The given recipient: invalid email does not contain a valid e-mail.'
-  assert_equals_helper 'Invalid email was passed' "$LINENO" "$expected" "$output"
-  assert_equals_helper 'Expected an error' "$LINENO" 22 "$ret"
-
-  output="$(validate_email_list 'lalala')"
-  ret="$?"
-  expected='The given recipient: lalala does not contain a valid e-mail.'
-  assert_equals_helper 'Invalid email was passed' "$LINENO" "$expected" "$output"
-  assert_equals_helper 'Expected an error' "$LINENO" 22 "$ret"
-
-  output="$(validate_email_list 'name1@lala.com,name2@lala.xpto,LastName, FirstName <last.first@lala.com>,test123@serious.gov')"
-  ret="$?"
-  expected='The given recipient: LastName does not contain a valid e-mail.'
-  assert_equals_helper 'Expected an error' "$LINENO" 22 "$ret"
-
-  # valid values
-  validate_email_list 'test@email.com'
-  ret="$?"
-  assert_equals_helper 'Expected a success' "$LINENO" 0 "$ret"
-
-  validate_email_list 'name1@lala.com,name2@lala.xpto,name3 second <name3second@lala.com>,test123@serious.gov'
-  ret="$?"
-  assert_equals_helper 'Expected a success' "$LINENO" 0 "$ret"
 }
 
 function test_reposition_commit_count_arg()

--- a/tests/unit/samples/signature_patch_samples/patch_model.patch
+++ b/tests/unit/samples/signature_patch_samples/patch_model.patch
@@ -1,0 +1,28 @@
+From f0440260c76695e874af21a45e3156d3ba7a817b Mon Sep 17 00:00:00 2001
+From: kw <kw@kw.net>
+Date: Thu, 24 May 2024 13:26:52 -0300
+To: Jane Doe <janedoe@mail.xyz>,kernel@list.org
+Subject: [PATCH] signature test
+
+This is just a dummy patch to test features.
+
+Signed-off-by: kw <kw@kw.net>
+---
+ sound/core/init.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sound/core/init.c b/sound/core/init.c
+index b02a99766351..fa769ff80e09 100644
+--- a/sound/core/init.c
++++ b/sound/core/init.c
+@@ -19,6 +19,8 @@
+ #include <sound/control.h>
+ #include <sound/info.h>
+
++/* Testing... */
++
+ /* monitor files for graceful shutdown (hotplug) */
+ struct snd_monitor_file {
+ 	struct file *file;
+--
+2.30.0

--- a/tests/unit/samples/signature_patch_samples/patch_model_acked.patch
+++ b/tests/unit/samples/signature_patch_samples/patch_model_acked.patch
@@ -1,0 +1,29 @@
+From f0440260c76695e874af21a45e3156d3ba7a817b Mon Sep 17 00:00:00 2001
+From: kw <kw@kw.net>
+Date: Thu, 24 May 2024 13:26:52 -0300
+To: Jane Doe <janedoe@mail.xyz>,kernel@list.org
+Subject: [PATCH] signature test
+
+This is just a dummy patch to test features.
+
+Signed-off-by: kw <kw@kw.net>
+Acked-by: Michael Doe <michaeldoe@kwkw.xyz>
+---
+ sound/core/init.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sound/core/init.c b/sound/core/init.c
+index b02a99766351..fa769ff80e09 100644
+--- a/sound/core/init.c
++++ b/sound/core/init.c
+@@ -19,6 +19,8 @@
+ #include <sound/control.h>
+ #include <sound/info.h>
+
++/* Testing... */
++
+ /* monitor files for graceful shutdown (hotplug) */
+ struct snd_monitor_file {
+ 	struct file *file;
+--
+2.30.0

--- a/tests/unit/samples/signature_patch_samples/patch_model_co_developed.patch
+++ b/tests/unit/samples/signature_patch_samples/patch_model_co_developed.patch
@@ -1,0 +1,30 @@
+From f0440260c76695e874af21a45e3156d3ba7a817b Mon Sep 17 00:00:00 2001
+From: kw <kw@kw.net>
+Date: Thu, 24 May 2024 13:26:52 -0300
+To: Jane Doe <janedoe@mail.xyz>,kernel@list.org
+Subject: [PATCH] signature test
+
+This is just a dummy patch to test features.
+
+Signed-off-by: kw <kw@kw.net>
+Co-developed-by: Bob Brown <bob.brown@mail.xyz>
+Signed-off-by: Bob Brown <bob.brown@mail.xyz>
+---
+ sound/core/init.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sound/core/init.c b/sound/core/init.c
+index b02a99766351..fa769ff80e09 100644
+--- a/sound/core/init.c
++++ b/sound/core/init.c
+@@ -19,6 +19,8 @@
+ #include <sound/control.h>
+ #include <sound/info.h>
+
++/* Testing... */
++
+ /* monitor files for graceful shutdown (hotplug) */
+ struct snd_monitor_file {
+ 	struct file *file;
+--
+2.30.0

--- a/tests/unit/samples/signature_patch_samples/patch_model_complete.patch
+++ b/tests/unit/samples/signature_patch_samples/patch_model_complete.patch
@@ -1,0 +1,31 @@
+From f0440260c76695e874af21a45e3156d3ba7a817b Mon Sep 17 00:00:00 2001
+From: kw <kw@kw.net>
+Date: Thu, 24 May 2024 13:26:52 -0300
+To: Jane Doe <janedoe@mail.xyz>,kernel@list.org
+Subject: [PATCH] signature test
+
+This is just a dummy patch to test features.
+
+Signed-off-by: kw <kw@kw.net>
+Acked-by: Michael Doe <michaeldoe@kwkw.xyz>
+Reviewed-by: John Doe <johndoe@kwkw.xyz>
+Fixes: <hash>
+---
+ sound/core/init.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sound/core/init.c b/sound/core/init.c
+index b02a99766351..fa769ff80e09 100644
+--- a/sound/core/init.c
++++ b/sound/core/init.c
+@@ -19,6 +19,8 @@
+ #include <sound/control.h>
+ #include <sound/info.h>
+
++/* Testing... */
++
+ /* monitor files for graceful shutdown (hotplug) */
+ struct snd_monitor_file {
+ 	struct file *file;
+--
+2.30.0

--- a/tests/unit/samples/signature_patch_samples/patch_model_fixes.patch
+++ b/tests/unit/samples/signature_patch_samples/patch_model_fixes.patch
@@ -1,0 +1,29 @@
+From f0440260c76695e874af21a45e3156d3ba7a817b Mon Sep 17 00:00:00 2001
+From: kw <kw@kw.net>
+Date: Thu, 24 May 2024 13:26:52 -0300
+To: Jane Doe <janedoe@mail.xyz>,kernel@list.org
+Subject: [PATCH] signature test
+
+This is just a dummy patch to test features.
+
+Signed-off-by: kw <kw@kw.net>
+Fixes: <hash>
+---
+ sound/core/init.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sound/core/init.c b/sound/core/init.c
+index b02a99766351..fa769ff80e09 100644
+--- a/sound/core/init.c
++++ b/sound/core/init.c
+@@ -19,6 +19,8 @@
+ #include <sound/control.h>
+ #include <sound/info.h>
+
++/* Testing... */
++
+ /* monitor files for graceful shutdown (hotplug) */
+ struct snd_monitor_file {
+ 	struct file *file;
+--
+2.30.0

--- a/tests/unit/samples/signature_patch_samples/patch_model_full_review.patch
+++ b/tests/unit/samples/signature_patch_samples/patch_model_full_review.patch
@@ -1,0 +1,30 @@
+From f0440260c76695e874af21a45e3156d3ba7a817b Mon Sep 17 00:00:00 2001
+From: kw <kw@kw.net>
+Date: Thu, 24 May 2024 13:26:52 -0300
+To: Jane Doe <janedoe@mail.xyz>,kernel@list.org
+Subject: [PATCH] signature test
+
+This is just a dummy patch to test features.
+
+Signed-off-by: kw <kw@kw.net>
+Reviewed-by: Jane Doe <janedoe@mail.xyz>
+Signed-off-by: Jane Doe <janedoe@mail.xyz>
+---
+ sound/core/init.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sound/core/init.c b/sound/core/init.c
+index b02a99766351..fa769ff80e09 100644
+--- a/sound/core/init.c
++++ b/sound/core/init.c
+@@ -19,6 +19,8 @@
+ #include <sound/control.h>
+ #include <sound/info.h>
+
++/* Testing... */
++
+ /* monitor files for graceful shutdown (hotplug) */
+ struct snd_monitor_file {
+ 	struct file *file;
+--
+2.30.0

--- a/tests/unit/samples/signature_patch_samples/patch_model_reported.patch
+++ b/tests/unit/samples/signature_patch_samples/patch_model_reported.patch
@@ -1,0 +1,29 @@
+From f0440260c76695e874af21a45e3156d3ba7a817b Mon Sep 17 00:00:00 2001
+From: kw <kw@kw.net>
+Date: Thu, 24 May 2024 13:26:52 -0300
+To: Jane Doe <janedoe@mail.xyz>,kernel@list.org
+Subject: [PATCH] signature test
+
+This is just a dummy patch to test features.
+
+Signed-off-by: kw <kw@kw.net>
+Reported-by: Bob Brown <bob.brown@mail.xyz>
+---
+ sound/core/init.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sound/core/init.c b/sound/core/init.c
+index b02a99766351..fa769ff80e09 100644
+--- a/sound/core/init.c
++++ b/sound/core/init.c
+@@ -19,6 +19,8 @@
+ #include <sound/control.h>
+ #include <sound/info.h>
+
++/* Testing... */
++
+ /* monitor files for graceful shutdown (hotplug) */
+ struct snd_monitor_file {
+ 	struct file *file;
+--
+2.30.0

--- a/tests/unit/samples/signature_patch_samples/patch_model_reviewed.patch
+++ b/tests/unit/samples/signature_patch_samples/patch_model_reviewed.patch
@@ -1,0 +1,29 @@
+From f0440260c76695e874af21a45e3156d3ba7a817b Mon Sep 17 00:00:00 2001
+From: kw <kw@kw.net>
+Date: Thu, 24 May 2024 13:26:52 -0300
+To: Jane Doe <janedoe@mail.xyz>,kernel@list.org
+Subject: [PATCH] signature test
+
+This is just a dummy patch to test features.
+
+Signed-off-by: kw <kw@kw.net>
+Reviewed-by: Jane Doe <janedoe@mail.xyz>
+---
+ sound/core/init.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sound/core/init.c b/sound/core/init.c
+index b02a99766351..fa769ff80e09 100644
+--- a/sound/core/init.c
++++ b/sound/core/init.c
+@@ -19,6 +19,8 @@
+ #include <sound/control.h>
+ #include <sound/info.h>
+
++/* Testing... */
++
+ /* monitor files for graceful shutdown (hotplug) */
+ struct snd_monitor_file {
+ 	struct file *file;
+--
+2.30.0

--- a/tests/unit/samples/signature_patch_samples/patch_model_signed_off.patch
+++ b/tests/unit/samples/signature_patch_samples/patch_model_signed_off.patch
@@ -1,0 +1,29 @@
+From f0440260c76695e874af21a45e3156d3ba7a817b Mon Sep 17 00:00:00 2001
+From: kw <kw@kw.net>
+Date: Thu, 24 May 2024 13:26:52 -0300
+To: Jane Doe <janedoe@mail.xyz>,kernel@list.org
+Subject: [PATCH] signature test
+
+This is just a dummy patch to test features.
+
+Signed-off-by: kw <kw@kw.net>
+Signed-off-by: Jane Doe <janedoe@mail.xyz>
+---
+ sound/core/init.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sound/core/init.c b/sound/core/init.c
+index b02a99766351..fa769ff80e09 100644
+--- a/sound/core/init.c
++++ b/sound/core/init.c
+@@ -19,6 +19,8 @@
+ #include <sound/control.h>
+ #include <sound/info.h>
+
++/* Testing... */
++
+ /* monitor files for graceful shutdown (hotplug) */
+ struct snd_monitor_file {
+ 	struct file *file;
+--
+2.30.0

--- a/tests/unit/samples/signature_patch_samples/patch_model_tested.patch
+++ b/tests/unit/samples/signature_patch_samples/patch_model_tested.patch
@@ -1,0 +1,29 @@
+From f0440260c76695e874af21a45e3156d3ba7a817b Mon Sep 17 00:00:00 2001
+From: kw <kw@kw.net>
+Date: Thu, 24 May 2024 13:26:52 -0300
+To: Jane Doe <janedoe@mail.xyz>,kernel@list.org
+Subject: [PATCH] signature test
+
+This is just a dummy patch to test features.
+
+Signed-off-by: kw <kw@kw.net>
+Tested-by: Bob Brown <bob.brown@mail.xyz>
+---
+ sound/core/init.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sound/core/init.c b/sound/core/init.c
+index b02a99766351..fa769ff80e09 100644
+--- a/sound/core/init.c
++++ b/sound/core/init.c
+@@ -19,6 +19,8 @@
+ #include <sound/control.h>
+ #include <sound/info.h>
+
++/* Testing... */
++
+ /* monitor files for graceful shutdown (hotplug) */
+ struct snd_monitor_file {
+ 	struct file *file;
+--
+2.30.0

--- a/tests/unit/signature_test.sh
+++ b/tests/unit/signature_test.sh
@@ -1,0 +1,814 @@
+#!/usr/bin/env bash
+
+include './src/signature.sh'
+include './tests/unit/utils.sh'
+
+# The variables below are holding the correct trailers
+# with the outputs of the following command:
+# git log --max-count <N> --format="%(trailers)"
+#
+# Where N is the number of commits to be printed.
+# The above command's behavior is to print only the
+# trailers. Also trailers from different commits are
+# divided by an empty line.
+#
+# It's also important to mention that most variables holding
+# trailer lines contain one additional trailer of a past commit
+# that should not be affected by the operations, helping to
+# indicate that we are not affecting older commits accidentaly.
+
+# Correct trailers for --add-signed-off-by and -s
+#
+# This variable holds the trailers lines of the last 2 commits.
+# The last one was reviewed as the first one was not.
+CORRECT_SIGNED_HEAD='Signed-off-by: kw <kw@kwkw.xyz>
+Signed-off-by: Jane Doe <janedoe@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>'
+
+# This variable holds the trailer lines of the last 4 commits.
+# The last 3 were reviewed while the first one was not.
+CORRECT_SIGNED_LOG='Signed-off-by: kw <kw@kwkw.xyz>
+Signed-off-by: Jane Doe <janedoe@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>
+Signed-off-by: Jane Doe <janedoe@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>
+Signed-off-by: Jane Doe <janedoe@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>'
+
+# Correct trailers for --add-reviewed-by and -r
+CORRECT_REVIEWED_HEAD='Signed-off-by: kw <kw@kwkw.xyz>
+Reviewed-by: Jane Doe <janedoe@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>'
+
+CORRECT_REVIEWED_LOG='Signed-off-by: kw <kw@kwkw.xyz>
+Reviewed-by: Jane Doe <janedoe@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>
+Reviewed-by: Jane Doe <janedoe@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>
+Reviewed-by: Jane Doe <janedoe@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>'
+
+# Often a maintainer will write both 'Reviewed-by' and
+# 'Signed-off-by' trailer lines when they apply the changes
+# presented in a patchset or pull/merge request. The two following
+# variables are used to test this usual operation.
+CORRECT_FULL_REVIEW_HEAD='Signed-off-by: kw <kw@kwkw.xyz>
+Reviewed-by: Jane Doe <janedoe@mail.xyz>
+Signed-off-by: Jane Doe <janedoe@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>'
+
+CORRECT_FULL_REVIEW_LOG='Signed-off-by: kw <kw@kwkw.xyz>
+Reviewed-by: Jane Doe <janedoe@mail.xyz>
+Signed-off-by: Jane Doe <janedoe@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>
+Reviewed-by: Jane Doe <janedoe@mail.xyz>
+Signed-off-by: Jane Doe <janedoe@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>
+Reviewed-by: Jane Doe <janedoe@mail.xyz>
+Signed-off-by: Jane Doe <janedoe@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>'
+
+# Correct trailers for --add-acked-by and -a
+CORRECT_ACKED_HEAD='Signed-off-by: kw <kw@kwkw.xyz>
+Acked-by: Michael Doe <michaeldoe@kwkw.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>'
+
+CORRECT_ACKED_LOG='Signed-off-by: kw <kw@kwkw.xyz>
+Acked-by: Michael Doe <michaeldoe@kwkw.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>
+Acked-by: Michael Doe <michaeldoe@kwkw.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>
+Acked-by: Michael Doe <michaeldoe@kwkw.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>'
+
+# Correct trailers for --add-fixes and -f
+#
+# Writting the correct hash is needed. This has
+# to be done during test runs, since hashes
+# are randomly generated.
+CORRECT_FIXES_HEAD='Signed-off-by: kw <kw@kwkw.xyz>
+Fixes: <hash>
+
+Signed-off-by: kw <kw@kwkw.xyz>'
+
+# Correct trailers for --add-tested-by and -t
+CORRECT_TESTED_HEAD='Signed-off-by: kw <kw@kwkw.xyz>
+Tested-by: Bob Brown <bob.brown@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>'
+
+CORRECT_TESTED_LOG='Signed-off-by: kw <kw@kwkw.xyz>
+Tested-by: Bob Brown <bob.brown@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>
+Tested-by: Bob Brown <bob.brown@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>
+Tested-by: Bob Brown <bob.brown@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>'
+
+# Correct trailers for --add-co-developed-by and -C
+CORRECT_CO_DEVELOPED_HEAD='Signed-off-by: kw <kw@kwkw.xyz>
+Co-developed-by: Bob Brown <bob.brown@mail.xyz>
+Signed-off-by: Bob Brown <bob.brown@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>'
+
+CORRECT_CO_DEVELOPED_LOG='Signed-off-by: kw <kw@kwkw.xyz>
+Co-developed-by: Bob Brown <bob.brown@mail.xyz>
+Signed-off-by: Bob Brown <bob.brown@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>
+Co-developed-by: Bob Brown <bob.brown@mail.xyz>
+Signed-off-by: Bob Brown <bob.brown@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>
+Co-developed-by: Bob Brown <bob.brown@mail.xyz>
+Signed-off-by: Bob Brown <bob.brown@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>'
+
+# Correct trailers for --add-reported-by and -R
+CORRECT_REPORTED_HEAD='Signed-off-by: kw <kw@kwkw.xyz>
+Reported-by: Bob Brown <bob.brown@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>'
+
+CORRECT_REPORTED_LOG='Signed-off-by: kw <kw@kwkw.xyz>
+Reported-by: Bob Brown <bob.brown@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>
+Reported-by: Bob Brown <bob.brown@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>
+Reported-by: Bob Brown <bob.brown@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>'
+
+# Correct trailers when using once each:
+# --add-acked-by    or -a
+# --add-reviewed-by or -r
+# --add-fixes       or -f
+#
+# This also requires a hash while running tests, assuming
+# only the last commit fixes another one.
+CORRECT_MULTI_CALL_LOG_1='Signed-off-by: kw <kw@kwkw.xyz>
+Acked-by: Michael Doe <michaeldoe@kwkw.xyz>
+Reviewed-by: John Doe <johndoe@kwkw.xyz>
+Fixes: <hash>
+
+Signed-off-by: kw <kw@kwkw.xyz>
+Acked-by: Michael Doe <michaeldoe@kwkw.xyz>
+Reviewed-by: John Doe <johndoe@kwkw.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>
+Acked-by: Michael Doe <michaeldoe@kwkw.xyz>
+Reviewed-by: John Doe <johndoe@kwkw.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>'
+
+# Correct trailers when using:
+# --add-co-developed-by or -C (twice)
+# --add-reported-by     or -R
+# --add-tested-by       or -t
+# --add-reviewed-by     or -r
+# --add-signed-off-by   or -s
+#
+# This variable helps to verify if trailers are being written
+# in a typical expected order imposed by the kernel documentation
+CORRECT_MULTI_CALL_LOG_2='Signed-off-by: kw <kw@kwkw.xyz>
+Reported-by: Michael Doe <michaeldoe@mail.xyz>
+Closes: http://link-to-bug.xyz.com
+Co-developed-by: Michael Doe <michaeldoe@mail.xyz>
+Signed-off-by: Michael Doe <michaeldoe@mail.xyz>
+Co-developed-by: John Doe <johndoe@mail.xyz>
+Signed-off-by: John Doe <johndoe@mail.xyz>
+Tested-by: Jane Doe <janedoe@mail.xyz>
+Reviewed-by: Jane Doe <janedoe@mail.xyz>
+Signed-off-by: Jane Doe <janedoe@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>
+Reported-by: Michael Doe <michaeldoe@mail.xyz>
+Closes: http://link-to-bug.xyz.com
+Co-developed-by: Michael Doe <michaeldoe@mail.xyz>
+Signed-off-by: Michael Doe <michaeldoe@mail.xyz>
+Co-developed-by: John Doe <johndoe@mail.xyz>
+Signed-off-by: John Doe <johndoe@mail.xyz>
+Tested-by: Jane Doe <janedoe@mail.xyz>
+Reviewed-by: Jane Doe <janedoe@mail.xyz>
+Signed-off-by: Jane Doe <janedoe@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>
+Reported-by: Michael Doe <michaeldoe@mail.xyz>
+Closes: http://link-to-bug.xyz.com
+Co-developed-by: Michael Doe <michaeldoe@mail.xyz>
+Signed-off-by: Michael Doe <michaeldoe@mail.xyz>
+Co-developed-by: John Doe <johndoe@mail.xyz>
+Signed-off-by: John Doe <johndoe@mail.xyz>
+Tested-by: Jane Doe <janedoe@mail.xyz>
+Reviewed-by: Jane Doe <janedoe@mail.xyz>
+Signed-off-by: Jane Doe <janedoe@mail.xyz>
+
+Signed-off-by: kw <kw@kwkw.xyz>'
+
+# Hold the original directory to go back in every tear down
+ORIGINAL_DIR="$PWD"
+
+function setUp()
+{
+  cp --force 'tests/unit/samples/signature_patch_samples/patch_model.patch' "${SHUNIT_TMPDIR}/"
+  cp --force 'tests/unit/samples/signature_patch_samples/patch_model_signed_off.patch' "${SHUNIT_TMPDIR}/"
+  cp --force 'tests/unit/samples/signature_patch_samples/patch_model_full_review.patch' "${SHUNIT_TMPDIR}/"
+  cp --force 'tests/unit/samples/signature_patch_samples/patch_model_reviewed.patch' "${SHUNIT_TMPDIR}/"
+  cp --force 'tests/unit/samples/signature_patch_samples/patch_model_acked.patch' "${SHUNIT_TMPDIR}/"
+  cp --force 'tests/unit/samples/signature_patch_samples/patch_model_fixes.patch' "${SHUNIT_TMPDIR}/"
+  cp --force 'tests/unit/samples/signature_patch_samples/patch_model_tested.patch' "${SHUNIT_TMPDIR}/"
+  cp --force 'tests/unit/samples/signature_patch_samples/patch_model_co_developed.patch' "${SHUNIT_TMPDIR}/"
+  cp --force 'tests/unit/samples/signature_patch_samples/patch_model_reported.patch' "${SHUNIT_TMPDIR}/"
+  cp --force 'tests/unit/samples/signature_patch_samples/patch_model_complete.patch' "${SHUNIT_TMPDIR}/"
+
+  cd "$SHUNIT_TMPDIR" || {
+    fail "(${LINENO}) It was not possible to move to temporary directory"
+    return
+  }
+
+  # Setup git repository for test
+  mk_fake_git
+
+  # Start repository
+  git config user.name kw
+  git config user.email kw@kwkw.xyz
+  mkdir fs
+  touch fs/some_file
+  git add patch_model.patch patch_model_reviewed.patch patch_model_acked.patch \
+    patch_model_fixes.patch patch_model_tested.patch patch_model_co_developed.patch \
+    patch_model_reported.patch patch_model_complete.patch
+  git add fs/
+  git commit --quiet --signoff --message 'Create files'
+
+  # Simulate wrong change
+  printf 'Wrong text' > fs/some_file
+  git add fs/some_file
+  git commit --quiet --signoff \
+    --message 'fs: some_file: Fill file' \
+    --message 'First'
+
+  # Regular change
+  touch fs/new_driver
+  git add fs/new_driver
+  git commit --quiet --signoff \
+    --message 'fs: new_driver: Add new driver' \
+    --message 'Second'
+
+  # Bug fix
+  printf 'Correct text' > fs/some_file
+  git add fs/some_file
+  git commit --quiet --signoff \
+    --message 'fs: some_file: Fix bug' \
+    --message 'Third'
+}
+
+function tearDown()
+{
+  cd "$ORIGINAL_DIR" || {
+    fail "(${LINENO}) It was not possible to go back to original directory"
+    return
+  }
+  if is_safe_path_to_remove "$SHUNIT_TMPDIR"; then
+    rm --recursive --force "$SHUNIT_TMPDIR"
+    mkdir --parents "$SHUNIT_TMPDIR"
+  else
+    fail "(${LINENO}) It was not possible to safely remove temporary directory"
+    return
+  fi
+}
+
+function test_signature_patch_single_option()
+{
+  local head2_msg
+
+  signature_main --add-signed-off-by='Jane Doe <janedoe@mail.xyz>' patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_signed_off.patch'
+  git restore patch_model.patch
+
+  signature_main -s'Jane Doe <janedoe@mail.xyz>' patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_signed_off.patch'
+  git restore patch_model.patch
+
+  signature_main --add-reviewed-by='Jane Doe <janedoe@mail.xyz>' patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_reviewed.patch'
+  git restore patch_model.patch
+
+  signature_main -r'Jane Doe <janedoe@mail.xyz>' patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_reviewed.patch'
+  git restore patch_model.patch
+
+  signature_main --add-acked-by='Michael Doe <michaeldoe@kwkw.xyz>' patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_acked.patch'
+  git restore patch_model.patch
+
+  signature_main -a'Michael Doe <michaeldoe@kwkw.xyz>' patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_acked.patch'
+  git restore patch_model.patch
+
+  signature_main --add-tested-by='Bob Brown <bob.brown@mail.xyz>' patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_tested.patch'
+  git restore patch_model.patch
+
+  signature_main -t'Bob Brown <bob.brown@mail.xyz>' patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_tested.patch'
+  git restore patch_model.patch
+
+  signature_main --add-co-developed-by='Bob Brown <bob.brown@mail.xyz>' patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_co_developed.patch'
+  git restore patch_model.patch
+
+  signature_main -C'Bob Brown <bob.brown@mail.xyz>' patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_co_developed.patch'
+  git restore patch_model.patch
+
+  signature_main --add-reported-by='Bob Brown <bob.brown@mail.xyz>' patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_reported.patch'
+  git restore patch_model.patch
+
+  signature_main -R'Bob Brown <bob.brown@mail.xyz>' patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_reported.patch'
+  git restore patch_model.patch
+
+  head2_msg="$(git rev-parse --short=12 HEAD~2) (\"fs: some_file: Fill file\")"
+
+  signature_main --add-fixes='HEAD~2' patch_model.patch
+  sed --in-place "s/<hash>/${head2_msg}/g" patch_model_fixes.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_fixes.patch'
+  git restore patch_model.patch patch_model_fixes.patch
+
+  signature_main -f'HEAD~2' patch_model.patch
+  sed --in-place "s/<hash>/${head2_msg}/g" patch_model_fixes.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_fixes.patch'
+  git restore patch_model.patch patch_model_fixes.patch
+}
+
+function test_signature_patch_single_option_default()
+{
+  git config user.name 'Jane Doe'
+  git config user.email 'janedoe@mail.xyz'
+
+  signature_main -s patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_signed_off.patch'
+  git restore patch_model.patch
+
+  signature_main -r patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_reviewed.patch'
+  git restore patch_model.patch
+
+  git config user.name 'Michael Doe'
+  git config user.email 'michaeldoe@kwkw.xyz'
+
+  signature_main -a patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_acked.patch'
+  git restore patch_model.patch
+
+  git config user.name 'Bob Brown'
+  git config user.email 'bob.brown@mail.xyz'
+
+  signature_main -t patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_tested.patch'
+  git restore patch_model.patch
+
+  signature_main -C patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_co_developed.patch'
+  git restore patch_model.patch
+
+  signature_main -R patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_reported.patch'
+  git restore patch_model.patch
+}
+
+function test_signature_patch_multi_options()
+{
+  local head2_msg
+
+  signature_main -r'Jane Doe <janedoe@mail.xyz>' patch_model.patch
+  signature_main -s'Jane Doe <janedoe@mail.xyz>' patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_full_review.patch'
+  git restore patch_model.patch
+
+  signature_main -r'Jane Doe <janedoe@mail.xyz>' -s'Jane Doe <janedoe@mail.xyz>' patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_full_review.patch'
+  git restore patch_model.patch
+
+  head2_msg="$(git rev-parse --short=12 HEAD~2) (\"fs: some_file: Fill file\")"
+  sed --in-place "s/<hash>/${head2_msg}/g" patch_model_complete.patch
+
+  signature_main --add-acked-by='Michael Doe <michaeldoe@kwkw.xyz>' patch_model.patch
+  signature_main --add-reviewed-by='John Doe <johndoe@kwkw.xyz>' patch_model.patch
+  signature_main --add-fixes='HEAD~2' patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_complete.patch'
+  git restore patch_model.patch
+
+  signature_main -r'John Doe <johndoe@kwkw.xyz>' -a'Michael Doe <michaeldoe@kwkw.xyz>' -f'HEAD~2' patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_complete.patch'
+  git restore patch_model.patch
+
+  git config user.name 'Jane Doe'
+  git config user.email 'janedoe@mail.xyz'
+
+  signature_main -r -s patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_full_review.patch'
+  git restore patch_model.patch
+
+  signature_main -s -r patch_model.patch
+  assertFileEquals 'patch_model.patch' 'patch_model_full_review.patch'
+  git restore patch_model.patch
+}
+
+function test_signature_patch_repetition_avoidance()
+{
+  local output_msg
+
+  output_msg="$(signature_main -s'Jane Doe <janedoe@mail.xyz>' -s'Jane Doe <janedoe@mail.xyz>' patch_model.patch)"
+  assertFileEquals 'patch_model.patch' 'patch_model_signed_off.patch'
+  assertEquals "(${LINENO})" "Skipping duplicated trailer line: 'Signed-off-by: Jane Doe <janedoe@mail.xyz>'" "$output_msg"
+  git restore patch_model.patch
+
+  output_msg="$(signature_main -r'Jane Doe <janedoe@mail.xyz>' -r'Jane Doe <janedoe@mail.xyz>' patch_model.patch)"
+  assertFileEquals 'patch_model.patch' 'patch_model_reviewed.patch'
+  assertEquals "(${LINENO})" "Skipping duplicated trailer line: 'Reviewed-by: Jane Doe <janedoe@mail.xyz>'" "$output_msg"
+  git restore patch_model.patch
+
+  output_msg="$(signature_main -r'Jane Doe <janedoe@mail.xyz>' -s'Jane Doe <janedoe@mail.xyz>' -r'Jane Doe <janedoe@mail.xyz>' patch_model.patch)"
+  assertFileEquals 'patch_model.patch' 'patch_model_full_review.patch'
+  assertEquals "(${LINENO})" "Skipping duplicated trailer line: 'Reviewed-by: Jane Doe <janedoe@mail.xyz>'" "$output_msg"
+  git restore patch_model.patch
+
+  output_msg="$(signature_main -r'Jane Doe <janedoe@mail.xyz>' -s'Jane Doe <janedoe@mail.xyz>' -s'Jane Doe <janedoe@mail.xyz>' patch_model.patch)"
+  assertFileEquals 'patch_model.patch' 'patch_model_full_review.patch'
+  assertEquals "(${LINENO})" "Skipping duplicated trailer line: 'Signed-off-by: Jane Doe <janedoe@mail.xyz>'" "$output_msg"
+  git restore patch_model.patch
+
+  output_msg="$(signature_main -a'Michael Doe <michaeldoe@kwkw.xyz>' -a'Michael Doe <michaeldoe@kwkw.xyz>' patch_model.patch)"
+  assertFileEquals 'patch_model.patch' 'patch_model_acked.patch'
+  assertEquals "(${LINENO})" "Skipping duplicated trailer line: 'Acked-by: Michael Doe <michaeldoe@kwkw.xyz>'" "$output_msg"
+  git restore patch_model.patch
+
+  output_msg="$(signature_main -t'Bob Brown <bob.brown@mail.xyz>' -t'Bob Brown <bob.brown@mail.xyz>' patch_model.patch)"
+  assertFileEquals 'patch_model.patch' 'patch_model_tested.patch'
+  assertEquals "(${LINENO})" "Skipping duplicated trailer line: 'Tested-by: Bob Brown <bob.brown@mail.xyz>'" "$output_msg"
+  git restore patch_model.patch
+
+  output_msg="$(signature_main -C'Bob Brown <bob.brown@mail.xyz>' -s'Bob Brown <bob.brown@mail.xyz>' patch_model.patch)"
+  assertFileEquals 'patch_model.patch' 'patch_model_co_developed.patch'
+  assertEquals "(${LINENO})" "Skipping duplicated trailer line: 'Signed-off-by: Bob Brown <bob.brown@mail.xyz>'" "$output_msg"
+  git restore patch_model.patch
+
+  output_msg="$(signature_main -s'Bob Brown <bob.brown@mail.xyz>' -C'Bob Brown <bob.brown@mail.xyz>' patch_model.patch)"
+  assertFileEquals 'patch_model.patch' 'patch_model_co_developed.patch'
+  assertEquals "(${LINENO})" "Skipping duplicated trailer line: 'Signed-off-by: Bob Brown <bob.brown@mail.xyz>'" "$output_msg"
+  git restore patch_model.patch
+
+  output_msg="$(signature_main -R'Bob Brown <bob.brown@mail.xyz>' -R'Bob Brown <bob.brown@mail.xyz>' patch_model.patch)"
+  assertFileEquals 'patch_model.patch' 'patch_model_reported.patch'
+  assertEquals "(${LINENO})" "Skipping duplicated trailer line: 'Reported-by: Bob Brown <bob.brown@mail.xyz>'" "$output_msg"
+  git restore patch_model.patch
+
+}
+
+function test_signature_patch_repetition_avoidance_default()
+{
+  local output_msg
+  local head2_msg
+
+  head2_msg="$(git rev-parse --short=12 HEAD~2) (\"fs: some_file: Fill file\")"
+  sed --in-place "s/<hash>/${head2_msg}/g" patch_model_complete.patch
+
+  git config --local user.name 'John Doe'
+  git config --local user.email 'johndoe@kwkw.xyz'
+
+  output_msg="$(signature_main -r -a'Michael Doe <michaeldoe@kwkw.xyz>' -r -f'HEAD~2' patch_model.patch)"
+  assertFileEquals 'patch_model.patch' 'patch_model_complete.patch'
+  assertEquals "(${LINENO})" "Skipping duplicated trailer line: 'Reviewed-by: John Doe <johndoe@kwkw.xyz>'" "$output_msg"
+  git restore patch_model.patch
+
+  output_msg="$(signature_main -r -a'Michael Doe <michaeldoe@kwkw.xyz>' -a'Michael Doe <michaeldoe@kwkw.xyz>' -f'HEAD~2' patch_model.patch)"
+  assertFileEquals 'patch_model.patch' 'patch_model_complete.patch'
+  assertEquals "(${LINENO})" "Skipping duplicated trailer line: 'Acked-by: Michael Doe <michaeldoe@kwkw.xyz>'" "$output_msg"
+  git restore patch_model.patch
+}
+
+function test_signature_commit_single_option()
+{
+  local original_commit
+  local current_log
+  local correct_fixed_value
+
+  # Save SHA from current commit allowing tests to reset the repository
+  original_commit="$(git rev-parse HEAD)"
+
+  signature_main -s'Jane Doe <janedoe@mail.xyz>'
+  current_log="$(git log --max-count 2 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_SIGNED_HEAD" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -s'Jane Doe <janedoe@mail.xyz>' 'HEAD~3'
+  current_log="$(git log --max-count 4 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_SIGNED_LOG" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -r'Jane Doe <janedoe@mail.xyz>'
+  current_log="$(git log --max-count 2 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_REVIEWED_HEAD" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -r'Jane Doe <janedoe@mail.xyz>' 'HEAD~3'
+  current_log="$(git log --max-count 4 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_REVIEWED_LOG" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -a'Michael Doe <michaeldoe@kwkw.xyz>'
+  current_log="$(git log --max-count 2 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_ACKED_HEAD" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -a'Michael Doe <michaeldoe@kwkw.xyz>' 'HEAD~3'
+  current_log="$(git log --max-count 4 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_ACKED_LOG" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -t'Bob Brown <bob.brown@mail.xyz>'
+  current_log="$(git log --max-count 2 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_TESTED_HEAD" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -t'Bob Brown <bob.brown@mail.xyz>' 'HEAD~3'
+  current_log="$(git log --max-count 4 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_TESTED_LOG" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -C'Bob Brown <bob.brown@mail.xyz>'
+  current_log="$(git log --max-count 2 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_CO_DEVELOPED_HEAD" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -C'Bob Brown <bob.brown@mail.xyz>' 'HEAD~3'
+  current_log="$(git log --max-count 4 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_CO_DEVELOPED_LOG" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -R'Bob Brown <bob.brown@mail.xyz>'
+  current_log="$(git log --max-count 2 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_REPORTED_HEAD" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -R'Bob Brown <bob.brown@mail.xyz>' 'HEAD~3'
+  current_log="$(git log --max-count 4 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_REPORTED_LOG" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -f'HEAD~2'
+  current_log="$(git log --max-count 2 --format="%(trailers)")"
+  correct_fixed_value="$(git rev-parse --short=12 HEAD~2) (\"fs: some_file: Fill file\")"
+  assertEquals "(${LINENO})" "${CORRECT_FIXES_HEAD//<hash>/$correct_fixed_value}" "$current_log"
+  git reset --quiet --hard "$original_commit"
+}
+
+function test_signature_commit_single_option_default()
+{
+  local original_commit
+  local current_log
+
+  # Save SHA from current commit allowing tests to reset the repository
+  original_commit="$(git rev-parse HEAD)"
+
+  git config user.name 'Jane Doe'
+  git config user.email 'janedoe@mail.xyz'
+
+  signature_main -s HEAD~3
+  current_log="$(git log --max-count 4 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_SIGNED_LOG" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -r HEAD~3
+  current_log="$(git log --max-count 4 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_REVIEWED_LOG" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  git config user.name 'Michael Doe'
+  git config user.email 'michaeldoe@kwkw.xyz'
+
+  signature_main -a HEAD~3
+  current_log="$(git log --max-count 4 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_ACKED_LOG" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  git config user.name 'Bob Brown'
+  git config user.email 'bob.brown@mail.xyz'
+
+  signature_main -t HEAD~3
+  current_log="$(git log --max-count 4 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_TESTED_LOG" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -C HEAD~3
+  current_log="$(git log --max-count 4 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_CO_DEVELOPED_LOG" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -R HEAD~3
+  current_log="$(git log --max-count 4 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_REPORTED_LOG" "$current_log"
+  git reset --quiet --hard "$original_commit"
+}
+
+function test_signature_commit_multi_options()
+{
+  local original_commit
+  local current_log
+  local correct_fixed_value
+
+  # Save SHA from current commit allowing tests to reset the repository
+  original_commit="$(git rev-parse HEAD)"
+
+  signature_main -r'Jane Doe <janedoe@mail.xyz>' -s'Jane Doe <janedoe@mail.xyz>'
+  current_log="$(git log --max-count 2 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_FULL_REVIEW_HEAD" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -r'Jane Doe <janedoe@mail.xyz>' -s'Jane Doe <janedoe@mail.xyz>' HEAD~3
+  current_log="$(git log --max-count 4 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_FULL_REVIEW_LOG" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -a'Michael Doe <michaeldoe@kwkw.xyz>' -r'John Doe <johndoe@kwkw.xyz>' HEAD~3
+  signature_main -f'HEAD~2'
+  current_log="$(git log --max-count 4 --format="%(trailers)")"
+  correct_fixed_value="$(git rev-parse --short=12 HEAD~2) (\"fs: some_file: Fill file\")"
+  assertEquals "(${LINENO})" "${CORRECT_MULTI_CALL_LOG_1//<hash>/$correct_fixed_value}" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -R'Michael Doe <michaeldoe@mail.xyz>;Closes=http://link-to-bug.xyz.com' \
+    -C'Michael Doe <michaeldoe@mail.xyz>' \
+    -C'John Doe <johndoe@mail.xyz>' \
+    -t'Jane Doe <janedoe@mail.xyz>' \
+    -r'Jane Doe <janedoe@mail.xyz>' \
+    -s'Jane Doe <janedoe@mail.xyz>' HEAD~3
+  current_log="$(git log --max-count 4 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_MULTI_CALL_LOG_2" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -s'Jane Doe <janedoe@mail.xyz>' \
+    -t'Jane Doe <janedoe@mail.xyz>' \
+    -R'Michael Doe <michaeldoe@mail.xyz>;Closes=http://link-to-bug.xyz.com' \
+    -C'John Doe <johndoe@mail.xyz>' \
+    -C'Michael Doe <michaeldoe@mail.xyz>' \
+    -r'Jane Doe <janedoe@mail.xyz>' HEAD~3
+  current_log="$(git log --max-count 4 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_MULTI_CALL_LOG_2" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  signature_main -C'Michael Doe <michaeldoe@mail.xyz>' \
+    -s'Jane Doe <janedoe@mail.xyz>' \
+    -t'Jane Doe <janedoe@mail.xyz>' \
+    -r'Jane Doe <janedoe@mail.xyz>' \
+    -R'Michael Doe <michaeldoe@mail.xyz>;Closes=http://link-to-bug.xyz.com' \
+    -C'John Doe <johndoe@mail.xyz>' HEAD~3
+  current_log="$(git log --max-count 4 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_MULTI_CALL_LOG_2" "$current_log"
+  git reset --quiet --hard "$original_commit"
+
+  git config user.name 'Jane Doe'
+  git config user.email 'janedoe@mail.xyz'
+
+  signature_main -r -s HEAD~3
+  current_log="$(git log --max-count 4 --format="%(trailers)")"
+  assertEquals "(${LINENO})" "$CORRECT_FULL_REVIEW_LOG" "$current_log"
+  git reset --quiet --hard "$original_commit"
+}
+
+# Simulating non-configured user.name and user.email by setting local empty values.
+# This has to be tested this way because we CAN NOT unset git config using:
+# 'git config --global --unset ( user.name | user.email )'
+# Since this would affect user's global git configuration outside tests.
+function test_signature_no_user_or_email_config()
+{
+  local output_msg
+  local return_status
+
+  git config user.name ''
+  git config user.email ''
+
+  output_msg="$(signature_main --add-signed-off-by)"
+  return_status="$?"
+  assertEquals "(${LINENO})" 22 "$return_status"
+  assertEquals "(${LINENO})" \
+    "You must configure your user.name and user.email with git to use --add-signed-off-by | -s without an argument" \
+    "$output_msg"
+
+  output_msg="$(signature_main --add-reviewed-by)"
+  return_status="$?"
+  assertEquals "(${LINENO})" 22 "$return_status"
+  assertEquals "(${LINENO})" \
+    "You must configure your user.name and user.email with git to use --add-reviewed-by | -r without an argument" \
+    "$output_msg"
+
+  output_msg="$(signature_main --add-acked-by)"
+  return_status="$?"
+  assertEquals "(${LINENO})" 22 "$return_status"
+  assertEquals "(${LINENO})" \
+    "You must configure your user.name and user.email with git to use --add-acked-by | -a without an argument" \
+    "$output_msg"
+
+  output_msg="$(signature_main --add-tested-by)"
+  return_status="$?"
+  assertEquals "(${LINENO})" 22 "$return_status"
+  assertEquals "(${LINENO})" \
+    "You must configure your user.name and user.email with git to use --add-tested-by | -t without an argument" \
+    "$output_msg"
+
+  output_msg="$(signature_main --add-co-developed-by)"
+  return_status="$?"
+  assertEquals "(${LINENO})" 22 "$return_status"
+  assertEquals "(${LINENO})" \
+    "You must configure your user.name and user.email with git to use --add-co-developed-by | -C without an argument" \
+    "$output_msg"
+
+  output_msg="$(signature_main --add-reported-by)"
+  return_status="$?"
+  assertEquals "(${LINENO})" 22 "$return_status"
+  assertEquals "(${LINENO})" \
+    "You must configure your user.name and user.email with git to use --add-reported-by | -R without an argument" \
+    "$output_msg"
+}
+
+function test_signature_invalid_signature_format()
+{
+  local output_msg
+  local return_status
+  local expected_msg
+
+  output_msg="$(signature_main --add-signed-off-by='Jane Doe <@mail.com>')"
+  return_status="$?"
+  expected_msg="$(printf 'Invalid email: @mail.com\nInvalid signature format: Jane Doe <@mail.com>')"
+  assertEquals "(${LINENO})" 22 "$return_status"
+  assertEquals "(${LINENO})" "$expected_msg" "$output_msg"
+
+  output_msg="$(signature_main --add-reviewed-by='<janedoe@mail.com>')"
+  return_status="$?"
+  assertEquals "(${LINENO})" 22 "$return_status"
+  assertEquals "(${LINENO})" 'Invalid signature format: <janedoe@mail.com>' "$output_msg"
+
+  output_msg="$(signature_main --add-acked-by='Jane Doe')"
+  return_status="$?"
+  assertEquals "(${LINENO})" 22 "$return_status"
+  assertEquals "(${LINENO})" 'Invalid signature format: Jane Doe' "$output_msg"
+
+  output_msg="$(signature_main --add-tested-by='Jane Doe janedoe@mail.com')"
+  return_status="$?"
+  assertEquals "(${LINENO})" 22 "$return_status"
+  assertEquals "(${LINENO})" 'Invalid signature format: Jane Doe janedoe@mail.com' "$output_msg"
+
+  output_msg="$(signature_main --add-co-developed-by='Jane Doe <janedoe@mailcom>')"
+  return_status="$?"
+  expected_msg="$(printf 'Invalid email: janedoe@mailcom\nInvalid signature format: Jane Doe <janedoe@mailcom>')"
+  assertEquals "(${LINENO})" 22 "$return_status"
+  assertEquals "(${LINENO})" "$expected_msg" "$output_msg"
+}
+
+function test_signature_invalid_commit_reference()
+{
+  local output_msg
+  local return_status
+
+  output_msg="$(signature_main --add-fixes)"
+  return_status="$?"
+  assertEquals "(${LINENO})" 22 "$return_status"
+  assertEquals "(${LINENO})" 'The option --add-fixes | -f demands an argument' "$output_msg"
+
+  output_msg="$(signature_main --add-fixes='8ac76z12wac3')"
+  return_status="$?"
+  assertEquals "(${LINENO})" 22 "$return_status"
+  assertEquals "(${LINENO})" 'Invalid commit reference with --add-fixes | -f: 8ac76z12wac3' "$output_msg"
+
+  output_msg="$(signature_main --add-fixes='HEAD~9999')"
+  return_status="$?"
+  assertEquals "(${LINENO})" 22 "$return_status"
+  assertEquals "(${LINENO})" 'Invalid commit reference with --add-fixes | -f: HEAD~9999' "$output_msg"
+}
+
+invoke_shunit


### PR DESCRIPTION
### Purpose
Often a kernel developer has to perform some operations over commit or patch trailer lines. Adding tags such as 'Reviewed-by' or 'Acked-by' is a common task and sometimes it might be required to do this over multiple commits or patches. Also another common one is the 'Fixes' tag, that must follow a specific format.

This feature helps on these cases. It uses 'git rebase', 'git commit --amend' and 'git interpret-trailers' as its backend in order to make these tasks quicker to complete.

### Inspiration
Both #1049 and #1051 represent similar issues, regarding trailer line manipulation of commits and patches. The idea is to deliver a new feature that can make such tasks easier and quicker to deal with.

### Some known limitations
There is no way to "revert" any change made by this command through kw. For example, if the commit log changes, there is no command to undo the previous operation. User will have to manually use `git reset --hard` if changes are not what they expected.

This feature currently does not provide ways to configure conditional actions, which is possible via `git config` as shown by Melissa here: #1049 