### PR TITLE
lib: remote: fix fetch error due to missing output path

### DIFF
--- a/src/lib/remote.sh
+++ b/src/lib/remote.sh
@@ -42,6 +42,7 @@ function is_ssh_connection_configured()
   local remote_file=${5:-${remote_parameters[REMOTE_FILE]}}
   local remote_file_host=${5:-${remote_parameters[REMOTE_FILE_HOST]}}
   local ssh_cmd='ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=5'
+  local output
   local ret
 
   if [[ -z "$remote" && -z "$port" && -z "$user" ]]; then


### PR DESCRIPTION
is_ssh_connection_configured erases $output data in get_config_from_proc due to undeclared local variable used in both function. This issue prevented kw config-kernel-manager --fetch from work properly.

Fixes: 68a2b3a ("src: remote: Improve ssh handling in case of failure")
Co-developer-by: Rodrigo Siqueira <siqueirajordao@riseup.net>