### PR TITLE
src: lib: remote: standarization of the function cmd_remotely

### DIFF
--- a/src/debug.sh
+++ b/src/debug.sh
@@ -208,7 +208,7 @@ function reset_debug()
         # TODO: We should check if the VM is up and running
       fi
 
-      cmd_remotely "$reset_cmd" "$flag" "$remote" "$port" "$user"
+      cmd_remotely "$flag" "$reset_cmd" "$remote" "$port" "$user"
       ;;
   esac
 }
@@ -275,7 +275,7 @@ function dmesg_debug()
         # TODO: We should check if the VM is up and running
       fi
 
-      cmd_remotely "$cmd" "$flag" '' '' '' '' "$save_following_log"
+      cmd_remotely "$flag" "$cmd" '' '' '' '' "$save_following_log"
       ;;
   esac
 }
@@ -387,13 +387,13 @@ function event_debug()
 
       if [[ -n "$list" ]]; then
         show_verbose "$flag" "$command"
-        list_output=$(cmd_remotely "$command" 'SILENT' "$remote" "$port" "$user")
+        list_output=$(cmd_remotely 'SILENT' "$command" "$remote" "$port" "$user")
         show_list "$list_output" "$event"
         ret="$?"
         return "$ret"
       fi
 
-      cmd_remotely "$command" "$flag" "$remote" "$port" "$user" '' "$save_following_log"
+      cmd_remotely "$flag" "$command" "$remote" "$port" "$user" '' "$save_following_log"
 
       # If we used --cmd, we need to retrieve the log
       if [[ -n "$user_cmd" ]]; then
@@ -442,7 +442,7 @@ function ftrace_list()
       fi
 
       show_verbose "$flag" "$cmd_list"
-      raw_data=$(cmd_remotely "$cmd_list" 'SILENT' "$remote" "$port" "$user")
+      raw_data=$(cmd_remotely 'SILENT' "$cmd_list" "$remote" "$port" "$user")
       ret="$?"
       ;;
   esac
@@ -531,7 +531,7 @@ function ftrace_debug()
         # TODO: We should check if the VM is up and running
       fi
 
-      cmd_remotely "$cmd_ftrace" "$flag" '' '' '' '' "$save_following_log"
+      cmd_remotely "$flag" "$cmd_ftrace" '' '' '' '' "$save_following_log"
       ret="$?"
 
       # If we used --cmd, we need to retrieve the log
@@ -900,7 +900,7 @@ function stop_debug()
         port="${remote_parameters['REMOTE_PORT']}"
         user="${remote_parameters['REMOTE_USER']}"
 
-        cmd_remotely "$stop_dmesg_cmd" "$flag" "$remote" "$port" "$user"
+        cmd_remotely "$flag" "$stop_dmesg_cmd" "$remote" "$port" "$user"
         ;;
     esac
   fi

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -352,7 +352,7 @@ function prepare_distro_for_deploy()
       local cmd="$REMOTE_INTERACE_CMD_PREFIX"
       cmd+=" --deploy-setup ${flag} ${target}"
 
-      cmd_remotely "$cmd" "$flag"
+      cmd_remotely "$flag" "$cmd"
       ;;
   esac
 }
@@ -389,7 +389,7 @@ function update_status_log()
       ;;
     3) # REMOTE_TARGET
       cmd="${metadata_string} >> ${kw_status_path}"
-      cmd_remotely "$cmd" "$flag"
+      cmd_remotely "$flag" "$cmd"
       ;;
   esac
 }
@@ -420,7 +420,7 @@ function check_setup_status()
       ret="$?"
       ;;
     3) # REMOTE_TARGET
-      cmd_remotely "$cmd" "$flag"
+      cmd_remotely "$flag" "$cmd"
       ret="$?"
       ;;
   esac
@@ -563,7 +563,7 @@ function prepare_remote_dir()
       '--archive' "$remote" "$port" "$user" 'quiet'
   else
     say '* Sending kw to the remote'
-    cmd_remotely "mkdir -p $REMOTE_KW_DEPLOY" "$flag"
+    cmd_remotely "$flag" "mkdir -p $REMOTE_KW_DEPLOY"
 
     if [[ -n ${remote_parameters['REMOTE_FILE']} && -n ${remote_parameters['REMOTE_FILE_HOST']} ]]; then
       cmd="scp -q -F ${remote_parameters['REMOTE_FILE']} $files_to_send ${remote_parameters['REMOTE_FILE_HOST']}:$REMOTE_KW_DEPLOY"
@@ -575,9 +575,9 @@ function prepare_remote_dir()
   fi
 
   # Removes temporary directory if already existent
