### PR TITLE
Apply part of the kw code style to the deploy files

### DIFF
--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -507,9 +507,9 @@ function prepare_host_deploy_dir()
   fi
 
   # In case we need to create some of the basic directories
-  mkdir -p "$KW_CACHE_DIR"
-  mkdir -p "${KW_CACHE_DIR}/${LOCAL_REMOTE_DIR}"
-  mkdir -p "${KW_CACHE_DIR}/${LOCAL_TO_DEPLOY_DIR}"
+  mkdir --parents "$KW_CACHE_DIR"
+  mkdir --parents "${KW_CACHE_DIR}/${LOCAL_REMOTE_DIR}"
+  mkdir --parents "${KW_CACHE_DIR}/${LOCAL_TO_DEPLOY_DIR}"
 }
 
 # To deploy a new kernel or module, we have to prepare a directory in the
@@ -530,7 +530,7 @@ function prepare_remote_dir()
   local user="${3:-${remote_parameters['REMOTE_USER']}}"
   local first_deploy="$4"
   local flag="$5"
-  local kw_deploy_cmd="mkdir -p ${REMOTE_KW_DEPLOY}"
+  local kw_deploy_cmd="mkdir --parents ${REMOTE_KW_DEPLOY}"
   local distro_info=''
   local distro=''
   local remote_deploy_path="${KW_PLUGINS_DIR}/kernel_install/remote_deploy.sh"
@@ -559,7 +559,7 @@ function prepare_remote_dir()
       '--archive' "$remote" "$port" "$user" 'quiet'
   else
     say '* Sending kw to the remote'
-    cmd_remotely "$flag" "mkdir -p ${REMOTE_KW_DEPLOY}"
+    cmd_remotely "$flag" "mkdir --parents ${REMOTE_KW_DEPLOY}"
     if [[ -n ${remote_parameters['REMOTE_FILE']} && -n ${remote_parameters['REMOTE_FILE_HOST']} ]]; then
       cmd="scp -q -F ${remote_parameters['REMOTE_FILE']} ${files_to_send} ${remote_parameters['REMOTE_FILE_HOST']}:${REMOTE_KW_DEPLOY}"
     else
@@ -572,7 +572,7 @@ function prepare_remote_dir()
   # Removes temporary directory if already existent
   cmd_remotely "$flag" "rm --preserve-root=all --recursive --force -- ${KW_DEPLOY_TMP_FILE}"
   # Create temporary folder
-  cmd_remotely "$flag" "mkdir -p $KW_DEPLOY_TMP_FILE"
+  cmd_remotely "$flag" "mkdir --parents ${KW_DEPLOY_TMP_FILE}"
 }
 
 # Create the temporary folder for local deploy.
@@ -803,11 +803,11 @@ function cleanup()
   fi
 
   if [[ -d "${KW_CACHE_DIR}/${LOCAL_REMOTE_DIR}" ]]; then
-    cmd_manager "$flag" "rm -rf ${KW_CACHE_DIR}/${LOCAL_REMOTE_DIR}/"*
+    cmd_manager "$flag" "rm --recursive --force ${KW_CACHE_DIR}/${LOCAL_REMOTE_DIR}/"*
   fi
 
   if [[ -d "${KW_CACHE_DIR}/${LOCAL_TO_DEPLOY_DIR}" ]]; then
-    cmd_manager "$flag" "rm -rf ${KW_CACHE_DIR}/${LOCAL_TO_DEPLOY_DIR}/"*
+    cmd_manager "$flag" "rm --recursive --force ${KW_CACHE_DIR}/${LOCAL_TO_DEPLOY_DIR}/"*
   fi
 
   say 'Exiting...'
@@ -1108,7 +1108,7 @@ function get_dts_and_dtb_files_for_deploy()
     cmd_manager "$flag" "cp ${copy_pattern} ${base_kw_deploy_store_path}/"
 
     if [[ -d "${dts_base_path}/overlays" ]]; then
-      cmd_manager "$flag" "mkdir -p ${base_kw_deploy_store_path}/overlays"
+      cmd_manager "$flag" "mkdir --parents ${base_kw_deploy_store_path}/overlays"
       cmd_manager "$flag" "cp ${dts_base_path}/overlays/*.dtbo ${base_kw_deploy_store_path}/overlays"
     fi
   fi
@@ -1198,12 +1198,12 @@ function build_kw_kernel_package()
   # Ensure that we will not add anything else in the package
   if [[ -n "${KW_CACHE_DIR}" && -n "${LOCAL_TO_DEPLOY_DIR}" &&
     -x "${KW_CACHE_DIR}/${LOCAL_TO_DEPLOY_DIR}" ]]; then
-    rm -rf "${cache_to_deploy_path:?}/*"
+    rm --recursive --force "${cache_to_deploy_path:?}/*"
   fi
 
   # Centralizing kernel files in a single place
-  mkdir -p "$cache_base_kw_pkg_store_path"
-  mkdir -p "$cache_kw_pkg_modules_path"
+  mkdir --parents "$cache_base_kw_pkg_store_path"
+  mkdir --parents "$cache_kw_pkg_modules_path"
 
   # 1. Prepare modules
   modules_install_to "${cache_kw_pkg_modules_path}" "$flag"

--- a/src/plugins/kernel_install/arch.sh
+++ b/src/plugins/kernel_install/arch.sh
@@ -129,7 +129,7 @@ function generate_arch_temporary_root_file_system()
   # We do not support initramfs outside grub scope
   [[ "$bootloader_type" != 'GRUB' ]] && return
 
-  [[ "$target" == 'local' ]] && sudo_cmd='sudo -E '
+  [[ "$target" == 'local' ]] && sudo_cmd='sudo --preserve-env '
 
   # Step 2: Make sure that we are generating a consistent modules.dep and map
   cmd="${sudo_cmd}depmod --all ${name}"

--- a/src/plugins/kernel_install/debian.sh
+++ b/src/plugins/kernel_install/debian.sh
@@ -47,7 +47,7 @@ function generate_debian_temporary_root_file_system()
   cmd+=" ${name}"
 
   if [[ "$target" == 'local' ]]; then
-    cmd="sudo -E ${cmd}"
+    cmd="sudo --preserve-env ${cmd}"
   fi
 
   # Update initramfs

--- a/src/plugins/kernel_install/debian.sh
+++ b/src/plugins/kernel_install/debian.sh
@@ -44,10 +44,10 @@ function generate_debian_temporary_root_file_system()
   # We do not support initramfs outside grub scope
   [[ "$bootloader_type" != 'GRUB' && "$bootloader_type" != 'RPI_BOOTLOADER' ]] && return
 
-  cmd+=" $name"
+  cmd+=" ${name}"
 
   if [[ "$target" == 'local' ]]; then
-    cmd="sudo -E $cmd"
+    cmd="sudo -E ${cmd}"
   fi
 
   # Update initramfs

--- a/src/plugins/kernel_install/fedora.sh
+++ b/src/plugins/kernel_install/fedora.sh
@@ -49,11 +49,11 @@ function generate_fedora_temporary_root_file_system()
   cmd+=" ${name}"
 
   if [[ "$target" == 'local' ]]; then
-    cmd_prefix="sudo -E"
+    cmd_prefix="sudo --preserve-env"
   fi
 
   cmd_manager "$flag" "${cmd_prefix} grub2-editenv - unset menu_auto_hide"
-  cmd_manager "$flag" "${cmd_prefix} sed -i -e '${grub_regex}' /etc/default/grub"
+  cmd_manager "$flag" "${cmd_prefix} sed --in-place --expression='${grub_regex}' /etc/default/grub"
 
   # Update initramfs
   cmd_manager "$flag" "$cmd_prefix $cmd"

--- a/src/plugins/kernel_install/fedora.sh
+++ b/src/plugins/kernel_install/fedora.sh
@@ -46,14 +46,14 @@ function generate_fedora_temporary_root_file_system()
   # We do not support initramfs outside grub scope
   [[ "$bootloader_type" != 'GRUB' ]] && return
 
-  cmd+=" $name"
+  cmd+=" ${name}"
 
   if [[ "$target" == 'local' ]]; then
     cmd_prefix="sudo -E"
   fi
 
-  cmd_manager "$flag" "$cmd_prefix grub2-editenv - unset menu_auto_hide"
-  cmd_manager "$flag" "$cmd_prefix sed -i -e '$grub_regex' /etc/default/grub"
+  cmd_manager "$flag" "${cmd_prefix} grub2-editenv - unset menu_auto_hide"
+  cmd_manager "$flag" "${cmd_prefix} sed -i -e '${grub_regex}' /etc/default/grub"
 
   # Update initramfs
   cmd_manager "$flag" "$cmd_prefix $cmd"

--- a/src/plugins/kernel_install/grub.sh
+++ b/src/plugins/kernel_install/grub.sh
@@ -2,7 +2,7 @@
 # follows the bootloader API. In other words, we have one entry point
 # functions: run_bootloader_update: Update GRUB in a local and remote machine.
 
-declare -g DEFAULT_GRUB_CMD_UPDATE='grub-mkconfig -o /boot/grub/grub.cfg'
+declare -g DEFAULT_GRUB_CMD_UPDATE='grub-mkconfig --output=/boot/grub/grub.cfg'
 
 # Some distributions, such as Fedora, use GRUB2 as the default bootloader. On
 # those systems, grub-mkconfig command is replaced by grub2-mkconfig. This function
@@ -25,7 +25,7 @@ function define_grub_cmd_update()
     if ! command_exists "$grub2_cmd"; then
       return 2 # ENOENT
     fi
-    DEFAULT_GRUB_CMD_UPDATE="grub2-mkconfig -o /boot/grub2/grub.cfg"
+    DEFAULT_GRUB_CMD_UPDATE="grub2-mkconfig --output=/boot/grub2/grub.cfg"
   fi
 
   return 0
@@ -41,7 +41,7 @@ function run_bootloader_update()
   local total_count
 
   if [[ "$target" == 'local' ]]; then
-    cmd_sudo='sudo -E '
+    cmd_sudo='sudo --preserve-env '
     cmd_grub+="$cmd_sudo"
   fi
 
@@ -68,9 +68,9 @@ function total_of_installed_kernels()
   local flag="$1"
   local target="$2"
   local total_count
-  local find_cmd="find /boot -name 'vmlinuz*' | wc -l"
+  local find_cmd="find /boot -name 'vmlinuz*' | wc --lines"
 
-  [[ "$target" == 'local' ]] && find_cmd="sudo -E $find_cmd"
+  [[ "$target" == 'local' ]] && find_cmd="sudo --preserve-env ${find_cmd}"
 
   [[ "$flag" != 'TEST_MODE' ]] && total_count=$(eval "$find_cmd")
   total_count=$((total_count * 2 + 7))

--- a/src/plugins/kernel_install/remote_deploy.sh
+++ b/src/plugins/kernel_install/remote_deploy.sh
@@ -28,7 +28,7 @@ options_string=''
 
 long_options='kw-path:,kw-tmp-files:,modules,kernel-update,uninstall-kernels,'
 long_options+='list-kernels,deploy-setup,collect-info'
-options="$(getopt -o '' --longoptions "$long_options" -- "$@")"
+options="$(getopt --options '' --longoptions "$long_options" -- "$@")"
 eval "set -- $options"
 
 # Tiny hack to extract actions parameters

--- a/src/plugins/kernel_install/remote_deploy.sh
+++ b/src/plugins/kernel_install/remote_deploy.sh
@@ -20,7 +20,7 @@
 # Global variable
 declare -g REMOTE_KW_DEPLOY='/opt/kw'
 declare -g KW_DEPLOY_TMP_FILE='/tmp/kw'
-declare -g INSTALLED_KERNELS_PATH="$REMOTE_KW_DEPLOY/INSTALLED_KERNELS"
+declare -g INSTALLED_KERNELS_PATH="${REMOTE_KW_DEPLOY}/INSTALLED_KERNELS"
 
 # Processing input data
 action=''
@@ -43,7 +43,7 @@ while true; do
   case "$1" in
     --kw-path)
       REMOTE_KW_DEPLOY="$2"
-      INSTALLED_KERNELS_PATH="$REMOTE_KW_DEPLOY/INSTALLED_KERNELS"
+      INSTALLED_KERNELS_PATH="${REMOTE_KW_DEPLOY}/INSTALLED_KERNELS"
       shift 2
       ;;
     --kw-tmp-files)

--- a/src/plugins/kernel_install/rpi_bootloader.sh
+++ b/src/plugins/kernel_install/rpi_bootloader.sh
@@ -87,7 +87,7 @@ function update_config_txt_file()
     fi
 
     # Remove kernel/initramfs entries
-    cmd="${sudo_cmd}sed -i '/${name}/d' ${RPI_CONFIG_TXT_PATH}"
+    cmd="${sudo_cmd}sed --in-place '/${name}/d' ${RPI_CONFIG_TXT_PATH}"
     cmd_manager "$flag" "$cmd"
     return
   fi
@@ -110,13 +110,13 @@ function update_config_txt_file()
   # and add it to the end of the file (easier to debug).
   grep --quiet --extended-regexp "#kernel=*.${kernel_name}" "$RPI_CONFIG_TXT_PATH"
   if [[ "$?" == 0 ]]; then
-    cmd="${sudo_cmd}sed -i '/#kernel=*.${find_target}/d' ${RPI_CONFIG_TXT_PATH}"
+    cmd="${sudo_cmd}sed --in-place '/#kernel=*.${find_target}/d' ${RPI_CONFIG_TXT_PATH}"
     cmd_manager "$flag" "$cmd"
   fi
 
   grep --quiet --extended-regexp "#initramfs=*.${init_name}" "$RPI_CONFIG_TXT_PATH"
   if [[ "$?" == 0 ]]; then
-    cmd="${sudo_cmd}sed -i '/#initramfs=*.${init_name}/d' $RPI_CONFIG_TXT_PATH"
+    cmd="${sudo_cmd}sed --in-place '/#initramfs=*.${init_name}/d' $RPI_CONFIG_TXT_PATH"
     cmd_manager "$flag" "$cmd"
   fi
 

--- a/tests/unit/deploy_test.sh
+++ b/tests/unit/deploy_test.sh
@@ -268,7 +268,7 @@ function test_prepare_distro_for_deploy_ext4()
     'sudo -E pacman-key --init'
     'sudo -E pacman-key --populate'
     'yes | sudo -E pacman -Syu'
-    'sudo -E yes | pacman -Syu rsync screen pv bzip2 lzip lzop zstd xz rng-tools'
+    'sudo --preserve-env yes | pacman -Syu rsync screen pv bzip2 lzip lzop zstd xz rng-tools'
   )
 
   compare_command_sequence '' "$LINENO" 'expected_cmd' "$output"
@@ -321,7 +321,7 @@ function test_prepare_distro_for_deploy_btrfs()
     'sudo -E pacman-key --init'
     'sudo -E pacman-key --populate'
     'yes | sudo -E pacman -Syu'
-    'sudo -E yes | pacman -Syu rsync screen pv bzip2 lzip lzop zstd xz rng-tools'
+    'sudo --preserve-env yes | pacman -Syu rsync screen pv bzip2 lzip lzop zstd xz rng-tools'
   )
 
   compare_command_sequence '' "$LINENO" 'expected_cmd' "$output"

