### PR TITLE
Create options to kw codestyle to check by function or line interval

### DIFF
--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -85,7 +85,7 @@ function _kw_autocomplete()
 
   kw_options['clear-cache']='--verbose'
 
-  kw_options['codestyle']='--verbose --help'
+  kw_options['codestyle']='--verbose --help --start-line --end-line'
   kw_options['c']="${kw_options['codestyle']}"
 
   mapfile -t COMPREPLY < <(compgen -W "${kw_options[${previous_command}]} " -- "${current_command}")

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -85,7 +85,7 @@ function _kw_autocomplete()
 
   kw_options['clear-cache']='--verbose'
 
-  kw_options['codestyle']='--verbose --help --start-line --end-line'
+  kw_options['codestyle']='--verbose --help --start-line --end-line --function'
   kw_options['c']="${kw_options['codestyle']}"
 
   mapfile -t COMPREPLY < <(compgen -W "${kw_options[${previous_command}]} " -- "${current_command}")


### PR DESCRIPTION
Add options to  "kw c" to receive the name of a function using `--function` as a parameter to search for code-style issues in this function definition, or in a line interval defined by `--start-line` and `--end-line` options.

Closes: #162 