-  cmd_remotely "rm --preserve-root=all --recursive --force -- ${KW_DEPLOY_TMP_FILE}" "$flag"
+  cmd_remotely "$flag" "rm --preserve-root=all --recursive --force -- ${KW_DEPLOY_TMP_FILE}"
   # Create temporary folder
-  cmd_remotely "mkdir -p $KW_DEPLOY_TMP_FILE" "$flag"
+  cmd_remotely "$flag" "mkdir -p $KW_DEPLOY_TMP_FILE"
 }
 
 # Create the temporary folder for local deploy.
@@ -663,7 +663,7 @@ function run_list_installed_kernels()
       local cmd="$REMOTE_INTERACE_CMD_PREFIX"
       cmd+=" --list-kernels $flag $single_line $all"
 
-      cmd_remotely "$cmd" "$flag"
+      cmd_remotely "$flag" "$cmd"
       ;;
   esac
 
@@ -707,7 +707,7 @@ function collect_target_info_for_deploy()
       local cmd="$REMOTE_INTERACE_CMD_PREFIX"
       cmd+=" --collect-info $flag $target"
 
-      data=$(cmd_remotely "$cmd" "$flag")
+      data=$(cmd_remotely "$flag" "$cmd")
       ;;
   esac
 
@@ -780,7 +780,7 @@ function run_kernel_uninstall()
       # line break with `\`; this may allow us to break a huge line like this.
       local cmd="$REMOTE_INTERACE_CMD_PREFIX"
       cmd+=" --uninstall-kernels '$reboot' 'remote' '$kernels_target_list' '$flag' '$force'"
-      cmd_remotely "$cmd" "$flag"
+      cmd_remotely "$flag" "$cmd"
       ;;
   esac
 }
@@ -853,7 +853,7 @@ function modules_install()
 
       # Execute script
       cmd="$REMOTE_INTERACE_CMD_PREFIX --modules ${release}.kw.tar"
-      cmd_remotely "$cmd" "$flag"
+      cmd_remotely "$flag" "$cmd"
       ;;
   esac
 }
@@ -1338,7 +1338,7 @@ function run_kernel_install()
       cmd="$REMOTE_INTERACE_CMD_PREFIX"
       cmd+=" --kernel-update $cmd_parameters"
 
-      cmd_remotely "$cmd" "$flag" "$remote" "$port"
+      cmd_remotely "$flag" "$cmd" "$remote" "$port"
       human_install_kernel_message "$?"
       return "$?"
       ;;

--- a/src/device_info.sh
+++ b/src/device_info.sh
@@ -88,7 +88,7 @@ function get_ram()
       ;;
     3) # REMOTE_TARGET
       show_verbose "$flag" "$cmd"
-      ram=$(cmd_remotely "$cmd" 'SILENT')
+      ram=$(cmd_remotely 'SILENT' "$cmd")
       ;;
   esac
 
@@ -131,10 +131,10 @@ function get_cpu()
       ;;
     3) # REMOTE_TARGET
       show_verbose "$flag" "$cmd_model"
-      cpu_model=$(cmd_remotely "$cmd_model" 'SILENT')
+      cpu_model=$(cmd_remotely 'SILENT' "$cmd_model")
 
       show_verbose "$flag" "$cmd_frequency"
-      cpu_frequency=$(cmd_remotely "$cmd_frequency" 'SILENT')
+      cpu_frequency=$(cmd_remotely 'SILENT' "$cmd_frequency")
       ;;
   esac
 
@@ -193,7 +193,7 @@ function get_disk()
       ;;
     3) # REMOTE_TARGET
       show_verbose "$flag" "$cmd"
-      info=$(cmd_remotely "$cmd" 'SILENT')
+      info=$(cmd_remotely 'SILENT' "$cmd")
       ;;
   esac
 
@@ -254,7 +254,7 @@ function get_os()
       root_path='/'
       cmd="cat $(join_path "$root_path" "$os_release_path")"
       show_verbose "$flag" "$cmd"
-      raw_os_release=$(cmd_remotely "$cmd" 'SILENT')
+      raw_os_release=$(cmd_remotely 'SILENT' "$cmd")
       ;;
   esac
 
@@ -313,7 +313,7 @@ function get_desktop_environment()
       ;;
     3) # REMOTE_TARGET
       show_verbose "$flag" "$cmd"
-      desktop_env=$(cmd_remotely "$cmd" 'SILENT')
+      desktop_env=$(cmd_remotely 'SILENT' "$cmd")
       ;;
   esac
 
@@ -379,11 +379,11 @@ function get_gpu()
       ;;
     3) # REMOTE_TARGET
       show_verbose "$flag" "$cmd_pci_address"
-      pci_addresses=$(cmd_remotely "$cmd_pci_address" 'SILENT')
+      pci_addresses=$(cmd_remotely 'SILENT' "$cmd_pci_address")
       for g in $pci_addresses; do
         cmd="lspci -v -s ${g}"
         show_verbose "$flag" "$cmd"