--- a/tests/unit/deploy_test.sh
+++ b/tests/unit/deploy_test.sh
@@ -697,8 +697,8 @@ function test_kernel_uninstall()
 function test_cleanup()
 {
   local output=''
-  local cmd_remote="rm -rf $KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR/*"
-  local cmd_to_deploy="rm -rf $KW_CACHE_DIR/$LOCAL_REMOTE_DIR/*"
+  local cmd_remote="rm --recursive --force $KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR/*"
+  local cmd_to_deploy="rm --recursive --force $KW_CACHE_DIR/$LOCAL_REMOTE_DIR/*"
 
   declare -a expected_cmd=(
     'Cleaning up temporary files...'
@@ -898,7 +898,7 @@ function test_prepare_remote_dir()
   declare -a expected_cmd=(
     "$debian_sync_files_cmd"
     "${CONFIG_SSH} ${CONFIG_REMOTE} sudo \"rm --preserve-root=all --recursive --force -- ${KW_DEPLOY_TMP_FILE}\""
-    "$CONFIG_SSH $CONFIG_REMOTE sudo \"mkdir -p $KW_DEPLOY_TMP_FILE\""
+    "$CONFIG_SSH $CONFIG_REMOTE sudo \"mkdir --parents $KW_DEPLOY_TMP_FILE\""
   )
 
   output=$(prepare_remote_dir '' '' '' '' 'TEST_MODE')
@@ -911,7 +911,7 @@ function test_prepare_remote_dir()
   declare -a expected_cmd=(
     "$arch_sync_files_cmd"
     "${CONFIG_SSH} ${CONFIG_REMOTE} sudo \"rm --preserve-root=all --recursive --force -- ${KW_DEPLOY_TMP_FILE}\""
-    "$CONFIG_SSH $CONFIG_REMOTE sudo \"mkdir -p $KW_DEPLOY_TMP_FILE\""
+    "$CONFIG_SSH $CONFIG_REMOTE sudo \"mkdir --parents $KW_DEPLOY_TMP_FILE\""
     "$CONFIG_RSYNC $KW_ETC_DIR/template_mkinitcpio.preset $CONFIG_REMOTE:$REMOTE_KW_DEPLOY $STD_RSYNC_FLAG"
   )
 
@@ -927,10 +927,10 @@ function test_prepare_remote_dir()
 
   declare -a expected_cmd=(
     "$UPDATE_KW_REMOTE_MSG"
-    "$CONFIG_SSH $CONFIG_REMOTE sudo \"mkdir -p $REMOTE_KW_DEPLOY\""
+    "$CONFIG_SSH $CONFIG_REMOTE sudo \"mkdir --parents $REMOTE_KW_DEPLOY\""
     "scp -q $scripts_path/$to_copy $CONFIG_REMOTE:$REMOTE_KW_DEPLOY"
     "${CONFIG_SSH} ${CONFIG_REMOTE} sudo \"rm --preserve-root=all --recursive --force -- ${KW_DEPLOY_TMP_FILE}\""
-    "$CONFIG_SSH $CONFIG_REMOTE sudo \"mkdir -p $KW_DEPLOY_TMP_FILE\""
+    "$CONFIG_SSH $CONFIG_REMOTE sudo \"mkdir --parents $KW_DEPLOY_TMP_FILE\""
   )
 
   compare_command_sequence '' "$LINENO" 'expected_cmd' "$output"

--- a/tests/unit/deploy_test.sh
+++ b/tests/unit/deploy_test.sh
@@ -17,18 +17,18 @@ function setUp()
 
   # Override some global variable
   export test_path="$FAKE_KERNEL"
-  export KW_CACHE_DIR="$SHUNIT_TMPDIR/.cache"
+  export KW_CACHE_DIR="${SHUNIT_TMPDIR}/.cache"
   export KW_ETC_DIR="${SAMPLES_DIR}/etc"
-  export DEPLOY_SCRIPT="$test_path/$kernel_install_path/deploy.sh"
-  export KW_PLUGINS_DIR="$PWD/src/plugins"
+  export DEPLOY_SCRIPT="${test_path}/${kernel_install_path}/deploy.sh"
+  export KW_PLUGINS_DIR="${PWD}/src/plugins"
   export REMOTE_KW_DEPLOY='/opt/kw'
   export KW_STATUS_BASE_PATH="$SHUNIT_TMPDIR"
 
-  KW_LIB_DIR="$PWD/$SAMPLES_DIR"
+  KW_LIB_DIR="${PWD}/${SAMPLES_DIR}"
 
   # Create fake .cache
-  mkdir -p "$KW_CACHE_DIR/$LOCAL_REMOTE_DIR/lib/modules"
-  mkdir -p "$KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR/"
+  mkdir -p "${KW_CACHE_DIR}/${LOCAL_REMOTE_DIR}/lib/modules"
+  mkdir -p "${KW_CACHE_DIR}/${LOCAL_TO_DEPLOY_DIR}/"
 
   # Define some basic values for configurations
   parse_configuration "$KW_CONFIG_SAMPLE"
@@ -58,11 +58,11 @@ function setUp()
   # Standard configuration makes the below standard commands
   CONFIG_REMOTE='juca@127.0.0.1'
   CONFIG_SSH='ssh -p 3333'
-  CONFIG_RSYNC="rsync --info=progress2 -e '$CONFIG_SSH'"
+  CONFIG_RSYNC="rsync --info=progress2 -e '${CONFIG_SSH}'"
   STD_RSYNC_FLAG="-LrlptD --rsync-path='sudo rsync'"
 
-  DEPLOY_REMOTE_PREFIX="bash $REMOTE_KW_DEPLOY/remote_deploy.sh"
-  DEPLOY_REMOTE_PREFIX+=" --kw-path '$REMOTE_KW_DEPLOY' --kw-tmp-files '$KW_DEPLOY_TMP_FILE'"
+  DEPLOY_REMOTE_PREFIX="bash ${REMOTE_KW_DEPLOY}/remote_deploy.sh"
+  DEPLOY_REMOTE_PREFIX+=" --kw-path '${REMOTE_KW_DEPLOY}' --kw-tmp-files '${KW_DEPLOY_TMP_FILE}'"
 
   # Default deploy messages
   SENDING_KERNEL_MSG='* Sending kernel boot files'
@@ -82,15 +82,15 @@ function setUp()
   GENERATE_BOOT_TAR_FILE="tar --lzop --directory='${LOCAL_TO_DEPLOY_PATH}'"
   GENERATE_BOOT_TAR_FILE+=" --create --file='${LOCAL_TO_DEPLOY_PATH}/${NAME}_boot.tar' boot"
 
-  SEND_BOOT_FILES_HOST2REMOTE="$CONFIG_RSYNC ${LOCAL_TO_DEPLOY_PATH}/${NAME}_boot.tar"
-  SEND_BOOT_FILES_HOST2REMOTE+=" $CONFIG_REMOTE:$KW_DEPLOY_TMP_FILE $STD_RSYNC_FLAG"
+  SEND_BOOT_FILES_HOST2REMOTE="${CONFIG_RSYNC} ${LOCAL_TO_DEPLOY_PATH}/${NAME}_boot.tar"
+  SEND_BOOT_FILES_HOST2REMOTE+=" ${CONFIG_REMOTE}:${KW_DEPLOY_TMP_FILE} ${STD_RSYNC_FLAG}"
 
   # Base sequence for ARM local
   declare -ga BASE_EXPECTED_CMD_ARM_LOCAL=(
     "$SENDING_KERNEL_MSG"
     "$UNDEFINED_CONFIG"
     "cp arch/arm64/boot/vmlinuz-5 ${TO_DEPLOY_BOOT_PATH}/Image-${NAME}"
-    "sudo cp -r $LOCAL_TO_DEPLOY_PATH/boot/* /boot/"
+    "sudo cp -r ${LOCAL_TO_DEPLOY_PATH}/boot/* /boot/"
     'generate_debian_temporary_root_file_system TEST_MODE test local GRUB'
     'sudo -E grub-mkconfig -o /boot/grub/grub.cfg'
     'touch /opt/kw/INSTALLED_KERNELS'
@@ -111,7 +111,7 @@ function setUp()
   COPY_KERNEL_IMAGE="cp arch/x86_64/boot/bzImage ${TO_DEPLOY_BOOT_PATH}/vmlinuz-${NAME}"
 
   SEND_BOOT_FILES_HOST2REMOTE="rsync --info=progress2 -e 'ssh -p 22' ${LOCAL_TO_DEPLOY_PATH}/${NAME}_boot.tar"
-  SEND_BOOT_FILES_HOST2REMOTE+=" root@localhost:$KW_DEPLOY_TMP_FILE $STD_RSYNC_FLAG"
+  SEND_BOOT_FILES_HOST2REMOTE+=" root@localhost:${KW_DEPLOY_TMP_FILE} ${STD_RSYNC_FLAG}"
 
   declare -ga BASE_EXPECTED_CMD_X86_REMOTE=(
     "$SENDING_KERNEL_MSG"
@@ -133,9 +133,9 @@ function get_deploy_cmd_helper()
   local deploy_cmd
 
   deploy_cmd="$DEPLOY_REMOTE_PREFIX"
-  deploy_cmd+=" --kernel-update $deploy_params"
+  deploy_cmd+=" --kernel-update ${deploy_params}"
 
-  printf '%s' "$CONFIG_SSH $CONFIG_REMOTE sudo \"$deploy_cmd\""
+  printf '%s' "${CONFIG_SSH} ${CONFIG_REMOTE} sudo \"${deploy_cmd}\""
 }
 
 function tearDown()
@@ -238,17 +238,17 @@ function test_prepare_distro_for_deploy_ext4()
 {
   local output
   local ssh_prefix='ssh -p 3333 juca@127.0.0.1 sudo'
-  local cmd="bash $REMOTE_KW_DEPLOY/remote_deploy.sh"
+  local cmd="bash ${REMOTE_KW_DEPLOY}/remote_deploy.sh"
 
   alias detect_filesystem_type='detect_filesystem_type_mock_ext4'
 
-  cmd+=" --kw-path '$REMOTE_KW_DEPLOY' --kw-tmp-files '$KW_DEPLOY_TMP_FILE'"
+  cmd+=" --kw-path '${REMOTE_KW_DEPLOY}' --kw-tmp-files '${KW_DEPLOY_TMP_FILE}'"
   cmd+=" --deploy-setup TEST_MODE"
 
   declare -a expected_cmd=(
     '-> Basic distro set up'
     '' # Extra space for the \n in the message
-    "$ssh_prefix \"$cmd 3\""
+    "${ssh_prefix} \"${cmd} 3\""
   )
 
   # Remote
@@ -288,18 +288,18 @@ function test_prepare_distro_for_deploy_btrfs()
 {
   local output
   local ssh_prefix='ssh -p 3333 juca@127.0.0.1 sudo'
-  local cmd="bash $REMOTE_KW_DEPLOY/remote_deploy.sh"
+  local cmd="bash ${REMOTE_KW_DEPLOY}/remote_deploy.sh"
 
   alias detect_filesystem_type='detect_filesystem_type_mock_btrfs'
   alias btrfs='btrfs_property_get_root_ro_mock'
 
-  cmd+=" --kw-path '$REMOTE_KW_DEPLOY' --kw-tmp-files '$KW_DEPLOY_TMP_FILE'"
+  cmd+=" --kw-path '${REMOTE_KW_DEPLOY}' --kw-tmp-files '${KW_DEPLOY_TMP_FILE}'"
   cmd+=" --deploy-setup TEST_MODE"
 
   declare -a expected_cmd=(
     '-> Basic distro set up'
     '' # Extra space for the \n in the message
-    "$ssh_prefix \"$cmd 3\""
+    "${ssh_prefix} \"${cmd} 3\""
   )
 
   # Remote
@@ -360,7 +360,7 @@ function test_check_setup_status()
 
   # Remote
   output=$(check_setup_status 3 'TEST_MODE')
-  expected_cmd="$ssh_prefix \"$cmd_check\""
+  expected_cmd="${ssh_prefix} \"${cmd_check}\""
   assert_equals_helper 'Status remote check' "$LINENO" "$expected_cmd" "$output"
 
   # Local
@@ -368,19 +368,19 @@ function test_check_setup_status()
 
   # 1. Fail case
   check_setup_status 1
-  assert_equals_helper 'Wrong return value' "($LINENO)" 2 "$?"
+  assert_equals_helper 'Wrong return value' "(${LINENO})" 2 "$?"
 
   # 2. Success case
   touch "${KW_STATUS_BASE_PATH}/kw_status"
   check_setup_status 2
-  assert_equals_helper 'Wrong return value' "($LINENO)" 0 "$?"
+  assert_equals_helper 'Wrong return value' "(${LINENO})" 0 "$?"
 }
 
 function test_modules_install_to()
 {
   local output
   local original="$PWD"
-  local make_cmd="make INSTALL_MOD_STRIP=1 INSTALL_MOD_PATH=$test_path modules_install"
+  local make_cmd="make INSTALL_MOD_STRIP=1 INSTALL_MOD_PATH=${test_path} modules_install"
 
   declare -a expected_cmd=(
     '* Preparing modules'
@@ -390,7 +390,7 @@ function test_modules_install_to()
   cp "${SAMPLES_DIR}/.config" "$FAKE_KERNEL"
 
   cd "$FAKE_KERNEL" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
@@ -398,7 +398,7 @@ function test_modules_install_to()
   compare_command_sequence '' "$LINENO" 'expected_cmd' "$output"
 
   cd "$original" || {
-    fail "($LINENO) It was not possible to move back from temp directory"
+    fail "(${LINENO}) It was not possible to move back from temp directory"
     return
   }
 }
@@ -414,15 +414,15 @@ function test_modules_install_to_no_strip_and_config_debug_info_enabled()
   KW_ETC_DIR="${PWD}/etc"
 
   cd "$FAKE_KERNEL" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
   output=$(modules_install_to "$test_path" 'TEST_MODE')
-  assert_substring_match "Wrong output: $output" "($LINENO)" 'strip_modules_debug_option' "$output"
+  assert_substring_match "Wrong output: ${output}" "(${LINENO})" 'strip_modules_debug_option' "$output"
 
   cd "$original" || {
-    fail "($LINENO) It was not possible to move back from temp directory"
+    fail "(${LINENO}) It was not possible to move back from temp directory"
     return
   }
 }
@@ -443,7 +443,7 @@ function test_modules_install_to_with_env()
   cp "${SAMPLES_DIR}/.config" "$FAKE_KERNEL"
 
   cd "$FAKE_KERNEL" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
@@ -454,7 +454,7 @@ function test_modules_install_to_with_env()
   compare_command_sequence '' "$LINENO" 'expected_cmd' "$output"
 
   cd "$original" || {
-    fail "($LINENO) It was not possible to move back from temp directory"
+    fail "(${LINENO}) It was not possible to move back from temp directory"
     return
   }
 }
@@ -475,7 +475,7 @@ function test_modules_install_to_with_env_local()
   cp "${SAMPLES_DIR}/.config" "$FAKE_KERNEL"
 
   cd "$FAKE_KERNEL" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
@@ -486,7 +486,7 @@ function test_modules_install_to_with_env_local()
   compare_command_sequence '' "$LINENO" 'expected_cmd' "$output"
 
   cd "$original" || {
-    fail "($LINENO) It was not possible to move back from temp directory"
+    fail "(${LINENO}) It was not possible to move back from temp directory"
     return
   }
 }
@@ -549,9 +549,9 @@ function test_kernel_modules()
 {
   local count=0
   local remote_path="$KW_DEPLOY_TMP_FILE"
-  local kernel_install_path="$SHUNIT_TMPDIR/kernel_install"
-  local to_deploy_path="$KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR"
-  local local_remote_path="$KW_CACHE_DIR/$LOCAL_REMOTE_DIR"
+  local kernel_install_path="${SHUNIT_TMPDIR}/kernel_install"
+  local to_deploy_path="${KW_CACHE_DIR}/${LOCAL_TO_DEPLOY_DIR}"
+  local local_remote_path="${KW_CACHE_DIR}/${LOCAL_REMOTE_DIR}"
   local version='5.4.0-rc7-test'
   local deploy_remote_cmd="$DEPLOY_REMOTE_PREFIX"
   local original="$PWD"
@@ -565,19 +565,19 @@ function test_kernel_modules()
   local exec_module_install
 
   # Create remote directory
-  dir_kw_deploy="$CONFIG_SSH $CONFIG_REMOTE sudo \"mkdir -p $remote_path\""
+  dir_kw_deploy="${CONFIG_SSH} ${CONFIG_REMOTE} sudo \"mkdir -p ${remote_path}\""
   # Rsync script command
-  rsync_debian="$CONFIG_RSYNC $kernel_install_path/debian.sh $CONFIG_REMOTE:$remote_path/distro_deploy.sh $STD_RSYNC_FLAG"
+  rsync_debian="${CONFIG_RSYNC} ${kernel_install_path}/debian.sh ${CONFIG_REMOTE}:${remote_path}/distro_deploy.sh ${STD_RSYNC_FLAG}"
 
-  rsync_deploy="$CONFIG_RSYNC $kernel_install_path/remote_deploy.sh $CONFIG_REMOTE:$remote_path/ $STD_RSYNC_FLAG"
+  rsync_deploy="${CONFIG_RSYNC} ${kernel_install_path}/remote_deploy.sh ${CONFIG_REMOTE}:${remote_path}/ ${STD_RSYNC_FLAG}"
 
-  rsync_utils="$CONFIG_RSYNC $kernel_install_path/utils.sh $CONFIG_REMOTE:$remote_path/ $STD_RSYNC_FLAG"
+  rsync_utils="${CONFIG_RSYNC} ${kernel_install_path}/utils.sh ${CONFIG_REMOTE}:${remote_path}/ ${STD_RSYNC_FLAG}"
 
   # Install modules
-  make_install_cmd="make INSTALL_MOD_STRIP=1 INSTALL_MOD_PATH=$local_remote_path/ modules_install"
+  make_install_cmd="make INSTALL_MOD_STRIP=1 INSTALL_MOD_PATH=${local_remote_path}/ modules_install"
 
   # Compress modules for sending
-  compress_cmd="tar --auto-compress --directory='$local_remote_path/lib/modules/' --create --file='$to_deploy_path/$version.tar' $version"
+  compress_cmd="tar --auto-compress --directory='${local_remote_path}/lib/modules/' --create --file='${to_deploy_path}/${version}.tar' ${version}"
 
   # Rsync modules
   rsync_tarball="${CONFIG_RSYNC} ${to_deploy_path}/${version}.kw.tar ${CONFIG_REMOTE}:${remote_path} ${STD_RSYNC_FLAG}"
@@ -585,12 +585,12 @@ function test_kernel_modules()
   # Install module inside remote
   deploy_remote_cmd+=" --modules ${version}.kw.tar"
 
-  exec_module_install="$CONFIG_SSH $CONFIG_REMOTE sudo \"$deploy_remote_cmd\""
+  exec_module_install="${CONFIG_SSH} ${CONFIG_REMOTE} sudo \"${deploy_remote_cmd}\""
 
   # Check modules deploy for a remote
   cp "${SAMPLES_DIR}/.config" "$FAKE_KERNEL"
   cd "$FAKE_KERNEL" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
@@ -618,7 +618,7 @@ function test_kernel_modules()
   compare_command_sequence '' "$LINENO" 'expected_cmd' "$output"
 
   cd "$original" || {
-    fail "($LINENO) It was not possible to move back from temp directory"
+    fail "(${LINENO}) It was not possible to move back from temp directory"
     return
   }
 }
@@ -642,11 +642,11 @@ function test_prepare_local_dir()
 function test_list_remote_kernels()
 {
   # Rsync script command
-  local remote_list_cmd="$CONFIG_SSH $CONFIG_REMOTE sudo"
+  local remote_list_cmd="${CONFIG_SSH} ${CONFIG_REMOTE} sudo"
   local output
   local deploy_remote_cmd="$DEPLOY_REMOTE_PREFIX" # Composing command
   deploy_remote_cmd+=" --list-kernels TEST_MODE 0 "
-  remote_list_cmd+=" \"$deploy_remote_cmd\""
+  remote_list_cmd+=" \"${deploy_remote_cmd}\""
 
   output=$(run_list_installed_kernels 'TEST_MODE' 0 3)
   assert_equals_helper 'Standard list' "$LINENO" "$remote_list_cmd" "$output"
@@ -658,12 +658,12 @@ function test_kernel_uninstall()
   local kernel_list='5.5.0-rc7,5.6.0-rc8,5.7.0-rc2'
   local single_kernel='5.7.0-rc2'
   local deploy_remote_cmd="$DEPLOY_REMOTE_PREFIX"
-  local run_kernel_uninstall_cmd="$CONFIG_SSH $CONFIG_REMOTE"
+  local run_kernel_uninstall_cmd="${CONFIG_SSH} ${CONFIG_REMOTE}"
 
   # Rsync script command
   deploy_remote_cmd+=" --uninstall-kernels '0' 'remote' '$kernel_list' 'TEST_MODE' ''"
 
-  run_kernel_uninstall_cmd+=" sudo \"$deploy_remote_cmd\""
+  run_kernel_uninstall_cmd+=" sudo \"${deploy_remote_cmd}\""
 
   # List of kernels
   output=$(run_kernel_uninstall 3 0 "$kernel_list" '' 'TEST_MODE')
@@ -674,31 +674,30 @@ function test_kernel_uninstall()
   deploy_remote_cmd="$DEPLOY_REMOTE_PREFIX"
   deploy_remote_cmd+=" --uninstall-kernels '1' 'remote' '$kernel_list' 'TEST_MODE' ''"
 
-  run_kernel_uninstall_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"$deploy_remote_cmd\""
+  run_kernel_uninstall_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"${deploy_remote_cmd}\""
   assert_equals_helper 'Reboot option' "$LINENO" "$run_kernel_uninstall_cmd" "$output"
 
   # Single kernel
   output=$(run_kernel_uninstall 3 1 "$single_kernel" '' 'TEST_MODE')
 
   deploy_remote_cmd="$DEPLOY_REMOTE_PREFIX"
-  deploy_remote_cmd+=" --uninstall-kernels '1' 'remote' '$single_kernel' 'TEST_MODE' ''"
-  run_kernel_uninstall_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"$deploy_remote_cmd\""
+  deploy_remote_cmd+=" --uninstall-kernels '1' 'remote' '${single_kernel}' 'TEST_MODE' ''"
+  run_kernel_uninstall_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"${deploy_remote_cmd}\""
   assert_equals_helper 'Reboot option' "$LINENO" "$run_kernel_uninstall_cmd" "$output"
 
   # Kernel with regex
   output=$(run_kernel_uninstall 3 1 "regex:(5.*-rc7)" '' 'TEST_MODE' '' 1)
   deploy_remote_cmd="$DEPLOY_REMOTE_PREFIX"
   deploy_remote_cmd+=" --uninstall-kernels '1' 'remote' 'regex:(5.*-rc7)' 'TEST_MODE' ''"
-  run_kernel_uninstall_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"$deploy_remote_cmd\""
+  run_kernel_uninstall_cmd="ssh -p 3333 juca@127.0.0.1 sudo \"${deploy_remote_cmd}\""
   assert_equals_helper 'Regex option' "$LINENO" "$run_kernel_uninstall_cmd" "$output"
-
 }
 
 function test_cleanup()
 {
   local output=''
-  local cmd_remote="rm --recursive --force $KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR/*"
-  local cmd_to_deploy="rm --recursive --force $KW_CACHE_DIR/$LOCAL_REMOTE_DIR/*"
+  local cmd_remote="rm --recursive --force ${KW_CACHE_DIR}/${LOCAL_TO_DEPLOY_DIR}/*"
+  local cmd_to_deploy="rm --recursive --force ${KW_CACHE_DIR}/${LOCAL_REMOTE_DIR}/*"
 
   declare -a expected_cmd=(
     'Cleaning up temporary files...'
@@ -723,142 +722,142 @@ function test_parse_deploy_options()
 
   # test default options
   parse_deploy_options
-  assert_equals_helper 'Default UNINSTALL did not match expectation' "($LINENO)" '' "${options_values['UNINSTALL']}"
-  assert_equals_helper 'Default UNINSTALL_FORCE did not match expectation' "($LINENO)" '' "${options_values['UNINSTALL_FORCE']}"
-  assert_equals_helper 'Default LS did not match expectation' "($LINENO)" '0' "${options_values['LS']}"
-  assert_equals_helper 'Default REBOOT did not match expectation' "($LINENO)" '0' "${options_values['REBOOT']}"
-  assert_equals_helper 'Default MODULES did not match expectation' "($LINENO)" '0' "${options_values['MODULES']}"
-  assert_equals_helper 'Default LS_LINE did not match expectation' "($LINENO)" '0' "${options_values['LS_LINE']}"
-  assert_equals_helper 'Default LS_ALL did not match expectation' "($LINENO)" '' "${options_values['LS_ALL']}"
-  assert_equals_helper 'Default MENU_CONFIG did not match expectation' "($LINENO)" 'nconfig' "${options_values['MENU_CONFIG']}"
-  assert_equals_helper 'Default TARGET did not match expectation' "($LINENO)" 3 "${options_values['TARGET']}"
+  assert_equals_helper 'Default UNINSTALL did not match expectation' "(${LINENO})" '' "${options_values['UNINSTALL']}"
+  assert_equals_helper 'Default UNINSTALL_FORCE did not match expectation' "(${LINENO})" '' "${options_values['UNINSTALL_FORCE']}"
+  assert_equals_helper 'Default LS did not match expectation' "(${LINENO})" '0' "${options_values['LS']}"
+  assert_equals_helper 'Default REBOOT did not match expectation' "(${LINENO})" '0' "${options_values['REBOOT']}"
+  assert_equals_helper 'Default MODULES did not match expectation' "(${LINENO})" '0' "${options_values['MODULES']}"
+  assert_equals_helper 'Default LS_LINE did not match expectation' "(${LINENO})" '0' "${options_values['LS_LINE']}"
+  assert_equals_helper 'Default LS_ALL did not match expectation' "(${LINENO})" '' "${options_values['LS_ALL']}"
+  assert_equals_helper 'Default MENU_CONFIG did not match expectation' "(${LINENO})" 'nconfig' "${options_values['MENU_CONFIG']}"
+  assert_equals_helper 'Default TARGET did not match expectation' "(${LINENO})" 3 "${options_values['TARGET']}"
 
   # test individual options
   unset options_values
   declare -gA options_values
   parse_deploy_options --remote 'user@127.0.2.1:8888'
-  assert_equals_helper 'Could not set deploy REMOTE_USER' "($LINENO)" 'user' "${remote_parameters['REMOTE_USER']}"
-  assert_equals_helper 'Could not set deploy REMOTE' "($LINENO)" '127.0.2.1' "${remote_parameters['REMOTE_IP']}"
-  assert_equals_helper 'Could not set deploy REMOTE_PORT' "($LINENO)" '8888' "${remote_parameters['REMOTE_PORT']}"
+  assert_equals_helper 'Could not set deploy REMOTE_USER' "(${LINENO})" 'user' "${remote_parameters['REMOTE_USER']}"
+  assert_equals_helper 'Could not set deploy REMOTE' "(${LINENO})" '127.0.2.1' "${remote_parameters['REMOTE_IP']}"
+  assert_equals_helper 'Could not set deploy REMOTE_PORT' "(${LINENO})" '8888' "${remote_parameters['REMOTE_PORT']}"
 
   unset options_values
   declare -gA options_values
   expected="kw deploy: option '--remote' requires an argument"
   parse_deploy_options --remote
-  assert_equals_helper 'Wrong return value' "($LINENO)" '22' "$?"
-  assertEquals "($LINENO)" "$expected" "${options_values['ERROR']}"
+  assert_equals_helper 'Wrong return value' "(${LINENO})" '22' "$?"
+  assertEquals "(${LINENO})" "$expected" "${options_values['ERROR']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options --remote ':8888' > /dev/null
-  assert_equals_helper 'Wrong return value' "($LINENO)" '22' "$?"
-  assertEquals "($LINENO)" 'Invalid remote: :8888' "${options_values['ERROR']}"
+  assert_equals_helper 'Wrong return value' "(${LINENO})" '22' "$?"
+  assertEquals "(${LINENO})" 'Invalid remote: :8888' "${options_values['ERROR']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options --local
-  assert_equals_helper 'Could not set deploy TARGET' "($LINENO)" '2' "${options_values['TARGET']}"
+  assert_equals_helper 'Could not set deploy TARGET' "(${LINENO})" '2' "${options_values['TARGET']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options --reboot
-  assert_equals_helper 'Could not set deploy REBOOT' "($LINENO)" '1' "${options_values['REBOOT']}"
+  assert_equals_helper 'Could not set deploy REBOOT' "(${LINENO})" '1' "${options_values['REBOOT']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options --no-reboot
-  assert_equals_helper 'Could not set deploy REBOOT' "($LINENO)" '0' "${options_values['REBOOT']}"
+  assert_equals_helper 'Could not set deploy REBOOT' "(${LINENO})" '0' "${options_values['REBOOT']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options --reboot --no-reboot
-  assert_equals_helper 'Could not set deploy REBOOT' "($LINENO)" '0' "${options_values['REBOOT']}"
+  assert_equals_helper 'Could not set deploy REBOOT' "(${LINENO})" '0' "${options_values['REBOOT']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options -r
-  assert_equals_helper 'Could not set deploy REBOOT' "($LINENO)" '1' "${options_values['REBOOT']}"
+  assert_equals_helper 'Could not set deploy REBOOT' "(${LINENO})" '1' "${options_values['REBOOT']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options --modules
-  assert_equals_helper 'Could not set deploy MODULES' "($LINENO)" '1' "${options_values['MODULES']}"
+  assert_equals_helper 'Could not set deploy MODULES' "(${LINENO})" '1' "${options_values['MODULES']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options -m
-  assert_equals_helper 'Could not set deploy MODULES' "($LINENO)" '1' "${options_values['MODULES']}"
+  assert_equals_helper 'Could not set deploy MODULES' "(${LINENO})" '1' "${options_values['MODULES']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options --list
-  assert_equals_helper 'Could not set deploy LS' "($LINENO)" '1' "${options_values['LS']}"
+  assert_equals_helper 'Could not set deploy LS' "(${LINENO})" '1' "${options_values['LS']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options -l
-  assert_equals_helper 'Could not set deploy LS' "($LINENO)" '1' "${options_values['LS']}"
+  assert_equals_helper 'Could not set deploy LS' "(${LINENO})" '1' "${options_values['LS']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options --ls-line
-  assert_equals_helper 'Could not set deploy LS_LINE' "($LINENO)" '1' "${options_values['LS_LINE']}"
+  assert_equals_helper 'Could not set deploy LS_LINE' "(${LINENO})" '1' "${options_values['LS_LINE']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options -s
-  assert_equals_helper 'Could not set deploy LS_LINE' "($LINENO)" '1' "${options_values['LS_LINE']}"
+  assert_equals_helper 'Could not set deploy LS_LINE' "(${LINENO})" '1' "${options_values['LS_LINE']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options --list-all
-  assert_equals_helper 'Could not set deploy LS_ALL' "($LINENO)" '1' "${options_values['LS_ALL']}"
+  assert_equals_helper 'Could not set deploy LS_ALL' "(${LINENO})" '1' "${options_values['LS_ALL']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options -a
-  assert_equals_helper 'Could not set deploy LS_ALL' "($LINENO)" '1' "${options_values['LS_ALL']}"
+  assert_equals_helper 'Could not set deploy LS_ALL' "(${LINENO})" '1' "${options_values['LS_ALL']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options --uninstall 'kernel_xpto'
-  assert_equals_helper 'Could not set deploy UNINSTALL' "($LINENO)" 'kernel_xpto' "${options_values['UNINSTALL']}"
+  assert_equals_helper 'Could not set deploy UNINSTALL' "(${LINENO})" 'kernel_xpto' "${options_values['UNINSTALL']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options -u 'kernel_xpto'
-  assert_equals_helper 'Could not set deploy UNINSTALL' "($LINENO)" 'kernel_xpto' "${options_values['UNINSTALL']}"
+  assert_equals_helper 'Could not set deploy UNINSTALL' "(${LINENO})" 'kernel_xpto' "${options_values['UNINSTALL']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options --uninstall 'kernel_xpto' --force
-  assert_equals_helper 'Could not set deploy UNINSTALL_FORCE' "($LINENO)" '1' "${options_values['FORCE']}"
+  assert_equals_helper 'Could not set deploy UNINSTALL_FORCE' "(${LINENO})" '1' "${options_values['FORCE']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options -u 'kernel_xpto' -f
-  assert_equals_helper 'Could not set deploy UNINSTALL_FORCE' "($LINENO)" '1' "${options_values['FORCE']}"
+  assert_equals_helper 'Could not set deploy UNINSTALL_FORCE' "(${LINENO})" '1' "${options_values['FORCE']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options --uninstall 'kernel_xpto' --force
-  assert_equals_helper 'Could not set deploy UNINSTALL_FORCE' "($LINENO)" '1' "${options_values['FORCE']}"
+  assert_equals_helper 'Could not set deploy UNINSTALL_FORCE' "(${LINENO})" '1' "${options_values['FORCE']}"
 
   unset options_values
   declare -gA options_values
   parse_deploy_options 'TEST_MODE'
-  assert_equals_helper 'Could not set deploy TEST_MODE' "($LINENO)" 'TEST_MODE' "${options_values['TEST_MODE']}"
+  assert_equals_helper 'Could not set deploy TEST_MODE' "(${LINENO})" 'TEST_MODE' "${options_values['TEST_MODE']}"
 
   # test integration of options
   unset options_values
   declare -gA options_values
   parse_deploy_options --remote 'user@127.0.2.1:8888' -m --ls-line -u 'kernel_xpto'
-  assert_equals_helper 'Option composition failed on UNINSTALL' "($LINENO)" 'kernel_xpto' "${options_values['UNINSTALL']}"
-  assert_equals_helper 'Option composition failed on MODULES' "($LINENO)" '1' "${options_values['MODULES']}"
-  assert_equals_helper 'Option composition failed on LS_LINE' "($LINENO)" '1' "${options_values['LS_LINE']}"
-  assert_equals_helper 'Option composition failed on REMOTE_USER' "($LINENO)" 'user' "${remote_parameters['REMOTE_USER']}"
-  assert_equals_helper 'Option composition failed on REMOTE_PORT' "($LINENO)" '8888' "${remote_parameters['REMOTE_PORT']}"
-  assert_equals_helper 'Option composition failed on REMOTE_IP' "($LINENO)" '127.0.2.1' "${remote_parameters['REMOTE_IP']}"
+  assert_equals_helper 'Option composition failed on UNINSTALL' "(${LINENO})" 'kernel_xpto' "${options_values['UNINSTALL']}"
+  assert_equals_helper 'Option composition failed on MODULES' "(${LINENO})" '1' "${options_values['MODULES']}"
+  assert_equals_helper 'Option composition failed on LS_LINE' "(${LINENO})" '1' "${options_values['LS_LINE']}"
+  assert_equals_helper 'Option composition failed on REMOTE_USER' "(${LINENO})" 'user' "${remote_parameters['REMOTE_USER']}"
+  assert_equals_helper 'Option composition failed on REMOTE_PORT' "(${LINENO})" '8888' "${remote_parameters['REMOTE_PORT']}"
+  assert_equals_helper 'Option composition failed on REMOTE_IP' "(${LINENO})" '127.0.2.1' "${remote_parameters['REMOTE_IP']}"
 }
 
 function test_prepare_host_deploy_dir()
@@ -871,9 +870,9 @@ function test_prepare_host_deploy_dir()
 
   # Check if we correctly create new directories
   prepare_host_deploy_dir
-  assertTrue "($LINENO): Cache dir not created" '[[ -d $KW_CACHE_DIR ]]'
-  assertTrue "($LINENO): Local dir not created" '[[ -d $KW_CACHE_DIR/$LOCAL_REMOTE_DIR ]]'
-  assertTrue "($LINENO): Check if kw dir was created" '[[ -d $KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR ]]'
+  assertTrue "(${LINENO}): Cache dir not created" '[[ -d $KW_CACHE_DIR ]]'
+  assertTrue "(${LINENO}): Local dir not created" '[[ -d $KW_CACHE_DIR/$LOCAL_REMOTE_DIR ]]'
+  assertTrue "(${LINENO}): Check if kw dir was created" '[[ -d $KW_CACHE_DIR/$LOCAL_TO_DEPLOY_DIR ]]'
 }
 
 function prepare_remote_list_of_files()
@@ -885,20 +884,20 @@ function prepare_remote_list_of_files()
 
 function test_prepare_remote_dir()
 {
-  local scripts_path="$KW_PLUGINS_DIR/kernel_install"
+  local scripts_path="${KW_PLUGINS_DIR}/kernel_install"
   local debian_sync_files_cmd
   local arch_sync_files_cmd
   local output
-  local rsync_quiet="rsync  -e '$CONFIG_SSH'"
+  local rsync_quiet="rsync  -e '${CONFIG_SSH}'"
 
   to_copy=$(prepare_remote_list_of_files 'debian')
-  debian_sync_files_cmd="$rsync_quiet $scripts_path/$to_copy $CONFIG_REMOTE:$REMOTE_KW_DEPLOY $STD_RSYNC_FLAG --archive"
+  debian_sync_files_cmd="${rsync_quiet} ${scripts_path}/${to_copy} ${CONFIG_REMOTE}:${REMOTE_KW_DEPLOY} ${STD_RSYNC_FLAG} --archive"
 
   # Test 1: Normal remote prepare
   declare -a expected_cmd=(
     "$debian_sync_files_cmd"
     "${CONFIG_SSH} ${CONFIG_REMOTE} sudo \"rm --preserve-root=all --recursive --force -- ${KW_DEPLOY_TMP_FILE}\""
-    "$CONFIG_SSH $CONFIG_REMOTE sudo \"mkdir --parents $KW_DEPLOY_TMP_FILE\""
+    "${CONFIG_SSH} ${CONFIG_REMOTE} sudo \"mkdir --parents ${KW_DEPLOY_TMP_FILE}\""
   )
 
   output=$(prepare_remote_dir '' '' '' '' 'TEST_MODE')
@@ -907,12 +906,12 @@ function test_prepare_remote_dir()
   # Test 2: Force ArchLinux
   expected_cmd=()
   to_copy=$(prepare_remote_list_of_files 'arch')
-  arch_sync_files_cmd="$rsync_quiet $scripts_path/$to_copy $CONFIG_REMOTE:$REMOTE_KW_DEPLOY $STD_RSYNC_FLAG --archive"
+  arch_sync_files_cmd="${rsync_quiet} ${scripts_path}/${to_copy} ${CONFIG_REMOTE}:${REMOTE_KW_DEPLOY} ${STD_RSYNC_FLAG} --archive"
   declare -a expected_cmd=(
     "$arch_sync_files_cmd"
     "${CONFIG_SSH} ${CONFIG_REMOTE} sudo \"rm --preserve-root=all --recursive --force -- ${KW_DEPLOY_TMP_FILE}\""
-    "$CONFIG_SSH $CONFIG_REMOTE sudo \"mkdir --parents $KW_DEPLOY_TMP_FILE\""
-    "$CONFIG_RSYNC $KW_ETC_DIR/template_mkinitcpio.preset $CONFIG_REMOTE:$REMOTE_KW_DEPLOY $STD_RSYNC_FLAG"
+    "${CONFIG_SSH} ${CONFIG_REMOTE} sudo \"mkdir --parents ${KW_DEPLOY_TMP_FILE}\""
+    "${CONFIG_RSYNC} ${KW_ETC_DIR}/template_mkinitcpio.preset ${CONFIG_REMOTE}:${REMOTE_KW_DEPLOY} ${STD_RSYNC_FLAG}"
   )
 
   alias detect_distro='detect_distro_arch_mock'
@@ -927,10 +926,10 @@ function test_prepare_remote_dir()
 
   declare -a expected_cmd=(
     "$UPDATE_KW_REMOTE_MSG"
-    "$CONFIG_SSH $CONFIG_REMOTE sudo \"mkdir --parents $REMOTE_KW_DEPLOY\""
-    "scp -q $scripts_path/$to_copy $CONFIG_REMOTE:$REMOTE_KW_DEPLOY"
+    "${CONFIG_SSH} ${CONFIG_REMOTE} sudo \"mkdir --parents ${REMOTE_KW_DEPLOY}\""
+    "scp -q ${scripts_path}/${to_copy} ${CONFIG_REMOTE}:${REMOTE_KW_DEPLOY}"
     "${CONFIG_SSH} ${CONFIG_REMOTE} sudo \"rm --preserve-root=all --recursive --force -- ${KW_DEPLOY_TMP_FILE}\""
-    "$CONFIG_SSH $CONFIG_REMOTE sudo \"mkdir --parents $KW_DEPLOY_TMP_FILE\""
+    "${CONFIG_SSH} ${CONFIG_REMOTE} sudo \"mkdir --parents ${KW_DEPLOY_TMP_FILE}\""
   )
 
   compare_command_sequence '' "$LINENO" 'expected_cmd' "$output"
@@ -939,7 +938,7 @@ function test_prepare_remote_dir()
   alias detect_distro='which_distro_none_mock'
 
   output=$(prepare_remote_dir '' '' '' '' 'TEST_MODE')
-  assert_equals_helper 'Wrong return value' "($LINENO)" 95 "$?"
+  assert_equals_helper 'Wrong return value' "(${LINENO})" 95 "$?"
 }
 
 function test_collect_target_info_for_deploy()
@@ -947,14 +946,14 @@ function test_collect_target_info_for_deploy()
   local output
 
   # Avoid alias overwrite
-  include "$KW_PLUGINS_DIR/kernel_install/bootloader_utils.sh"
-  include "$KW_PLUGINS_DIR/kernel_install/utils.sh"
+  include "${KW_PLUGINS_DIR}/kernel_install/bootloader_utils.sh"
+  include "${KW_PLUGINS_DIR}/kernel_install/utils.sh"
 
   # LOCAL
   alias collect_deploy_info='collect_deploy_info_other_mock'
   collect_target_info_for_deploy 2 'TEST_MODE'
-  assert_equals_helper 'Check bootloader' "($LINENO)" 'LILO' "${target_deploy_info[bootloader]}"
-  assert_equals_helper 'Check distro' "($LINENO)" 'fedora' "${target_deploy_info[distro]}"
+  assert_equals_helper 'Check bootloader' "(${LINENO})" 'LILO' "${target_deploy_info[bootloader]}"
+  assert_equals_helper 'Check distro' "(${LINENO})" 'fedora' "${target_deploy_info[distro]}"
 
   # REMOTE
   function cmd_remotely()
@@ -963,8 +962,8 @@ function test_collect_target_info_for_deploy()
     printf '[bootloader]=syslinux [distro]=chrome'
   }
   collect_target_info_for_deploy 3 'TEST_MODE'
-  assert_equals_helper 'Check bootloader' "($LINENO)" 'syslinux' "${target_deploy_info[bootloader]}"
-  assert_equals_helper 'Check distro' "($LINENO)" 'chrome' "${target_deploy_info[distro]}"
+  assert_equals_helper 'Check bootloader' "(${LINENO})" 'syslinux' "${target_deploy_info[bootloader]}"
+  assert_equals_helper 'Check distro' "(${LINENO})" 'chrome' "${target_deploy_info[distro]}"
 }
 
 function test_get_kernel_binary_name_outside_env()
