### PR TITLE
[README] Suggest new contributors to look for new issues that aren't done

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ firefox build/index.html
 
 We are happy that you want to help us! If you are looking for a good starting
 point, check
-[those issues](https://github.com/kworkflow/kworkflow/labels/good%20first%20issue)
+[those issues](https://github.com/kworkflow/kworkflow/issues?q=is%3Aopen+label%3A%22good+first+issue%22+-label%3A%22done%3A+wait+for+stable%22)
 and don't forget to read our
 [Contribuitor's Guide](https://kworkflow.org/content/howtocontribute.html)
 (or [howtocontribute file](documentation/content/howtocontribute.rst)).


### PR DESCRIPTION
Currently the suggestion is to suggest new contributors to look for "good first issues", however some of those issues have potential stable branch candidates that are added to unstable branch as of now. Just modifying old Readme to point to [good first issues with no candidates](https://github.com/kworkflow/kworkflow/issues?q=is%3Aopen+label%3A%22good+first+issue%22+-label%3A%22done%3A+wait+for+stable%22).

Trivial, but something I came across right now. I love the labeling system by the way, and hope more projects use this! 