### PR TITLE
run_tests: dedicate a container per test file for integration tests

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,9 +6,10 @@ include './tests/integration/utils.sh'
 include './src/lib/kwio.sh'
 
 declare -a TESTS
-declare TESTS_DIR
+declare TESTS_DIR='./tests'
 declare TESTS_UNIT=1
 declare TESTS_INTEGRATION=1
+declare VERBOSE=0
 
 function show_help()
 {
@@ -21,6 +22,8 @@ function show_help()
     '         Limit tests to integration tests' \
     '  -u, --unit' \
     '         Limit tests to unit tests' \
+    '  -v, --verbose' \
+    '         Increase verbosity of the output' \
     '' \
     'COMMANDS' \
     '  clear-cache - clears tests cache' \
@@ -76,25 +79,13 @@ function run_tests()
   local -i fail=0
   local test_failure_list=''
   local test_dir
-  local integration_tests_setup=0 # have we setup the environment for integration tests?
   local current_test
   local target
 
   for target in "${TESTS[@]}"; do
     if [[ -f "$target" ]]; then
 
-      # if we are running integration tests, we will set up the environment for
-      # them here. That is because all integration tests share the same setup:
-      # at least the container environment must be up. It is much more efficient
-      # to run the setup just once for all tests than to run it for every test.
-      # This approach also avoids code duplication in the files.
       test_dir=$(dirname "${target}")
-      if [[ "$test_dir" =~ '/integration' && "$integration_tests_setup" == 0 ]]; then
-        integration_tests_setup=1
-        say 'Preparing environment for integration tests...'
-        setup_container_environment
-        printf '\n'
-      fi
 
       # Format the test name to be displayed in the output.
       current_test="$(basename "$test_dir")/$(basename "$target" | sed 's/.sh//')"
@@ -122,14 +113,11 @@ function run_tests()
     fi
   done
 
-  # instead of tearing down the container environment after each integration test,
-  # we will tear it down only after all tests have ran. This optimizes significant
-  # amount of time for the integration tests.
-  if [[ "${integration_tests_setup}" == 1 ]]; then
-    printf '\n' # add new line after the last "OK"
+  if [[ "$test_dir" =~ '/integration' && "$VERBOSE" -eq 1 ]]; then
+    say '' # add new line after the last "OK"
     say 'Tearing down containers used in integration tests...'
     teardown_containers
-    printf '\n'
+    say ''
   fi
 
   report_results "$total" "$success" "$notfound" "$fail" "$test_failure_list"
@@ -206,22 +194,32 @@ function run_user_provided_tests()
   LANGUAGE=en_US.UTF_8 run_tests
 }
 
-# parse flag
-case "$1" in
-  --unit | -u)
-    TESTS_DIR='./tests/unit'
-    TESTS_INTEGRATION=0
-    shift
-    ;;
-  --integration | -i)
-    TESTS_DIR='./tests/integration'
-    TESTS_UNIT=0
-    shift
-    ;;
-  *)
-    TESTS_DIR='./tests'
-    ;;
-esac
+# Parse flag
+while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
+  case $1 in
+    --unit | -u)
+      TESTS_DIR='./tests/unit'
+      TESTS_UNIT=0
+      shift
+      ;;
+    --integration | -i)
+      TESTS_DIR='./tests/integration'
+      TESTS_UNIT=0
+      shift
+      ;;
+    --verbose | -v)
+      VERBOSE=1
+      export VERBOSE
+      shift
+      ;;
+    *)
+      show_help
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$1" == '--' ]]; then shift; fi
 
 action=${1:-all}
 shift