-        gpu_info=$(cmd_remotely "$cmd" 'SILENT')
+        gpu_info=$(cmd_remotely 'SILENT' "$cmd")
 
         cmd="printf '%s\n' '${gpu_info}' | sed --quiet --regexp-extended '/Subsystem/s/\s*.*:\s+(.*)/\1/p'"
         show_verbose "$flag" "$cmd"
@@ -444,20 +444,20 @@ function get_motherboard()
       ;;
     3) # REMOTE_TARGET
       show_verbose "$flag" "$cmd_name"
-      mb_name=$(cmd_remotely "$cmd_name" 'SILENT')
+      mb_name=$(cmd_remotely 'SILENT' "$cmd_name")
 
       show_verbose "$flag" "$cmd_vendor"
-      mb_vendor=$(cmd_remotely "$cmd_vendor" 'SILENT')
+      mb_vendor=$(cmd_remotely 'SILENT' "$cmd_vendor")
 
       # Fallback
       if [[ -z "$mb_name" ]]; then
         show_verbose "$flag" "$fallback_name_cmd"
-        mb_name=$(cmd_remotely "$fallback_name_cmd" 'SILENT')
+        mb_name=$(cmd_remotely 'SILENT' "$fallback_name_cmd")
       fi
 
       if [[ -z "$mb_vendor" ]]; then
         show_verbose "$flag" "$fallback_vendor_cmd"
-        mb_vendor=$(cmd_remotely "$fallback_vendor_cmd" 'SILENT')
+        mb_vendor=$(cmd_remotely 'SILENT' "$fallback_vendor_cmd")
       fi
       ;;
   esac
@@ -508,10 +508,10 @@ function get_chassis()
     3) # REMOTE_TARGET
       cmd="test -f ${dmi_file_path}"
       show_verbose "$flag" "$cmd"
-      cmd_remotely "$cmd" "$flag"
+      cmd_remotely "$flag" "$cmd"
       if [[ "$?" == 0 ]]; then
         show_verbose "$flag" "$dmi_cmd"
-        chassis_type=$(cmd_remotely "$dmi_cmd" 'SILENT')
+        chassis_type=$(cmd_remotely 'SILENT' "$dmi_cmd")
       fi
       ;;
   esac

--- a/src/kernel_config_manager.sh
+++ b/src/kernel_config_manager.sh
@@ -259,13 +259,13 @@ function get_config_from_proc()
       return 0
       ;;
     3) # REMOTE
-      cmd_remotely "[ -f ${PROC_CONFIG_PATH} ]" "$flag"
+      cmd_remotely "$flag" "[ -f ${PROC_CONFIG_PATH} ]"
       if [[ "$?" != 0 ]]; then
-        cmd_remotely "$CMD_LOAD_CONFIG_MODULE" "$flag"
+        cmd_remotely "$flag" "$CMD_LOAD_CONFIG_MODULE"
         [[ "$?" != 0 ]] && return 95 # Operation not supported
       fi
 
-      cmd_remotely "$CMD_GET_CONFIG" "$flag"
+      cmd_remotely "$flag" "$CMD_GET_CONFIG"
       [[ "$?" != 0 ]] && return 95 # Operation not supported
       remote2host "$flag" "/tmp/${output}" "$config_base_path"
       return 0
@@ -313,8 +313,8 @@ function get_config_from_boot()
       return 0
       ;;
     3) # REMOTE
-      kernel_release=$(cmd_remotely 'uname -r' "$flag")
-      cmd_remotely "[ -f ${root}boot/config-${kernel_release} ]" "$flag"
+      kernel_release=$(cmd_remotely "$flag" 'uname -r')
+      cmd_remotely "$flag" "[ -f ${root}boot/config-${kernel_release} ]"
       [[ "$?" != 0 ]] && return 95 # ENOTSUP
 
       remote2host "$flag" "${root}boot/config-${kernel_release}" "$config_base_path"
@@ -476,7 +476,7 @@ function fetch_config()
         mods=$(cmd_manager "$flag" 'lsmod')
         ;;
       3) # REMOTE
-        mods=$(cmd_remotely 'lsmod' "$flag")
+        mods=$(cmd_remotely "$flag" 'lsmod')
         ;;
     esac
 

