### PR TITLE
.github: workflows: integration_tests: refactor to remove redundant initialize-repository job

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -3,20 +3,7 @@ on:
   [push, pull_request]
 
 jobs:
-  initialize-repository:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
   integration-tests:
-    needs: initialize-repository
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Removed the initialize-repository job which was checking out the repository. Kept the checkout step in the integration-tests job to ensure the repository is checked out in a fresh environment. Streamlined the workflow for simplicity and efficiency.

Closes: #1075