### PR TITLE
    tests: integration: Add notification on image build

### DIFF
--- a/tests/integration/utils.sh
+++ b/tests/integration/utils.sh
@@ -29,14 +29,46 @@ DISTROS=(
 # The status code of the command ran to build the image.
 function build_distro_image()
 {
-  local distro="$1"
+  local verbose="$1"
+  local distro="$2"
   local file="${CONTAINER_DIR}/Containerfile_${distro}"
+  local id
+  local mb_size
+  local gb_size
+  local size
+  local size_unit
 
   image_build --file "$file" --tag "kw-${distro}"
 
   if [[ "$?" -ne 0 ]]; then
     fail "(${LINENO}): Error building the image for distribution ${distro}"
     return "$?"
+  fi
+
+  size_unit=$(podman image inspect --format '{{ .Size }}' "kw-${distro}")
+  id=$(podman image inspect --format '{{ .Id }}' "kw-${distro}")
+
+  # Converting size in bytes to the appropriate units
+  if [[ "$size_unit" -lt 1024 ]]; then
+    size="${size_unit} B"
+  elif [[ "$size_unit" -lt "$(bc <<< 1024^2)" ]]; then
+    size_unit=$(printf "scale=2; %s / %s\n" "${size_unit}" "1024" | bc)
+    size="${size_unit} KB"
+  elif [[ "$size_unit" -lt "$(bc <<< 1024^3)" ]]; then
+    mb_size=$(bc <<< 1024^2)
+    size_unit=$(printf "scale=2; %s / %s\n" "${size_unit}" "$mb_size" | bc)
+    size="${size_unit} MB"
+  else
+    gb_size=$(bc <<< 1024^3)
+    size_unit=$(printf "scale=2; %s / %s\n" "${size_unit}" "$gb_size" | bc)
+    size="${size_unit} GB"
+  fi
+
+  if [[ "$verbose" -eq 1 ]]; then
+    warning "- Cached container distro: ${distro}"
+    warning "- Image ID: ${id}"
+    warning "- Containerfile path: ${file}"
+    warning "- Size: ${size}"
   fi
 }
 
@@ -78,7 +110,7 @@ function setup_container_environment()
         say "[${current_step}/${total_steps}] Building container image for ${distro}. This might take a while..."
       fi
 
-      build_distro_image "$distro"
+      build_distro_image "$verbose" "$distro"
       if [[ "$?" -ne 0 ]]; then
         complain "Failed to setup container for distro ${distro}"
 
@@ -141,6 +173,12 @@ function setup_container_environment()
   # Update DISTRO so it only has distros whose setup succeed.
   # Thus, the integration tests can run even if some distros failed to set up.
   DISTROS=("${distros_ok[@]}")
+
+  if [[ "$verbose" -eq 1 && "$distro" == "fedora" ]]; then
+    warning ''
+    warning 'To clear all cache, run the command:'
+    warning '- ./run_tests.sh --integration clear-cache'
+  fi
 }
 
 # Destroy all containers used in the tests.


### PR DESCRIPTION
    When doing integration tests, container images are created without notifying
    the user about their size and other relevant information. This change notifies
    the user of the container's distribution, image ID, image repository and image
    size, and also suggests a command to clear all cache.

    Closes: #1014

    Signed-off-by: Bruno Rocha Levi brunolevilevi@usp.br
    Co-developed-by: Lucas Antonio Pataluch dos Santos lucasantonio.santos@usp.br