@@ -973,20 +972,20 @@ function test_get_kernel_binary_name_outside_env()
   local output
 
   cd "$FAKE_KERNEL" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
   build_config['arch']='arm64'
   output=$(get_kernel_binary_name)
-  assert_equals_helper 'Expected Image for ARM' "($LINENO)" 'Image' "$output"
+  assert_equals_helper 'Expected Image for ARM' "(${LINENO})" 'Image' "$output"
 
   build_config['arch']='x86_64'
   output=$(get_kernel_binary_name)
-  assert_equals_helper 'Expected bzImage for x86' "($LINENO)" 'bzImage' "$output"
+  assert_equals_helper 'Expected bzImage for x86' "(${LINENO})" 'bzImage' "$output"
 
   cd "$original" || {
-    fail "($LINENO) It was not possible to move back from temp directory"
+    fail "(${LINENO}) It was not possible to move back from temp directory"
     return
   }
 }
@@ -999,11 +998,11 @@ function test_get_kernel_binary_name_inside_env()
 
   build_config['arch']='arm64'
   output=$(get_kernel_binary_name)
-  assert_equals_helper 'Expected Image for ARM' "($LINENO)" 'Image' "$output"
+  assert_equals_helper 'Expected Image for ARM' "(${LINENO})" 'Image' "$output"
 
   build_config['arch']='x86_64'
   output=$(get_kernel_binary_name)
