### PR TITLE
src: remote: Fix bug when the user asks to remove IP from known host

### DIFF
--- a/src/lib/remote.sh
+++ b/src/lib/remote.sh
@@ -128,7 +128,7 @@ function remove_key_from_kwown_hosts()
   #shellcheck disable=SC2119
   extract_remote_info_from_config_file
 
-  remove_key_cmd+=" '${HOME}/.ssh/known_hosts' -R '[${remote_parameters['REMOTE_IP']}]:${remote_parameters['REMOTE_PORT']}'"
+  remove_key_cmd+=" '${HOME}/.ssh/known_hosts' -R '${remote_parameters['REMOTE_IP']}'"
 
   warning 'kw was not able to ssh into:'
   warning " Host: ${remote_parameters['REMOTE_IP']}"

--- a/tests/unit/lib/remote_test.sh
+++ b/tests/unit/lib/remote_test.sh
@@ -472,7 +472,7 @@ function test_extract_remote_info_from_config_file()
 
 function test_remove_key_from_kwown_hosts_by_user_request()
 {
-  local expected_cmd="ssh-keygen -q -f '${HOME}/.ssh/known_hosts' -R '[steamdeck]:8888'"
+  local expected_cmd="ssh-keygen -q -f '${HOME}/.ssh/known_hosts' -R 'steamdeck'"
 
   remote_parameters['REMOTE_FILE']="${TEST_PATH}/.kw/remote.config"
   remote_parameters['REMOTE_FILE_HOST']='steamos'


### PR DESCRIPTION
When the target IP is already in the know host file, kw pop up a message to users asking them if they want to remove the target IP from the file.  This operation failed due to a mistake in how kw handles the IP information to compose the ssh-keygen command; this commit addressed this issue using proper syntax.