### PR TITLE
src: pomodoro: Add watch flag to pomodoro

### DIFF
--- a/src/_kw
+++ b/src/_kw
@@ -432,6 +432,7 @@ _kw_pomodoro()
     '(-t --set-timer -c --check-timer -s --show-tags)'{-t,--set-timer}'[set the timer for the Pomodoro timebox]: : ' \
     '(-c --check-timer -t --set-timer -s --show-tags)'{-c,--check-timer}'[shows information of each active Pomodoro timebox]' \
     '(-s --show-tags -c --check-timer -t --set-timer)'{-s,--show-tags}'[shows registered tags]' \
+    '(-w --watch)'{-w,--watch}'[lock the terminal and display the current Pomodoro every second]' \
     $set_timer_options \
     $tag_options
 }

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -56,7 +56,7 @@ function _kw_autocomplete()
   kw_options['explore']='--log --grep --all --only-header --only-source --exactly --show-context --verbose'
   kw_options['e']="${kw_options['explore']}"
 
-  kw_options['pomodoro']='--set-timer --check-timer --show-tags --tag --description --help --verbose'
+  kw_options['pomodoro']='--set-timer --check-timer --show-tags --tag --description --help --watch --verbose'
   kw_options['p']="${kw_options['pomodoro']}"
 
   kw_options['report']='--day --week --month --year --output --statistics --pomodoro --all --verbose'


### PR DESCRIPTION
This pull request addresses the enhancement request detailed in issue [#1115](https://github.com/kworkflow/kworkflow/issues/1115) 

The kw pomodoro functionality has been improved by adding a new --watch option, allowing users to monitor their active pomodoro sessions in real-time.

**Implementation Details**
The kw pomodoro command now accepts a --watch flag.
When --watch is enabled, the command enters a loop, refreshing the display every second to show the current status of the active pomodoro session.
This continuous update mechanism allows users to monitor their pomodoro sessions without manual intervention.

**Benefits**
Improved User Experience: Users can now easily track their pomodoro sessions without re-running commands.
Real-Time Monitoring: Provides a live view of the session progress, enhancing productivity and focus.

**Code Changes**
Updated the kw pomodoro command to include the --watch option.
Implemented a loop that refreshes the session status every second when --watch is enabled.

**Example Usage**
To use the new feature, after setting a timer, run:

`kw pomodoro --watch`

This will display the active pomodoro session and update the status every second in the terminal.

Please review the changes and provide any feedback. Thank you for considering this enhancement to the kw pomodoro functionality.