### PR TITLE
plugins/drm: fix syntax error in local gui_control

### DIFF
--- a/src/plugins/subsystems/drm/drm.sh
+++ b/src/plugins/subsystems/drm/drm.sh
@@ -264,8 +264,8 @@ function gui_control()
 
   case "$target" in
     2) # LOCAL TARGET
-      gui_control_cmd="sudo ${gui_control_cmd}"
-      bind_control_cmd="sudo ${bind_control_cmd}"
+      gui_control_cmd="sudo -- sh -c '${gui_control_cmd}'"
+      bind_control_cmd="sudo -- sh -c '${bind_control_cmd}'"
       cmd_manager "$flag" "$gui_control_cmd"
       cmd_manager "$flag" "$bind_control_cmd"
       ;;

--- a/tests/unit/drm_plugin_test.sh
+++ b/tests/unit/drm_plugin_test.sh
@@ -346,16 +346,16 @@ function test_gui_control_local()
   configurations[gui_off_after_reboot]="$gui_off_after_reboot_cmd"
 
   declare -a expected_cmd_seq=(
-    "sudo ${gui_on_cmd}"
-    "sudo ${bind_cmd}"
+    "sudo -- sh -c '${gui_on_cmd}'"
+    "sudo -- sh -c '${bind_cmd}'"
   )
 
   output=$(gui_control 'ON' '2' '' 'TEST_MODE')
   compare_command_sequence '' "$LINENO" 'expected_cmd_seq' "$output"
 
   declare -a expected_cmd_seq=(
-    "sudo ${gui_off_cmd}"
-    "sudo ${unbind_cmd}"
+    "sudo -- sh -c '${gui_off_cmd}'"
+    "sudo -- sh -c '${unbind_cmd}'"
   )
 
   output=$(gui_control 'OFF' '2' '' 'TEST_MODE')
@@ -363,8 +363,8 @@ function test_gui_control_local()
 
   # Test GUI ON after reboot
   declare -a expected_cmd_seq=(
-    "sudo ${gui_on_after_reboot_cmd}"
-    "sudo ${bind_cmd}"
+    "sudo -- sh -c '${gui_on_after_reboot_cmd}'"
+    "sudo -- sh -c '${bind_cmd}'"
   )
 
   output=$(gui_control 'ON_AFTER_REBOOT' '2' '' 'TEST_MODE')
@@ -372,8 +372,8 @@ function test_gui_control_local()
 
   # Test GUI OFF after reboot
   declare -a expected_cmd_seq=(
-    "sudo ${gui_off_after_reboot_cmd}"
-    "sudo ${unbind_cmd}"
+    "sudo -- sh -c '${gui_off_after_reboot_cmd}'"
+    "sudo -- sh -c '${unbind_cmd}'"
   )
 
   output=$(gui_control 'OFF_AFTER_REBOOT' '2' '' 'TEST_MODE')


### PR DESCRIPTION
There is a syntax error when running `kw drm --gui-(on/off)` for local target:

$ kw drm --gui-off --verbose --local
sudo systemctl isolate multi-user.target
sudo for i in /sys/class/vtconsole/*/bind; do printf "%s\n" 0 > $i; done; sleep 0.5 /.local/lib/kw/lib/kwlib.sh: eval: line 122: syntax error near unexpected token `do' /.local/lib/kw/lib/kwlib.sh: eval: line 122: `sudo for i in /sys/class/vtconsole/*/bind; do printf "%s\n" 0 > $i; done; sleep 0.5'

The cause is that sudo prefix is only applied to the first command in a sequence of multiple commands separated by semicolons. Fix that by using `sudo -- sh -c '$cmd'`, which ensures multiple commands are executed as sudo.