-  assert_equals_helper 'Expected bzImage for x86' "($LINENO)" 'bzImage' "$output"
+  assert_equals_helper 'Expected bzImage for x86' "(${LINENO})" 'bzImage' "$output"
 }
 
 function test_get_kernel_binary_name_invalid_operation()
@@ -1011,7 +1010,7 @@ function test_get_kernel_binary_name_invalid_operation()
   local output
 
   output=$(get_kernel_binary_name)
-  assert_equals_helper 'It should not find a kernel image' "($LINENO)" 125 "$?"
+  assert_equals_helper 'It should not find a kernel image' "(${LINENO})" 125 "$?"
 }
 
 function test_get_config_file_for_deploy_local_config()
@@ -1020,7 +1019,7 @@ function test_get_config_file_for_deploy_local_config()
   local fake_cache_path
 
   cd "$FAKE_KERNEL" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
@@ -1034,7 +1033,7 @@ function test_get_config_file_for_deploy_local_config()
   assertFileEquals "$STD_CONFIG_FILE" "${fake_cache_path}/config-test"
 
   cd "$original" || {
-    fail "($LINENO) It was not possible to move back from temp directory"
+    fail "(${LINENO}) It was not possible to move back from temp directory"
     return
   }
 }
@@ -1045,7 +1044,7 @@ function test_get_config_file_for_deploy_no_kernel_name()
   local fake_cache_path
 
   cd "$FAKE_KERNEL" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