--- a/tests/integration/config_test.sh
+++ b/tests/integration/config_test.sh
@@ -7,6 +7,11 @@ function oneTimeSetUp()
 {
   local distro
 
+  # The VERBOSE variable is set and exported in the run_tests.sh script based
+  # on the command-line options provided by the user. It controls the verbosity
+  # of the output during the test runs.
+  setup_container_environment "$VERBOSE" 'config'
+
   # copy config files to the containers
   for distro in "${DISTROS[@]}"; do
     container_copy "kw-${distro}" "${SAMPLES_DIR}/config" '/tmp/.kw'

--- a/tests/integration/device_test.sh
+++ b/tests/integration/device_test.sh
@@ -4,6 +4,14 @@ include './tests/unit/utils.sh'
 include './tests/integration/utils.sh'
 include './src/device_info.sh'
 
+function oneTimeSetUp()
+{
+  # The VERBOSE variable is set and exported in the run_tests.sh script based
+  # on the command-line options provided by the user. It controls the verbosity
+  # of the output during the test runs.
+  setup_container_environment "$VERBOSE" 'device'
+}
+
 # test if `kw device --local` in the container matches the host
 function device_info_test_helper()
 {

--- a/tests/integration/kw_version_test.sh
+++ b/tests/integration/kw_version_test.sh
@@ -4,6 +4,14 @@ include './src/lib/kwio.sh'
 include './tests/unit/utils.sh'
 include './tests/integration/utils.sh'
 
+function oneTimeSetUp()
+{
+  # The VERBOSE variable is set and exported in the run_tests.sh script based
+  # on the command-line options provided by the user. It controls the verbosity
+  # of the output during the test runs.
+  setup_container_environment "$VERBOSE" 'version'
+}
+
 # This function gets the commit hash and base version of the specified branch,
 # constructs the expected output.
 #

--- a/tests/integration/utils.sh
+++ b/tests/integration/utils.sh
@@ -43,6 +43,8 @@ function build_distro_image()
 # Build container images and create containers used accross the tests.
 function setup_container_environment()
 {
+  local verbose="$1"
+  local feature="$2"
   local working_directory # working directory in the container
   local container_name
   local container_img
@@ -50,6 +52,10 @@ function setup_container_environment()
   local total_steps
   local distros_ok # array of distros whose setup succeeded
   local distro
+
+  if [[ "$verbose" -eq 1 ]]; then
+    say "Preparing environment for kw ${feature} integration tests..."
+  fi
 
   distros_ok=()
   current_step=0
@@ -67,7 +73,10 @@ function setup_container_environment()
     image_exists "${container_img}"
     if [[ "$?" -ne 0 ]]; then
       current_step=$((current_step + 1))
-      say "[${current_step}/${total_steps}] Building container image for ${distro}. This might take a while..."
+
+      if [[ "$verbose" -eq 1 ]]; then
+        say "[${current_step}/${total_steps}] Building container image for ${distro}. This might take a while..."
+      fi
 
       build_distro_image "$distro"
       if [[ "$?" -ne 0 ]]; then
@@ -80,7 +89,10 @@ function setup_container_environment()
       fi
     else
       current_step=$((current_step + 1))
-      say "[${current_step}/${total_steps}] Using cached container image for ${distro}."
+
+      if [[ "$verbose" -eq 1 ]]; then
+        say "[${current_step}/${total_steps}] Using cached container image for ${distro}."
+      fi
     fi
 
     # If container exists, we tear it down and create a new one in order to
@@ -91,7 +103,10 @@ function setup_container_environment()
     fi
 
     current_step=$((current_step + 1))
-    say "[${current_step}/${total_steps}] Creating ${distro} container."
+
+    if [[ "$verbose" -eq 1 ]]; then
+      say "[${current_step}/${total_steps}] Creating ${distro} container."
+    fi
 
     # Podman containers are isolated environments designed to run a single
     # process. After the process ends, the container is destroyed. In order to

--- a/tests/integration/utils.sh
+++ b/tests/integration/utils.sh
@@ -167,8 +167,10 @@ function teardown_single_container()
   container_exists "${container}"
 
   if [[ "$?" -eq 0 ]]; then
-    # Destroy container sending SIGKILL instantly.
-    podman container rm --force --time 0 "${container}" > /dev/null 2>&1
+    # Stop the container with no wait time
+    podman stop --time 0 "$container" > /dev/null 2>&1
+    # Remove the container forcefully
+    podman container rm --force "$container" > /dev/null 2>&1
   fi
 }
 


### PR DESCRIPTION
This PR refactors the integration test setup to dedicate a separate
container for each test file. The `prepare_testing_environment` function
is introduced in individual test scripts to set up the environment
specifically for each test, ensuring isolated test environments.
