### PR TITLE
src: pomodoro: create pomodoro timer with no tag specified

### DIFF
--- a/src/pomodoro.sh
+++ b/src/pomodoro.sh
@@ -172,9 +172,10 @@ function timer_thread()
 
   flag=${flag:-'SILENT'}
 
-  if [[ -n "${options_values['TAG']}" ]]; then
-    register_data_for_report "$flag"
+  if [[ -z "${options_values['TAG']}" ]]; then
+    options_values['TAG']='NO_TAG'
   fi
+  register_data_for_report "$flag"
 
   cmd_manager "$flag" "sleep ${options_values['TIMER']}"
   alert_completion "Pomodoro: Your ${options_values['TIMER']} timebox ended" '--alert=vs'


### PR DESCRIPTION
This commit modifies the pomodoro.sh script to allow the registration of a Pomodoro timer without requiring a specified tag. If no tag is provided, the timer is now automatically registered with the default tag NO-TAG.

Solves: #1156

 Signed-off-by: gabrielsrd <gabrielalves@usp.br>