@@ -1055,10 +1054,10 @@ function test_get_config_file_for_deploy_no_kernel_name()
 
   cp "$STD_CONFIG_FILE" ./
   get_config_file_for_deploy '' "$fake_cache_path"
-  assert_equals_helper 'There is no kernel name' "($LINENO)" 22 "$?"
+  assert_equals_helper 'There is no kernel name' "(${LINENO})" 22 "$?"
 
   cd "$original" || {
-    fail "($LINENO) It was not possible to move back from temp directory"
+    fail "(${LINENO}) It was not possible to move back from temp directory"
     return
   }
 }
@@ -1094,7 +1093,7 @@ function test_get_config_file_for_deploy_warning_message()
 
   cp "$STD_CONFIG_FILE" "$FAKE_KERNEL"
   output=$(get_config_file_for_deploy 'test' "$fake_cache_path")
-  assert_equals_helper 'Expected a warning' "($LINENO)" "$expected_str" "$output"
+  assert_equals_helper 'Expected a warning' "(${LINENO})" "$expected_str" "$output"
 }
 
 function test_get_kernel_image_for_deploy_no_env_x86()
@@ -1103,7 +1102,7 @@ function test_get_kernel_image_for_deploy_no_env_x86()
   local final_kernel_binary_image_name
 
   cd "$FAKE_KERNEL" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
@@ -1116,7 +1115,7 @@ function test_get_kernel_image_for_deploy_no_env_x86()
   assert_equals_helper 'vmlinuz for x86' "(${LINENO})" 'vmlinuz-test' "$final_kernel_binary_image_name"
 
   cd "$original" || {
-    fail "($LINENO) It was not possible to move back from temp directory"
+    fail "(${LINENO}) It was not possible to move back from temp directory"
     return
   }
 }
@@ -1127,7 +1126,7 @@ function test_get_kernel_image_for_deploy_no_env_arm()
   local final_kernel_binary_image_name
 
   cd "$FAKE_KERNEL" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
@@ -1140,7 +1139,7 @@ function test_get_kernel_image_for_deploy_no_env_arm()
   assert_equals_helper 'Image for ARM' "(${LINENO})" 'Image-test' "$final_kernel_binary_image_name"
 
   cd "$original" || {
-    fail "($LINENO) It was not possible to move back from temp directory"
+    fail "(${LINENO}) It was not possible to move back from temp directory"
     return
   }
 }
@@ -1170,7 +1169,7 @@ function test_get_kernel_image_for_deploy_kernel_image_does_not_exist()
   local final_kernel_binary_image_name
 
   get_kernel_image_for_deploy 'arm64' 'test' 'Image' 'arch/arm64/boot' "$fake_cache" final_kernel_binary_image_name
-  assert_equals_helper 'There is no kernel image' "($LINENO)" 2 "$?"
+  assert_equals_helper 'There is no kernel image' "(${LINENO})" 2 "$?"
 }
 
 # TODO: Move this function to mk_fake_kernel_root
@@ -1192,7 +1191,7 @@ function test_get_dts_and_dtb_files_for_deploy_copy_overlay_and_dtbo()
   local original="$PWD"
 
   cd "$FAKE_KERNEL" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
@@ -1201,11 +1200,11 @@ function test_get_dts_and_dtb_files_for_deploy_copy_overlay_and_dtbo()
   mkdir "${FAKE_KERNEL}/TEST"
 
   get_dts_and_dtb_files_for_deploy 'arm64' 'arch/arm64/boot' "${FAKE_KERNEL}/TEST"
-  assertTrue "($LINENO): Copy overlay folder" '[[ -d ${FAKE_KERNEL}/TEST/overlays ]]'
-  assertTrue "($LINENO): Expted dtb files" '[[ -f ${FAKE_KERNEL}/TEST/bcm2710-rpi-2-b.dtb ]]'
+  assertTrue "(${LINENO}): Copy overlay folder" '[[ -d ${FAKE_KERNEL}/TEST/overlays ]]'
+  assertTrue "(${LINENO}): Expted dtb files" '[[ -f ${FAKE_KERNEL}/TEST/bcm2710-rpi-2-b.dtb ]]'
 
   cd "$original" || {
-    fail "($LINENO) It was not possible to move back from temp directory"
+    fail "(${LINENO}) It was not possible to move back from temp directory"
     return
   }
 }
@@ -1215,7 +1214,7 @@ function test_get_dts_and_dtb_files_for_deploy_copy_only_dtbo()
   local original="$PWD"
 
   cd "$FAKE_KERNEL" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
@@ -1227,11 +1226,11 @@ function test_get_dts_and_dtb_files_for_deploy_copy_only_dtbo()
 
   get_dts_and_dtb_files_for_deploy 'arm64' 'arch/arm64/boot' "${FAKE_KERNEL}/TEST"
 
-  assertTrue "($LINENO): It should not have overlays" '[[ ! -d ${FAKE_KERNEL}/TEST/overlays ]]'
-  assertTrue "($LINENO): Expted dtb files" '[[ -f ${FAKE_KERNEL}/TEST/bcm2710-rpi-2-b.dtb ]]'
+  assertTrue "(${LINENO}): It should not have overlays" '[[ ! -d ${FAKE_KERNEL}/TEST/overlays ]]'
+  assertTrue "(${LINENO}): Expted dtb files" '[[ -f ${FAKE_KERNEL}/TEST/bcm2710-rpi-2-b.dtb ]]'
 
   cd "$original" || {
-    fail "($LINENO) It was not possible to move back from temp directory"
+    fail "(${LINENO}) It was not possible to move back from temp directory"
     return
   }
 }
@@ -1249,8 +1248,8 @@ function test_get_dts_and_dtb_files_for_deploy_inside_env()
   create_fake_dts_folder
 
   get_dts_and_dtb_files_for_deploy 'arm64' 'arch/arm64/boot' "${FAKE_KERNEL}/TEST"
-  assertTrue "($LINENO): Copy overlay folder" '[[ -d ${FAKE_KERNEL}/TEST/overlays ]]'
-  assertTrue "($LINENO): Expted dtb files" '[[ -f ${FAKE_KERNEL}/TEST/bcm2710-rpi-2-b.dtb ]]'
+  assertTrue "(${LINENO}): Copy overlay folder" '[[ -d ${FAKE_KERNEL}/TEST/overlays ]]'
+  assertTrue "(${LINENO}): Expted dtb files" '[[ -f ${FAKE_KERNEL}/TEST/bcm2710-rpi-2-b.dtb ]]'
 }
 
 function test_create_pkg_metadata_file_for_deploy()
@@ -1259,7 +1258,7 @@ function test_create_pkg_metadata_file_for_deploy()
   local output
 
   cd "$FAKE_KERNEL" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
@@ -1267,16 +1266,16 @@ function test_create_pkg_metadata_file_for_deploy()
 
   create_pkg_metadata_file_for_deploy 'x86_64' 'test' 'vmlinuz' './TEST'
   output=$(grep 'kernel_name' './TEST/kw.pkg.info')
-  assertEquals "($LINENO)" 'kernel_name=test' "$output"
+  assertEquals "(${LINENO})" 'kernel_name=test' "$output"
 
   output=$(grep 'kernel_binary_image_file' './TEST/kw.pkg.info')
-  assertEquals "($LINENO)" 'kernel_binary_image_file=vmlinuz' "$output"
+  assertEquals "(${LINENO})" 'kernel_binary_image_file=vmlinuz' "$output"
 
   output=$(grep 'architecture' './TEST/kw.pkg.info')
-  assertEquals "($LINENO)" 'architecture=x86_64' "$output"
+  assertEquals "(${LINENO})" 'architecture=x86_64' "$output"
 
   cd "$original" || {
-    fail "($LINENO) It was not possible to move back from temp directory"
+    fail "(${LINENO}) It was not possible to move back from temp directory"
     return
   }
 }
@@ -1287,28 +1286,28 @@ function test_run_commands_outside_kernel_tree()
   local original="$PWD"
 
   cd "${NON_KERNEL_TREE}" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
   options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=''
   parse_deploy_options --list
-  assertTrue "($LINENO) - Should list outside kernel tree" "[[ -n ${options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']} ]]"
+  assertTrue "(${LINENO}) - Should list outside kernel tree" "[[ -n ${options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']} ]]"
 
   options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=''
   parse_deploy_options --list-all
-  assertTrue "($LINENO) - Should list all outside kernel tree" "[[ -n ${options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']} ]]"
+  assertTrue "(${LINENO}) - Should list all outside kernel tree" "[[ -n ${options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']} ]]"
 
   options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=''
   parse_deploy_options --ls-line
-  assertTrue "($LINENO) - Should line list outside kernel tree" "[[ -n ${options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']} ]]"
+  assertTrue "(${LINENO}) - Should line list outside kernel tree" "[[ -n ${options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']} ]]"
 
   options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=''
   parse_deploy_options --uninstall 'some_kernel'
-  assertTrue "($LINENO) - Should uninstall outside kernel tree" "[[ -n ${options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']} ]]"
+  assertTrue "(${LINENO}) - Should uninstall outside kernel tree" "[[ -n ${options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']} ]]"
 
   cd "$original" || {
-    fail "($LINENO) It was not possible to move back from temp directory"
+    fail "(${LINENO}) It was not possible to move back from temp directory"
     return
   }
 }

--- a/tests/unit/plugins/kernel_install/arch_test.sh
+++ b/tests/unit/plugins/kernel_install/arch_test.sh
@@ -18,7 +18,7 @@ function setUp()
   cp "tests/unit/samples/mkinitcpio_output/mkinitcpio_log_only_warnings" "$SHUNIT_TMPDIR"
 
   cd "$SHUNIT_TMPDIR" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 }
@@ -26,7 +26,7 @@ function setUp()
 function tearDown()
 {
   cd "$ORIGINAL_PATH" || {
-    fail "($LINENO) It was not possible to move to the kw folder"
+    fail "(${LINENO}) It was not possible to move to the kw folder"
     return
   }
   rm -rf "$SHUNIT_TMPDIR"
@@ -57,7 +57,7 @@ function test_generate_arch_temporary_root_file_system_local_and_mkinitcpio()
     {
       return 0
     }
-    generate_arch_temporary_root_file_system 'TEST_MODE' "$name" 'local' 'GRUB'
+    generate_arch_temporary_root_file_system 'TEST_MODE' "${name}" 'local' 'GRUB'
   )"
   ret="$?"
 
@@ -79,7 +79,7 @@ function test_generate_arch_temporary_root_file_system_local_and_mkinitcpio_fail
     {
       return 0
     }
-    generate_arch_temporary_root_file_system 'TEST_MODE' "$name" 'local' 'GRUB'
+    generate_arch_temporary_root_file_system 'TEST_MODE' "${name}" 'local' 'GRUB'
   )"
   ret="$?"
 
@@ -105,7 +105,7 @@ function test_generate_arch_temporary_root_file_system_remote_and_mkinitcpio()
     {
       return 0
     }
-    generate_arch_temporary_root_file_system 'TEST_MODE' "$name" 'remote' 'GRUB'
+    generate_arch_temporary_root_file_system 'TEST_MODE' "${name}" 'remote' 'GRUB'
   )"
   compare_command_sequence '' "$LINENO" 'cmd_sequence' "$output"
 }
@@ -154,13 +154,13 @@ function test_generate_arch_temporary_root_file_system_remote_and_not_supported(
   output="$(
     function command_exists()
     {
-      [[ "$1" == 'mkinitcpio' ]] && return 1
-      [[ "$1" == 'dracut' ]] && return 1
+      [[ "${1}" == 'mkinitcpio' ]] && return 1
+      [[ "${1}" == 'dracut' ]] && return 1
     }
-    generate_arch_temporary_root_file_system 'TEST_MODE' "$name" 'remote' 'GRUB'
+    generate_arch_temporary_root_file_system 'TEST_MODE' "${name}" 'remote' 'GRUB'
   )"
 
-  assertEquals "($LINENO)" 22 "$?"
+  assertEquals "(${LINENO})" 22 "$?"
 }
 
 function test_generate_arch_temporary_root_file_system_remote_preferred_root_fs()
@@ -173,7 +173,7 @@ function test_generate_arch_temporary_root_file_system_remote_preferred_root_fs(
 
   # Remote
   declare -a cmd_sequence=(
-    "depmod --all $name"
+    "depmod --all ${name}"
     "DRACUT_NO_XATTR=1 dracut --force --persistent-policy by-partuuid --hostonly /boot/initramfs-${name}.img ${name}"
   )
 
@@ -205,10 +205,10 @@ function test_generate_arch_temporary_root_file_system_remote_preferred_root_fs_
     {
       return 1
     }
-    generate_arch_temporary_root_file_system 'TEST_MODE' "$name" 'remote' 'GRUB' '' 'xpto'
+    generate_arch_temporary_root_file_system 'TEST_MODE' "${name}" 'remote' 'GRUB' '' 'xpto'
   )"
 
-  assert_equals_helper "Expected error message" "($LINENO)" "$expected_output" "$output"
+  assert_equals_helper "Expected error message" "(${LINENO})" "$expected_output" "$output"
 }
 
 function test_process_mkinitcpio_message_check_errors_return()

--- a/tests/unit/plugins/kernel_install/arch_test.sh
+++ b/tests/unit/plugins/kernel_install/arch_test.sh
@@ -42,7 +42,7 @@ function test_generate_arch_temporary_root_file_system_local_and_mkinitcpio()
   local ret
 
   # Local
-  sudo_cmd='sudo -E'
+  sudo_cmd='sudo --preserve-env'
   declare -a cmd_sequence=(
     "${sudo_cmd} depmod --all ${name}"
     "${sudo_cmd} mkinitcpio --generate /boot/initramfs-${name}.img --kernel ${name}"

--- a/tests/unit/plugins/kernel_install/bootloader_utils_test.sh
+++ b/tests/unit/plugins/kernel_install/bootloader_utils_test.sh
@@ -73,13 +73,13 @@ function test_identify_bootloader_from_files()
   local output
 
   output=$(identify_bootloader_from_files "${SHUNIT_TMPDIR}/GRUB_FILES")
-  assertEquals "($LINENO): Expected Grub" 'GRUB' "$output"
+  assertEquals "(${LINENO}): Expected Grub" 'GRUB' "$output"
 
   output=$(identify_bootloader_from_files "${SHUNIT_TMPDIR}/SYSLINUX_FILES")
-  assertEquals "($LINENO): Expected Syslinux" 'SYSLINUX' "$output"
+  assertEquals "(${LINENO}): Expected Syslinux" 'SYSLINUX' "$output"
 
   output=$(identify_bootloader_from_files "${SHUNIT_TMPDIR}/RPI_FILES")
-  assertEquals "($LINENO): Expected Raspberry Pi" 'RPI_BOOTLOADER' "$output"
+  assertEquals "(${LINENO}): Expected Raspberry Pi" 'RPI_BOOTLOADER' "$output"
 }
 
 invoke_shunit