--- a/src/lib/remote.sh
+++ b/src/lib/remote.sh
@@ -246,8 +246,8 @@ function ssh_connection_failure_message()
 # If no command is specified, we finish the execution and return 22
 function cmd_remotely()
 {
-  local command="$1"
-  local flag=${2:-'HIGHLIGHT_CMD'}
+  local flag=${1:-'HIGHLIGHT_CMD'}
+  local command="$2"
   local remote=${3:-${remote_parameters['REMOTE_IP']}}
   local port=${4:-${remote_parameters['REMOTE_PORT']}}
   local user=${5:-${remote_parameters['REMOTE_USER']}}
@@ -371,7 +371,7 @@ function which_distro()
   local output
 
   cmd='cat /etc/os-release'
-  output=$(cmd_remotely "$cmd" "$flag" "$remote" "$port" "$user")
+  output=$(cmd_remotely "$flag" "$cmd" "$remote" "$port" "$user")
   # TODO: I think we can find a better way to test this...
   if [[ "$flag" =~ 'TEST_MODE' ]]; then
     printf '%s' "$output"

--- a/src/plugins/subsystems/drm/drm.sh
+++ b/src/plugins/subsystems/drm/drm.sh
@@ -120,7 +120,7 @@ function module_control()
       remote=$(get_based_on_delimiter "$unformatted_remote" ':' 1)
       port=$(get_based_on_delimiter "$unformatted_remote" ':' 2)
 
-      cmd_remotely "$module_cmd" "$flag" "$remote" "$port"
+      cmd_remotely "$flag" "$module_cmd" "$remote" "$port"
       ;;
   esac
 }
@@ -234,8 +234,8 @@ function gui_control()
       cmd_manager "$flag" "$bind_control_cmd"
       ;;
     3) # REMOTE TARGET
-      cmd_remotely "$gui_control_cmd" "$flag" "$remote" "$port"
-      cmd_remotely "$bind_control_cmd" "$flag" "$remote" "$port" '' '1'
+      cmd_remotely "$flag" "$gui_control_cmd" "$remote" "$port"
+      cmd_remotely "$flag" "$bind_control_cmd" "$remote" "$port" '' '1'
       ;;
   esac
 }
@@ -277,7 +277,7 @@ function get_available_connectors()
       target_label='local'
       ;;
     3) # REMOTE TARGET
-      cards_raw_list=$(cmd_remotely "$find_conn_cmd" "$flag" | sort --dictionary-order)
+      cards_raw_list=$(cmd_remotely "$flag" "$find_conn_cmd" | sort --dictionary-order)
       target_label='remote'
       ;;
   esac
@@ -346,7 +346,7 @@ function get_supported_mode_per_connector()
       target_label='local'
       ;;
     3) # REMOTE TARGET
-      modes=$(cmd_remotely "$cmd" 'SILENT' '' '' '' '1')
+      modes=$(cmd_remotely 'SILENT' "$cmd" '' '' '' '1')
       target_label='remote'
       ;;
   esac

--- a/tests/unit/lib/remote_test.sh
+++ b/tests/unit/lib/remote_test.sh
@@ -328,7 +328,7 @@ function test_cmd_remote()
   remote_parameters['REMOTE_FILE_HOST']='origin'
 
   expected_command="ssh -F ${SHUNIT_TMPDIR}/remote.config origin sudo \"$command\""
-  output=$(cmd_remotely "$command" "$flag")
+  output=$(cmd_remotely "$flag" "$command")
   assertEquals "($LINENO): Command did not match" "$expected_command" "$output"
 
   configurations=()
@@ -340,23 +340,23 @@ function test_cmd_remote()
   remote_parameters['REMOTE_USER']='root'
 
   expected_command="ssh -p $port $user@$remote sudo \"$command\""
-  output=$(cmd_remotely "$command" "$flag" "$remote" "$port" "$user")
+  output=$(cmd_remotely "$flag" "$command" "$remote" "$port" "$user")
   assertEquals "($LINENO):" "$expected_command" "$output"
 
   expected_command="ssh -p $port $user@localhost sudo \"$command\""
-  output=$(cmd_remotely "$command" "$flag" '' "$port" "$user")
+  output=$(cmd_remotely "$flag" "$command" '' "$port" "$user")
   assertEquals "($LINENO):" "$expected_command" "$output"
 
   expected_command="ssh -p 22 $user@localhost sudo \"$command\""
-  output=$(cmd_remotely "$command" "$flag" '' '' "$user")
+  output=$(cmd_remotely "$flag" "$command" '' '' "$user")
   assertEquals "($LINENO):" "$expected_command" "$output"
 
   expected_command="ssh -p 22 root@localhost sudo \"$command\""
-  output=$(cmd_remotely "$command" "$flag")
+  output=$(cmd_remotely "$flag" "$command")
   assertEquals "($LINENO):" "$expected_command" "$output"
 
   expected_command="No command specified"
-  output=$(cmd_remotely '' "$flag")
+  output=$(cmd_remotely "$flag" '')
   assertEquals "($LINENO):" "$expected_command" "$output"
 }
 


### PR DESCRIPTION
The problem is the different standards in the functions cmd_remotely and cmd_manager.
In this sense, flipped the positions to fix the problem.
#952