### PR TITLE
setup: install `kw` completions for nushell

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -596,19 +596,18 @@ function install_nucompletion()
     return
   fi
 
-  if [[ $(ask_yN "Nushell detected. Want to download completions for kw?") =~ '0' ]]; then
-    say "If you change your mind, download it manually download from https://github.com/nushell/nu_scripts/tree/main/custom-completions/kw"
+  if [[ $(ask_yN 'Nushell detected: Do you want to download completions for kw?') =~ '0' ]]; then
+    say 'If you change your mind, download it manually download from https://github.com/nushell/nu_scripts/tree/main/custom-completions/kw'
     return
   fi
 
-  curl --silent https://raw.githubusercontent.com/nushell/nu_scripts/main/custom-completions/kw/kw-completions.nu --output "${completions_file}"
-
+  curl --silent 'https://raw.githubusercontent.com/nushell/nu_scripts/main/custom-completions/kw/kw-completions.nu' --output "${completions_file}"
   if [[ "$?" != 0 ]]; then
     complain 'Failed to download nu completions for kw. Try manually downloading from https://github.com/nushell/nu_scripts/tree/main/custom-completions/kw'
     return
   fi
 
-  say "Nu completions downloaded successfully, add \`source ${completions_file}\` to your nushell config file (\$nu.config-file)"
+  say "Nu completions downloaded successfully, add \`source ${completions_file}\` to your nushell config file (\$nu.config-path)"
 }
 
 function append_bashcompletion()

--- a/setup.sh
+++ b/setup.sh
@@ -571,6 +571,11 @@ function synchronize_files()
     fi
   fi
 
+  if command_exists 'nu'; then
+    # Add tabcompletion to nu
+    install_nucompletion
+  fi
+
   say "$SEPARATOR"
   # Create ~/.cache/kw for support some of the operations
   mkdir -p "$cachedir"
@@ -581,6 +586,29 @@ function synchronize_files()
   fi
 
   say "$app_name installed into $HOME"
+}
+
+function install_nucompletion()
+{
+  local completions_file="${libdir}/kw-completions.nu"
+
+  if [[ -f "$completions_file" ]]; then
+    return
+  fi
+
+  if [[ $(ask_yN "Nushell detected. Want to download completions for kw?") =~ '0' ]]; then
+    say "If you change your mind, download it manually download from https://github.com/nushell/nu_scripts/tree/main/custom-completions/kw"
+    return
+  fi
+
+  curl --silent https://raw.githubusercontent.com/nushell/nu_scripts/main/custom-completions/kw/kw-completions.nu --output "${completions_file}"
+
+  if [[ "$?" != 0 ]]; then
+    complain 'Failed to download nu completions for kw. Try manually downloading from https://github.com/nushell/nu_scripts/tree/main/custom-completions/kw'
+    return
+  fi
+
+  say "Nu completions downloaded successfully, add \`source ${completions_file}\` to your nushell config file (\$nu.config-file)"
 }
 
 function append_bashcompletion()


### PR DESCRIPTION
This PR adds a `install_nucompletion` function that downloads the `kw-completions.nu` script from the official
[nu_scripts](https://github.com/nushell/nu_scripts) into the `${libdir}` folder.

The script is downloaded if, and only if, the `nu` executable is detected.


Co-developed-by: Lais Nuto <laisnuto@gmail.com>