--- a/tests/unit/plugins/kernel_install/debian_test.sh
+++ b/tests/unit/plugins/kernel_install/debian_test.sh
@@ -22,7 +22,7 @@ function test_update_debian_boot_loader()
   assert_equals_helper 'Check simple flow' "$LINENO" "$cmd" "$output"
 
   output=$(generate_debian_temporary_root_file_system 'TEST_MODE' 'xpto' 'local' 'GRUB')
-  cmd='sudo -E update-initramfs -c -k xpto'
+  cmd='sudo --preserve-env update-initramfs -c -k xpto'
   assert_equals_helper 'Check local deploy' "$LINENO" "$cmd" "$output"
 }
 

--- a/tests/unit/plugins/kernel_install/fedora_test.sh
+++ b/tests/unit/plugins/kernel_install/fedora_test.sh
@@ -20,7 +20,7 @@ function test_update_fedora_boot_loader()
 
   declare -a cmd_sequence=(
     'grub2-editenv - unset menu_auto_hide'
-    'sed -i -e '\'s/GRUB_ENABLE_BLSCFG=true/GRUB_ENABLE_BLSCFG=false/g\'' /etc/default/grub'
+    'sed --in-place --expression='\'s/GRUB_ENABLE_BLSCFG=true/GRUB_ENABLE_BLSCFG=false/g\'' /etc/default/grub'
     'dracut --force --kver xpto'
   )
 
@@ -28,9 +28,9 @@ function test_update_fedora_boot_loader()
   compare_command_sequence 'Check simple flow' "$LINENO" 'cmd_sequence' "$output"
 
   declare -a cmd_sequence=(
-    'sudo -E grub2-editenv - unset menu_auto_hide'
-    'sudo -E sed -i -e '\'s/GRUB_ENABLE_BLSCFG=true/GRUB_ENABLE_BLSCFG=false/g\'' /etc/default/grub'
-    'sudo -E dracut --force --kver xpto'
+    'sudo --preserve-env grub2-editenv - unset menu_auto_hide'
+    'sudo --preserve-env sed --in-place --expression='\'s/GRUB_ENABLE_BLSCFG=true/GRUB_ENABLE_BLSCFG=false/g\'' /etc/default/grub'
+    'sudo --preserve-env dracut --force --kver xpto'
   )
 
   output=$(generate_fedora_temporary_root_file_system 'TEST_MODE' 'xpto' 'local' 'GRUB')

--- a/tests/unit/plugins/kernel_install/grub_test.sh
+++ b/tests/unit/plugins/kernel_install/grub_test.sh
@@ -39,12 +39,12 @@ function test_grub()
   }
 
   output=$(run_bootloader_update 'TEST_MODE' 'local')
-  expected_cmd='sudo -E grub-mkconfig -o /boot/grub/grub.cfg'
+  expected_cmd='sudo --preserve-env grub-mkconfig --output=/boot/grub/grub.cfg'
 
   assert_equals_helper 'Local update' "$LINENO" "$expected_cmd" "$output"
 
   output=$(run_bootloader_update 'TEST_MODE' 'remote')
-  expected_cmd='grub-mkconfig -o /boot/grub/grub.cfg'
+  expected_cmd='grub-mkconfig --output=/boot/grub/grub.cfg'
 
   assert_equals_helper 'Remote update' "$LINENO" "$expected_cmd" "$output"
 
@@ -61,12 +61,12 @@ function test_grub()
   }
 
   output=$(run_bootloader_update 'TEST_MODE' 'local')
-  expected_cmd='sudo -E grub2-mkconfig -o /boot/grub2/grub.cfg'
+  expected_cmd='sudo --preserve-env grub2-mkconfig --output=/boot/grub2/grub.cfg'
 
   assert_equals_helper 'Local update' "$LINENO" "$expected_cmd" "$output"
 
   output=$(run_bootloader_update 'TEST_MODE' 'remote')
-  expected_cmd='grub2-mkconfig -o /boot/grub2/grub.cfg'
+  expected_cmd='grub2-mkconfig --output=/boot/grub2/grub.cfg'
 
   assert_equals_helper 'Remote update' "$LINENO" "$expected_cmd" "$output"
 }

--- a/tests/unit/plugins/kernel_install/grub_test.sh
+++ b/tests/unit/plugins/kernel_install/grub_test.sh
@@ -31,7 +31,7 @@ function test_grub()
     local command="$1"
     local package=${command%% *}
 
-    if [[ $command == 'grub-mkconfig' ]]; then
+    if [[ "$command" == 'grub-mkconfig' ]]; then
       return 0
     fi
 
@@ -53,7 +53,7 @@ function test_grub()
     local command="$1"
     local package=${command%% *}
 
-    if [[ $command == 'grub2-mkconfig' ]]; then
+    if [[ "$command" == 'grub2-mkconfig' ]]; then
       return 0
     fi
 

--- a/tests/unit/plugins/kernel_install/rpi_test.sh
+++ b/tests/unit/plugins/kernel_install/rpi_test.sh
@@ -66,7 +66,7 @@ function test_remote_add_new_image()
 
   update_config_txt_file 'SILENT' 'remote' "$KERNEL_NAME" "$KERNEL_IMAGE_NAME"
   output=$(get_kernel_from_config)
-  assertEquals "($LINENO): " "kernel-$KERNEL_NAME.img" "$output"
+  assertEquals "(${LINENO}): " "kernel-${KERNEL_NAME}.img" "$output"
 }
 
 function test_remote_add_same_kernel_multiple_times()
@@ -76,7 +76,7 @@ function test_remote_add_same_kernel_multiple_times()
   update_config_txt_file 'SILENT' 'remote' "$KERNEL_NAME" "$KERNEL_IMAGE_NAME"
 
   output=$(get_kernel_from_config)
-  assertEquals "($LINENO): " "kernel-$KERNEL_NAME.img" "$output"
+  assertEquals "(${LINENO}): " "kernel-${KERNEL_NAME}.img" "$output"
 }
 
 function test_remote_add_two_different_kernels()
@@ -92,7 +92,7 @@ function test_remote_add_two_different_kernels()
   update_config_txt_file 'SILENT' 'remote' "${KERNEL_NAME}-42" "$kernel_image_name_2"
 
   output=$(get_kernel_from_config)
-  assertEquals "($LINENO): " "kernel-$KERNEL_NAME-42" "$output"
+  assertEquals "(${LINENO}): " "kernel-${KERNEL_NAME}-42" "$output"
 }
 
 function test_remote_other_files_with_similar_name()
@@ -103,10 +103,10 @@ function test_remote_other_files_with_similar_name()
 
   touch "${FAKE_FW_PATH}/${kernel_image_name}"
   touch "${FAKE_FW_PATH}/config-${kernel_name}-42"
-  update_config_txt_file 'SILENT' 'remote' "$kernel_name-42" "$kernel_image_name"
+  update_config_txt_file 'SILENT' 'remote' "${kernel_name}-42" "$kernel_image_name"
 
   output=$(get_kernel_from_config)
-  assertEquals "($LINENO): " "kernel-$kernel_name-42" "$output"
+  assertEquals "(${LINENO}): " "kernel-${kernel_name}-42" "$output"
 }
 
 function test_remote_add_the_same_kernel_twice()
@@ -121,14 +121,14 @@ function test_remote_add_the_same_kernel_twice()
   touch "${FAKE_FW_PATH}/kernel-${kernel_name}-41"
   touch "${FAKE_FW_PATH}/config-${kernel_name}-41"
 
-  update_config_txt_file 'SILENT' 'remote' "$kernel_name-42" "$kernel_image_name_1"
-  update_config_txt_file 'SILENT' 'remote' "$kernel_name-41" "$kernel_image_name_2"
-  update_config_txt_file 'SILENT' 'remote' "$kernel_name-42" "$kernel_image_name_1"
+  update_config_txt_file 'SILENT' 'remote' "${kernel_name}-42" "$kernel_image_name_1"
+  update_config_txt_file 'SILENT' 'remote' "${kernel_name}-41" "$kernel_image_name_2"
+  update_config_txt_file 'SILENT' 'remote' "${kernel_name}-42" "$kernel_image_name_1"
   output=$(get_kernel_from_config)
-  assertEquals "($LINENO): " "kernel-$kernel_name-42" "$output"
+  assertEquals "(${LINENO}): " "kernel-${kernel_name}-42" "$output"
 
   output=$(grep "#kernel=kernel-${kernel_name}-42" "${FAKE_RPI_PATH}")
-  assertEquals "($LINENO): " "" "$output"
+  assertEquals "(${LINENO}): " "" "$output"
 }
 
 function test_remote_remove_kernel()
@@ -138,7 +138,7 @@ function test_remote_remove_kernel()
   update_config_txt_file 'SILENT' 'remote' 'rpi-config' "$STD_KERNEL_NAME"
 
   output=$(get_kernel_from_config)
-  assertEquals "($LINENO): " '' "$output"
+  assertEquals "(${LINENO}): " '' "$output"
 }
 
 function test_remote_remove_kernel_check_around_kernel()

--- a/tests/unit/plugins/kernel_install/utils_test.sh
+++ b/tests/unit/plugins/kernel_install/utils_test.sh
@@ -42,7 +42,7 @@ function oneTimeTearDown()
 {
   rm -f "$INSTALLED_KERNELS_PATH"
   # shellcheck disable=SC2115
-  [[ -d ${TARGET_PATH} ]] && rm -rf "${TARGET_PATH}/*"
+  [[ -d ${TARGET_PATH} ]] && rm --recursive --force "${TARGET_PATH}/*"
 }
 
 function setUp()
@@ -58,7 +58,7 @@ function setUp()
   test_tmp_file="$SHUNIT_TMPDIR/tmp/kw"
   REMOTE_KW_DEPLOY="$SHUNIT_TMPDIR/opt/kw"
   KW_DEPLOY_TMP_FILE="$test_tmp_file"
-  mkdir -p "$test_tmp_file"
+  mkdir --parents "$test_tmp_file"
 
   # Mock variables
   KW_PLUGINS_DIR="$PWD/src/plugins"
@@ -67,8 +67,8 @@ function setUp()
 
 function tearDown()
 {
-  rm -rf "$SHUNIT_TMPDIR"
-  mkdir -p "$SHUNIT_TMPDIR"
+  rm --recursive --force "$SHUNIT_TMPDIR"
+  mkdir --parents "$SHUNIT_TMPDIR"
 }
 
 function total_of_installed_kernels_mock()
@@ -215,10 +215,10 @@ function test_reboot_machine()
   assert_equals_helper 'Disable reboot in a non-local machine' "$LINENO" '' "$output"
 
   output=$(reboot_machine '1' 'local' 'TEST_MODE')
-  assert_equals_helper 'Disable reboot in a non-local machine' "$LINENO" 'sudo -E reboot' "$output"
+  assert_equals_helper 'Disable reboot in a non-local machine' "$LINENO" 'sudo --preserve-env reboot' "$output"
 
   output=$(reboot_machine '1' 'local' 'TEST_MODE')
-  assert_equals_helper 'Disable reboot in a non-local machine' "$LINENO" 'sudo -E reboot' "$output"
+  assert_equals_helper 'Disable reboot in a non-local machine' "$LINENO" 'sudo --preserve-env reboot' "$output"
 }
 
 function test_is_in_array()
@@ -281,7 +281,7 @@ function test_kernel_uninstall_regex_one_kernel()
 
   # Composing expected command sequence
   local -a cmd_sequence=(
-    "sudo mkdir -p ${REMOTE_KW_DEPLOY}"
+    "sudo mkdir --parents ${REMOTE_KW_DEPLOY}"
     "sudo touch '${INSTALLED_KERNELS_PATH}'"
     "Removing: ${kernel_name}"
   )
@@ -291,7 +291,7 @@ function test_kernel_uninstall_regex_one_kernel()
   # shellcheck disable=SC2068
   for file in ${boot_files[@]}; do
     cmd_sequence["$((index++))"]="Removing: ${file}"
-    cmd_sequence["$((index++))"]="sudo -E rm ${file}"
+    cmd_sequence["$((index++))"]="sudo --preserve-env rm ${file}"
   done
 
   cmd_sequence["$((index++))"]="Can't find ${TARGET_PATH}/${mkinitcpio_d_path_1}"
@@ -328,7 +328,7 @@ function test_kernel_uninstall_regex_two_kernels()
 
   # Composing expected command sequence
   local -a cmd_sequence=(
-    "sudo mkdir -p ${REMOTE_KW_DEPLOY}"
+    "sudo mkdir --parents ${REMOTE_KW_DEPLOY}"
     "sudo touch '${INSTALLED_KERNELS_PATH}'"
     "Removing: ${kernel_name_1}"
   )
@@ -338,7 +338,7 @@ function test_kernel_uninstall_regex_two_kernels()
   # shellcheck disable=SC2068
   for file in ${boot_files[@]}; do
     cmd_sequence["$((index++))"]="Removing: ${file}"
-    cmd_sequence["$((index++))"]="sudo -E rm ${file}"
+    cmd_sequence["$((index++))"]="sudo --preserve-env rm ${file}"
   done
 
   cmd_sequence["$((index++))"]="Can't find ${TARGET_PATH}/${mkinitcpio_d_path_1}"
@@ -351,7 +351,7 @@ function test_kernel_uninstall_regex_two_kernels()
   # shellcheck disable=SC2068
   for file in ${boot_files[@]}; do
     cmd_sequence["$((index++))"]="Removing: ${file}"
-    cmd_sequence["$((index++))"]="sudo -E rm ${file}"
+    cmd_sequence["$((index++))"]="sudo --preserve-env rm ${file}"
   done
 
   cmd_sequence["$((index++))"]="Can't find ${TARGET_PATH}/${mkinitcpio_d_path_2}"
@@ -387,12 +387,12 @@ function test_kernel_uninstall_unmanaged()
   # Notice that we are only testing the force feature, we did not create fake
   # files, as a result we can't find files.
   local -a cmd_sequence=(
-    "sudo mkdir -p ${REMOTE_KW_DEPLOY}"
+    "sudo mkdir --parents ${REMOTE_KW_DEPLOY}"
     "sudo touch '${INSTALLED_KERNELS_PATH}'"
     "${target} not managed by kw. Use --force/-f to uninstall anyway."
   )
 
-  mkdir -p "${TARGET_PATH}/boot"
+  mkdir --parents "${TARGET_PATH}/boot"
   printf '%s\n' "menuentry 'Arch Linux, with Linux 5.5.0-rc2-NOTMANAGED'" >> "${TARGET_PATH}/boot/grub/grub.cfg"
   touch "${TARGET_PATH}/boot/vmlinuz-5.5.0-rc2-NOTMANAGED"
   output=$(kernel_uninstall 0 'local' '5.5.0-rc2-NOTMANAGED' 'TEST_MODE' '' "$TARGET_PATH")
@@ -414,25 +414,25 @@ function test_kernel_force_uninstall_unmanaged()
   # Notice that we are only testing the force feature, we did not create fake
   # files, as a result we can't find files.
   local -a cmd_sequence=(
-    "sudo mkdir -p ${REMOTE_KW_DEPLOY}"
+    "sudo mkdir --parents ${REMOTE_KW_DEPLOY}"
     "sudo touch '${INSTALLED_KERNELS_PATH}'"
     "Removing: ${target}"
     "Removing: ${boot_path}"
-    "sudo -E rm ${boot_path}"
+    "sudo --preserve-env rm ${boot_path}"
     "Removing: ${mkinitcpio_d_path}"
-    "sudo -E rm ${mkinitcpio_d_path}"
+    "sudo --preserve-env rm ${mkinitcpio_d_path}"
     "Removing: ${initramfs_tools_var_path}"
-    "sudo -E rm ${initramfs_tools_var_path}"
+    "sudo --preserve-env rm ${initramfs_tools_var_path}"
     "Removing: ${modules_lib_path}"
-    "sudo -E rm -rf ${modules_lib_path}"
+    "sudo --preserve-env rm --recursive --force ${modules_lib_path}"
     "sudo sed -i '/${target}/d' '${INSTALLED_KERNELS_PATH}'"
     'run_bootloader_update_mock'
   )
 
