### PR TITLE
Add missing `g` to bash completion

### DIFF
--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -50,6 +50,7 @@ function _kw_autocomplete()
   kw_options['k']="${kw_options['kernel-config-manager']}"
 
   kw_options['config']='--local --global --show --help --verbose'
+  kw_options['g']="${kw_options['config']}"
 
   kw_options['remote']='--add --remove --rename --list --global --set-default --verbose'
 


### PR DESCRIPTION
The long `config` bash completion also has a short option `g` that can be used to enter it.

Fixes: a330623 ("src: config: Introduce config option")