-  mkdir -p "${TARGET_PATH}/boot"
-  mkdir -p "${TARGET_PATH}/lib/modules/"
-  mkdir -p "${TARGET_PATH}/var/lib/initramfs-tools"
-  mkdir -p "${TARGET_PATH}/etc/mkinitcpio.d"
+  mkdir --parents "${TARGET_PATH}/boot"
+  mkdir --parents "${TARGET_PATH}/lib/modules/"
+  mkdir --parents "${TARGET_PATH}/var/lib/initramfs-tools"
+  mkdir --parents "${TARGET_PATH}/etc/mkinitcpio.d"
 
   tmp_grub_cfg="${TARGET_PATH}/tmp/grub.cfg"
   cp "$grub_cfg_path" "$tmp_grub_cfg"
@@ -440,7 +440,7 @@ function test_kernel_force_uninstall_unmanaged()
   touch "$boot_path"
   touch "$mkinitcpio_d_path"
   touch "$initramfs_tools_var_path"
-  mkdir -p "$modules_lib_path"
+  mkdir --parents "$modules_lib_path"
 
   output=$(kernel_uninstall 0 'local' '5.5.0-rc2-NOTMANAGED' 'TEST_MODE' 1 "$TARGET_PATH")
   compare_command_sequence '' "$LINENO" 'cmd_sequence' "$output"
@@ -449,7 +449,7 @@ function test_kernel_force_uninstall_unmanaged()
   rm "$boot_path"
   rm "$mkinitcpio_d_path"
   rm "$initramfs_tools_var_path"
-  rm -rf "$modules_lib_path"
+  rm --recursive --force "$modules_lib_path"
 }
 
 function test_remove_managed_kernel_local()
@@ -469,7 +469,7 @@ function test_remove_managed_kernel_local()
   local index
 
   # Adding mock file
-  mkdir -p "${TARGET_PATH}/boot"
+  mkdir --parents "${TARGET_PATH}/boot"
   touch "${TARGET_PATH}/boot/vmlinuz-${kernel_name}"
   touch "${TARGET_PATH}/boot/initrd.img-${kernel_name}"
   touch "${TARGET_PATH}/boot/initramfs-${kernel_name}.img"
@@ -478,7 +478,7 @@ function test_remove_managed_kernel_local()
 
   # Composing command sequence list
   local -a cmd_sequence=(
-    "sudo mkdir -p $REMOTE_KW_DEPLOY"
+    "sudo mkdir --parents $REMOTE_KW_DEPLOY"
     "sudo touch '$INSTALLED_KERNELS_PATH'"
     "Removing: $kernel_name"
   )
@@ -499,7 +499,7 @@ function test_remove_managed_kernel_local()
   for file in ${boot_files[@]}; do
     cmd_sequence["$index"]="Removing: $file"
     ((index++))
-    cmd_sequence["$index"]="sudo -E rm $file"
+    cmd_sequence["$index"]="sudo --preserve-env rm $file"
     ((index++))
   done
 
@@ -549,7 +549,7 @@ function test_do_uninstall_valid_path_cmd_sequence()
     return
   }
 
-  mkdir -p "$prefix"
+  mkdir --parents "$prefix"
   mk_fake_remote_system "$prefix" "$kernel_name"
 
   # Composing command
@@ -568,7 +568,7 @@ function test_do_uninstall_valid_path_cmd_sequence()
     "Removing: $initramfs_tools_var_path"
     "rm $initramfs_tools_var_path"
     "Removing: $modules_lib_path"
-    "rm -rf $modules_lib_path"
+    "rm --recursive --force $modules_lib_path"
   )
 
   for cmd in "${cmd_sequence_last_part[@]}"; do
@@ -596,10 +596,10 @@ function test_do_uninstall_partial_cmd_sequence()
   local index=0
   local boot_files
 
-  mkdir -p "$prefix"
+  mkdir --parents "$prefix"
   mk_fake_remote_system "$prefix" "$kernel_name"
 
-  rm -rf "$modules_lib_path"
+  rm --recursive --force "$modules_lib_path"
 
   # Composing command
   boot_files=$(find "${TARGET_PATH}/boot/" -name "*${kernel_name}*" | sort)
@@ -651,7 +651,7 @@ function test_install_modules()
   # Test preparation
   mk_fake_tar_file_to_deploy "$PWD"
   LIB_MODULES_PATH="${KW_DEPLOY_TMP_FILE}${LIB_MODULES_PATH}"
-  mkdir -p "$LIB_MODULES_PATH"
+  mkdir --parents "$LIB_MODULES_PATH"
 
   install_modules 'remote'
 
@@ -688,7 +688,7 @@ function test_install_kernel_remote()
 
   # Check standard remote kernel installation
   declare -a cmd_sequence=(
-    "rm -rf ${KW_DEPLOY_TMP_FILE}/kw_pkg"
+    "rm --recursive --force ${KW_DEPLOY_TMP_FILE}/kw_pkg"
     "tar --touch --auto-compress --extract --file='${KW_DEPLOY_TMP_FILE}/${name}.kw.tar' --directory='${SHUNIT_TMPDIR}/tmp/kw' --no-same-owner"
     "rsync --archive ${SHUNIT_TMPDIR}/tmp/kw/kw_pkg/modules/lib/modules/* /lib/modules"
     "cp ${PWD}/boot/vmlinuz-${name} ${PWD}/boot/vmlinuz-${name}.old"
@@ -696,26 +696,26 @@ function test_install_kernel_remote()
     "cp ${SHUNIT_TMPDIR}/tmp/kw/kw_pkg/bzImage /boot/"
     'generate_debian_temporary_root_file_system TEST_MODE test remote GRUB'
     'run_bootloader_update_mock'
-    "grep -Fxq ${name} ${INSTALLED_KERNELS_PATH}"
+    "grep --fixed-strings --line-regexp --quiet ${name} ${INSTALLED_KERNELS_PATH}"
     'reboot'
   )
 
   # Check remote kernel installation with dtb
   declare -a cmd_sequence2=(
-    "rm -rf ${KW_DEPLOY_TMP_FILE}/kw_pkg"
+    "rm --recursive --force ${KW_DEPLOY_TMP_FILE}/kw_pkg"
     "tar --touch --auto-compress --extract --file='${KW_DEPLOY_TMP_FILE}/${name}.kw.tar' --directory='${SHUNIT_TMPDIR}/tmp/kw' --no-same-owner"
     "rsync --archive ${SHUNIT_TMPDIR}/tmp/kw/kw_pkg/modules/lib/modules/* /lib/modules"
     "cp ${SHUNIT_TMPDIR}/tmp/kw/kw_pkg/config-test /boot/"
     "cp ${SHUNIT_TMPDIR}/tmp/kw/kw_pkg/bzImage /boot/"
     'generate_debian_temporary_root_file_system TEST_MODE test remote GRUB'
     'run_bootloader_update_mock'
-    "grep -Fxq ${name} ${INSTALLED_KERNELS_PATH}"
+    "grep --fixed-strings --line-regexp --quiet ${name} ${INSTALLED_KERNELS_PATH}"
     'reboot'
   )
 
   # Test preparation
   mk_fake_tar_file_to_deploy "$PWD" "$KW_DEPLOY_TMP_FILE" "$name"
-  mkdir -p "${KW_DEPLOY_TMP_FILE}/kw_pkg"
+  mkdir --parents "${KW_DEPLOY_TMP_FILE}/kw_pkg"
   touch "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
   {
     printf 'kernel_name=%s\n' "$name"
@@ -748,7 +748,7 @@ function test_install_kernel_local()
   local architecture='x86_64'
   local target='local'
   local flag='TEST_MODE'
-  local sudo_cmd='sudo -E'
+  local sudo_cmd='sudo --preserve-env'
   local path_prefix=''
   local output
 
@@ -759,7 +759,7 @@ function test_install_kernel_local()
 
   # Test preparation
   mk_fake_tar_file_to_deploy "$PWD" "$KW_DEPLOY_TMP_FILE"
-  mkdir -p "${KW_DEPLOY_TMP_FILE}/kw_pkg"
+  mkdir --parents "${KW_DEPLOY_TMP_FILE}/kw_pkg"
   touch "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
   {
     printf 'kernel_name=%s\n' "$name"
@@ -769,15 +769,15 @@ function test_install_kernel_local()
 
   # Check standard remote kernel installation
   declare -a cmd_sequence=(
-    "rm -rf ${KW_DEPLOY_TMP_FILE}/kw_pkg"
+    "rm --recursive --force ${KW_DEPLOY_TMP_FILE}/kw_pkg"
     "tar --touch --auto-compress --extract --file='${KW_DEPLOY_TMP_FILE}/${name}.kw.tar' --directory='${SHUNIT_TMPDIR}/tmp/kw' --no-same-owner"
-    "sudo -E rsync --archive ${SHUNIT_TMPDIR}/tmp/kw/kw_pkg/modules/lib/modules/* /lib/modules"
-    "sudo -E cp ${KW_DEPLOY_TMP_FILE}/kw_pkg/config-test /boot/"
-    "sudo -E cp ${KW_DEPLOY_TMP_FILE}/kw_pkg/${kernel_image_name} /boot/"
+    "sudo --preserve-env rsync --archive ${SHUNIT_TMPDIR}/tmp/kw/kw_pkg/modules/lib/modules/* /lib/modules"
+    "sudo --preserve-env cp ${KW_DEPLOY_TMP_FILE}/kw_pkg/config-test /boot/"
+    "sudo --preserve-env cp ${KW_DEPLOY_TMP_FILE}/kw_pkg/${kernel_image_name} /boot/"
     'generate_debian_temporary_root_file_system TEST_MODE test local GRUB'
     'run_bootloader_update_mock'
-    "sudo -E grep -Fxq ${name} ${INSTALLED_KERNELS_PATH}"
-    'sudo -E reboot'
+    "sudo --preserve-env grep --fixed-strings --line-regexp --quiet ${name} ${INSTALLED_KERNELS_PATH}"
+    'sudo --preserve-env reboot'
   )
 
   output=$(install_kernel 'debian' "$reboot" "$target" '' 'TEST_MODE')
@@ -826,7 +826,7 @@ function test_distro_deploy_setup_local()
 
   output=$(distro_deploy_setup 'TEST_MODE' 2)
 
-  expected_cmd="sudo -E ${package_manager_cmd} ${required_packages[*]} "
+  expected_cmd="sudo --preserve-env ${package_manager_cmd} ${required_packages[*]} "
 
   assert_equals_helper 'Install packages' "$LINENO" "$expected_cmd" "$output"
 }
@@ -914,7 +914,7 @@ function test_is_filesystem_writable()
 
   AB_ROOTFS_PARTITION="${PWD}/kw"
   output=$(is_filesystem_writable 'ext4' 'TEST_MODE')
-  expected_cmd="tune2fs -l '$AB_ROOTFS_PARTITION' | grep -q '^Filesystem features: .*read-only.*$'"
+  expected_cmd="tune2fs -l '$AB_ROOTFS_PARTITION' | grep --quiet '^Filesystem features: .*read-only.*$'"
   assert_equals_helper 'Expected tune2fs command' "$LINENO" "$expected_cmd" "$output"
 }
 
@@ -947,7 +947,7 @@ function test_make_root_partition_writable()
   )"
   expected_sequence=(
     "tune2fs -O ^read-only ${AB_ROOTFS_PARTITION}"
-    'mount -o remount,rw /'
+    'mount --options remount,rw /'
   )
   compare_command_sequence 'Wrong sequence' "$LINENO" 'expected_sequence' "$output"
 
@@ -965,7 +965,7 @@ function test_make_root_partition_writable()
     make_root_partition_writable 'TEST_MODE'
   )"
   expected_sequence=(
-    'mount -o remount,rw /'
+    'mount --options remount,rw /'
     'btrfs property set / ro false'
   )
   compare_command_sequence 'Wrong sequence' "$LINENO" 'expected_sequence' "$output"
@@ -999,7 +999,7 @@ function test_uncompress_kw_package_check_invalid_path()
 function test_parse_kw_package_metadata()
 {
   # Prepare fake kw.pkg.info
-  mkdir -p "${KW_DEPLOY_TMP_FILE}/kw_pkg"
+  mkdir --parents "${KW_DEPLOY_TMP_FILE}/kw_pkg"
   touch "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
   printf 'kernel_name=test\n' > "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"
   printf 'kernel_binary_image_file=vmlinuz-test\n' >> "${KW_DEPLOY_TMP_FILE}/kw_pkg/kw.pkg.info"

--- a/tests/unit/plugins/kernel_install/utils_test.sh
+++ b/tests/unit/plugins/kernel_install/utils_test.sh
@@ -34,8 +34,8 @@ function oneTimeSetUp()
 
   . ./src/plugins/kernel_install/utils.sh --source-only
 
-  REMOTE_KW_DEPLOY="$PWD/tests/unit/samples"
-  INSTALLED_KERNELS_PATH="$REMOTE_KW_DEPLOY/INSTALLED_KERNELS"
+  REMOTE_KW_DEPLOY="${PWD}/tests/unit/samples"
+  INSTALLED_KERNELS_PATH="${REMOTE_KW_DEPLOY}/INSTALLED_KERNELS"
 }
 
 function oneTimeTearDown()
@@ -55,14 +55,14 @@ function setUp()
   printf '\n%s' '5.6.0-rc2-AMDGPU+' >> "$INSTALLED_KERNELS_PATH"
 
   # Replace KW_DEPLOY_TMP_FILE
-  test_tmp_file="$SHUNIT_TMPDIR/tmp/kw"
-  REMOTE_KW_DEPLOY="$SHUNIT_TMPDIR/opt/kw"
+  test_tmp_file="${SHUNIT_TMPDIR}/tmp/kw"
+  REMOTE_KW_DEPLOY="${SHUNIT_TMPDIR}/opt/kw"
   KW_DEPLOY_TMP_FILE="$test_tmp_file"
   mkdir --parents "$test_tmp_file"
 
   # Mock variables
-  KW_PLUGINS_DIR="$PWD/src/plugins"
-  REMOTE_KW_DEPLOY="$KW_PLUGINS_DIR/kernel_install"
+  KW_PLUGINS_DIR="${PWD}/src/plugins"
+  REMOTE_KW_DEPLOY="${KW_PLUGINS_DIR}/kernel_install"
 }
 
 function tearDown()
@@ -137,7 +137,7 @@ function test_human_list_installed_kernels()
     {
       return 0
     }
-    list_installed_kernels 'TEST_MODE' '0' '' "$SHUNIT_TMPDIR"
+    list_installed_kernels 'TEST_MODE' '0' '' "${SHUNIT_TMPDIR}"
   )"
 
   compare_command_sequence '' "$LINENO" 'expected_out' "$output"
@@ -159,7 +159,7 @@ function test_command_list_installed_kernels()
     {
       return 0
     }
-    list_installed_kernels 'TEST_MODE' '1' '' "$SHUNIT_TMPDIR"
+    list_installed_kernels 'TEST_MODE' '1' '' "${SHUNIT_TMPDIR}"
   )"
 
   compare_command_sequence '' "$LINENO" 'expected_out' "$output"
@@ -183,7 +183,7 @@ function test_list_unmanaged_kernels()
     {
       return 0
     }
-    list_installed_kernels 'TEST_MODE' '1' '1' "$SHUNIT_TMPDIR"
+    list_installed_kernels 'TEST_MODE' '1' '1' "${SHUNIT_TMPDIR}"
   )"
   compare_command_sequence '' "$LINENO" 'expected' "$output"
 }
@@ -268,7 +268,7 @@ function test_process_installed_kernels()
 function test_kernel_uninstall_regex_one_kernel()
 {
   local kernel_name='5.5.0-rc2-VKMS+'
-  local mkinitcpio_d_path_1="etc/mkinitcpio.d/$kernel_name.preset"
+  local mkinitcpio_d_path_1="etc/mkinitcpio.d/${kernel_name}.preset"
   local grub_cfg_path="${TARGET_PATH}/boot/grub/grub.cfg"
   local output
   local boot_files
@@ -305,7 +305,7 @@ function test_kernel_uninstall_regex_one_kernel()
   compare_command_sequence '' "$LINENO" 'cmd_sequence' "$output"
 
   cd "$TEST_ROOT_PATH" || {
-    fail "($LINENO) It was not possible to move back from temp directory"
+    fail "(${LINENO}) It was not possible to move back from temp directory"
     return
   }
 }
@@ -322,7 +322,7 @@ function test_kernel_uninstall_regex_two_kernels()
 
   cd "$SHUNIT_TMPDIR" || {
 
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
@@ -344,7 +344,7 @@ function test_kernel_uninstall_regex_two_kernels()
   cmd_sequence["$((index++))"]="Can't find ${TARGET_PATH}/${mkinitcpio_d_path_1}"
   cmd_sequence["$((index++))"]="Can't find ${TARGET_PATH}/var/lib/initramfs-tools/${kernel_name_1}"
   cmd_sequence["$((index++))"]="Can't find ${TARGET_PATH}/lib/modules/${kernel_name_1}"
-  cmd_sequence["$((index++))"]="sudo sed -i '/${kernel_name_1}/d' '$INSTALLED_KERNELS_PATH'"
+  cmd_sequence["$((index++))"]="sudo sed -i '/${kernel_name_1}/d' '${INSTALLED_KERNELS_PATH}'"
   cmd_sequence["$((index++))"]="Removing: ${kernel_name_2}"
 
   boot_files=$(find "${TARGET_PATH}/boot/" -name "*${kernel_name_2}*" | sort)
@@ -371,7 +371,7 @@ function test_kernel_uninstall_regex_two_kernels()
   compare_command_sequence '' "$LINENO" 'cmd_sequence' "$output"
 
   cd "$TEST_ROOT_PATH" || {
-    fail "($LINENO) It was not possible to move back from temp directory"
+    fail "(${LINENO}) It was not possible to move back from temp directory"
     return
   }
 }
@@ -457,13 +457,13 @@ function test_remove_managed_kernel_local()
   local target='xpto'
   local prefix="./test"
   local kernel_name='5.5.0-rc2-VKMS+'
-  local kernel_boot_img_path="/boot/vmlinuz-$target"
-  local initrd_boot_path="/boot/initrd.img-$target"
-  local modules_lib_path="/lib/modules/$target"
-  local initramfs_tools_var_path="/var/lib/initramfs-tools/$target"
-  local initramfs_boot_img_path="/boot/initramfs-$kernel_name.img"
-  local initramfs_fallback_boot_img_path="/boot/initramfs-$kernel_name-fallback.img"
-  local mkinitcpio_d_path="etc/mkinitcpio.d/$kernel_name.preset"
+  local kernel_boot_img_path="/boot/vmlinuz-${target}"
+  local initrd_boot_path="/boot/initrd.img-${target}"
+  local modules_lib_path="/lib/modules/${target}"
+  local initramfs_tools_var_path="/var/lib/initramfs-tools/${target}"
+  local initramfs_boot_img_path="/boot/initramfs-${kernel_name}.img"
+  local initramfs_fallback_boot_img_path="/boot/initramfs-${kernel_name}-fallback.img"
+  local mkinitcpio_d_path="etc/mkinitcpio.d/${kernel_name}.preset"
   local output
   local boot_files
   local index
@@ -478,18 +478,18 @@ function test_remove_managed_kernel_local()
 
   # Composing command sequence list
   local -a cmd_sequence=(
-    "sudo mkdir --parents $REMOTE_KW_DEPLOY"
-    "sudo touch '$INSTALLED_KERNELS_PATH'"
-    "Removing: $kernel_name"
+    "sudo mkdir --parents ${REMOTE_KW_DEPLOY}"
+    "sudo touch '${INSTALLED_KERNELS_PATH}'"
+    "Removing: ${kernel_name}"
   )
 
   index=${#cmd_sequence[@]}
 
   local -a cmd_last_part=(
-    "Can't find ${TARGET_PATH}//$mkinitcpio_d_path"
-    "Can't find ${TARGET_PATH}//var/lib/initramfs-tools/$kernel_name"
-    "Can't find ${TARGET_PATH}//lib/modules/$kernel_name"
-    "sudo sed -i '/$kernel_name/d' '$INSTALLED_KERNELS_PATH'"
+    "Can't find ${TARGET_PATH}//${mkinitcpio_d_path}"
+    "Can't find ${TARGET_PATH}//var/lib/initramfs-tools/${kernel_name}"
+    "Can't find ${TARGET_PATH}//lib/modules/${kernel_name}"
+    "sudo sed -i '/${kernel_name}/d' '${INSTALLED_KERNELS_PATH}'"
     'run_bootloader_update_mock'
   )
 
@@ -497,9 +497,9 @@ function test_remove_managed_kernel_local()
 
   # shellcheck disable=SC2068
   for file in ${boot_files[@]}; do
-    cmd_sequence["$index"]="Removing: $file"
+    cmd_sequence["$index"]="Removing: ${file}"
     ((index++))
-    cmd_sequence["$index"]="sudo --preserve-env rm $file"
+    cmd_sequence["$index"]="sudo --preserve-env rm ${file}"
     ((index++))
   done
 
@@ -509,7 +509,7 @@ function test_remove_managed_kernel_local()
   done
 
   # Check
-  output=$(kernel_uninstall 0 'local' '5.5.0-rc2-VKMS+' 'TEST_MODE' 1 "$SHUNIT_TMPDIR/")
+  output=$(kernel_uninstall 0 'local' '5.5.0-rc2-VKMS+' 'TEST_MODE' 1 "${SHUNIT_TMPDIR}/")
   compare_command_sequence '' "$LINENO" 'cmd_sequence' "$output"
 }
 
@@ -523,9 +523,9 @@ function test_do_uninstall_invalid_path_cmd_sequence()
   local output
 
   declare -a cmd_sequence=(
-    "Can't find $mkinitcpio_d_path"
-    "Can't find $initramfs_tools_var_path"
-    "Can't find $modules_lib_path"
+    "Can't find ${mkinitcpio_d_path}"
+    "Can't find ${initramfs_tools_var_path}"
+    "Can't find ${modules_lib_path}"
   )
 
   output=$(do_uninstall 'remote' "$kernel_name" "$prefix" 'TEST_MODE')
@@ -545,7 +545,7 @@ function test_do_uninstall_valid_path_cmd_sequence()
 
   # TEST 2: Valid paths
   cd "$SHUNIT_TMPDIR" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
@@ -563,12 +563,12 @@ function test_do_uninstall_valid_path_cmd_sequence()
   done
 
   declare -a cmd_sequence_last_part=(
-    "Removing: $mkinitcpio_d_path"
-    "rm $mkinitcpio_d_path"
-    "Removing: $initramfs_tools_var_path"
-    "rm $initramfs_tools_var_path"
-    "Removing: $modules_lib_path"
-    "rm --recursive --force $modules_lib_path"
+    "Removing: ${mkinitcpio_d_path}"
+    "rm ${mkinitcpio_d_path}"
+    "Removing: ${initramfs_tools_var_path}"
+    "rm ${initramfs_tools_var_path}"
+    "Removing: ${modules_lib_path}"
+    "rm --recursive --force ${modules_lib_path}"
   )
 
   for cmd in "${cmd_sequence_last_part[@]}"; do
@@ -580,7 +580,7 @@ function test_do_uninstall_valid_path_cmd_sequence()
   compare_command_sequence '' "$LINENO" 'cmd_sequence' "$output"
 
   cd "$TEST_ROOT_PATH" || {
-    fail "($LINENO) It was not possible to move back from temp directory"
+    fail "(${LINENO}) It was not possible to move back from temp directory"
     return
   }
 }
@@ -612,11 +612,11 @@ function test_do_uninstall_partial_cmd_sequence()
   done
 
   declare -a cmd_sequence_last_part=(
-    "Removing: $mkinitcpio_d_path"
-    "rm $mkinitcpio_d_path"
-    "Removing: $initramfs_tools_var_path"
-    "rm $initramfs_tools_var_path"
-    "Can't find $modules_lib_path"
+    "Removing: ${mkinitcpio_d_path}"
+    "rm ${mkinitcpio_d_path}"
+    "Removing: ${initramfs_tools_var_path}"
+    "rm ${initramfs_tools_var_path}"
+    "Can't find ${modules_lib_path}"
   )
 
   for cmd in "${cmd_sequence_last_part[@]}"; do
@@ -628,7 +628,7 @@ function test_do_uninstall_partial_cmd_sequence()
   compare_command_sequence '' "$LINENO" 'cmd_sequence' "$output"
 
   cd "$TEST_ROOT_PATH" || {
-    fail "($LINENO) It was not possible to move back from temp directory"
+    fail "(${LINENO}) It was not possible to move back from temp directory"
     return
   }
 }
@@ -644,7 +644,7 @@ function test_install_modules()
   assert_equals_helper 'We did not find required files' "$LINENO" 2 "$?"
 
   cd "$test_tmp_file" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
@@ -655,11 +655,11 @@ function test_install_modules()
 
   install_modules 'remote'
 
-  assertTrue "($LINENO): Expected kw_pkg" '[[ -f "${LIB_MODULES_PATH}/something_1" ]]'
-  assertTrue "($LINENO): Expected kw_pkg" '[[ -f "${LIB_MODULES_PATH}/something_2" ]]'
+  assertTrue "(${LINENO}): Expected kw_pkg" '[[ -f "${LIB_MODULES_PATH}/something_1" ]]'
+  assertTrue "(${LINENO}): Expected kw_pkg" '[[ -f "${LIB_MODULES_PATH}/something_2" ]]'
 
   cd "$TEST_ROOT_PATH" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
@@ -682,7 +682,7 @@ function test_install_kernel_remote()
   assert_equals_helper 'Test invalid name' "$LINENO" 2 "$ret"
 
   cd "$SHUNIT_TMPDIR" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
@@ -735,7 +735,7 @@ function test_install_kernel_remote()
   compare_command_sequence '' "$LINENO" 'cmd_sequence2' "$output"
 
   cd "$TEST_ROOT_PATH" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 }
@@ -753,7 +753,7 @@ function test_install_kernel_local()
   local output
 
   cd "$SHUNIT_TMPDIR" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
@@ -784,7 +784,7 @@ function test_install_kernel_local()
   compare_command_sequence '' "$LINENO" 'cmd_sequence' "$output"
 
   cd "$TEST_ROOT_PATH" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 }
@@ -807,7 +807,7 @@ function test_distro_deploy_setup()
   )
   output=$(distro_deploy_setup 'TEST_MODE')
 
-  expected_cmd="$package_manager_cmd ${required_packages[*]} "
+  expected_cmd="${package_manager_cmd} ${required_packages[*]} "
 
   assert_equals_helper 'Install packages' "$LINENO" "$expected_cmd" "$output"
 }
@@ -974,7 +974,7 @@ function test_make_root_partition_writable()
 function test_uncompress_kw_package()
 {
   cd "$SHUNIT_TMPDIR" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 
@@ -982,10 +982,10 @@ function test_uncompress_kw_package()
   mk_fake_tar_file_to_deploy "$PWD" "$KW_DEPLOY_TMP_FILE"
 
   uncompress_kw_package
-  assertTrue "($LINENO): Expected kw_pkg" '[[ -d "${KW_DEPLOY_TMP_FILE}/kw_pkg" ]]'
+  assertTrue "(${LINENO}): Expected kw_pkg" '[[ -d "${KW_DEPLOY_TMP_FILE}/kw_pkg" ]]'
 
   cd "$TEST_ROOT_PATH" || {
-    fail "($LINENO) It was not possible to move to temporary directory"
+    fail "(${LINENO}) It was not possible to move to temporary directory"
     return
   }
 }
@@ -993,7 +993,7 @@ function test_uncompress_kw_package()
 function test_uncompress_kw_package_check_invalid_path()
 {
   uncompress_kw_package '/somethig/xpto/abc/kw.pkg.tar'
-  assert_equals_helper 'Invalid path' "($LINENO)" 2 "$?"
+  assert_equals_helper 'Invalid path' "(${LINENO})" 2 "$?"
 }
 
 function test_parse_kw_package_metadata()
@@ -1010,21 +1010,21 @@ function test_parse_kw_package_metadata()
   arch=${kw_package_metadata['architecture']}
   kernel_image_name=${kw_package_metadata['kernel_binary_image_file']}
 
-  assert_equals_helper 'Wrong kernel name' "($LINENO)" 'test' "${kw_package_metadata['kernel_name']}"
-  assert_equals_helper 'Wrong architecture' "($LINENO)" 'x86_64' "${kw_package_metadata['architecture']}"
-  assert_equals_helper 'Wrong binary image name' "($LINENO)" 'vmlinuz-test' "${kw_package_metadata['kernel_binary_image_file']}"
+  assert_equals_helper 'Wrong kernel name' "(${LINENO})" 'test' "${kw_package_metadata['kernel_name']}"
+  assert_equals_helper 'Wrong architecture' "(${LINENO})" 'x86_64' "${kw_package_metadata['architecture']}"
+  assert_equals_helper 'Wrong binary image name' "(${LINENO})" 'vmlinuz-test' "${kw_package_metadata['kernel_binary_image_file']}"
 }
 
 function test_parse_kw_package_metadata_invalid_path()
 {
   parse_kw_package_metadata '/an/invalid/folder'
-  assert_equals_helper 'Expected an error with invalid path' "($LINENO)" 22 "$?"
+  assert_equals_helper 'Expected an error with invalid path' "(${LINENO})" 22 "$?"
 }
 
 function test_parse_kw_package_metadata_no_pkg_info()
 {
   parse_kw_package_metadata ''
-  assert_equals_helper 'Expected an error due to the lack of info file' "($LINENO)" 22 "$?"
+  assert_equals_helper 'Expected an error due to the lack of info file' "(${LINENO})" 22 "$?"
 }
 
 invoke_shunit


### PR DESCRIPTION
I'm preparing a deploy refactor, but before that, I need to apply some basic kw code style to avoid noise in the PR review. This PR basically applies these two code-style rules to deploy related files:

- https://kworkflow.org/content/codingstyle.html#avoid-short-options
- https://kworkflow.org/content/codingstyle.html#string-concatenation