### PR TITLE
src: plugins: kernel_install: uninstall: Skip intramfs images generation during uninstall

### DIFF
--- a/src/plugins/kernel_install/uninstall.sh
+++ b/src/plugins/kernel_install/uninstall.sh
@@ -83,7 +83,7 @@ function kernel_uninstall()
     update_bootloader "$flag" "$kernel" "$target" "$kernel_image_name" '' '' '' "$force"
 
     # Reboot
-    reboot_machine "$reboot" "$target" "$flag"  
+    reboot_machine "$reboot" "$target" "$flag"
   fi
 }
 


### PR DESCRIPTION
During uninstallation, kw unnecessarily generates multiple intramfs images. This is wasteful since these images serve no purpose for an uninstallation.

The solution is to remove the @root_file_system parameter from update_bootloader calls, allowing bootloader to update without generating unnecessaries initramfs images.

Closes: #1212 

Signed-off-by: Lucas Antonio <lucasantonio.santos@usp.br>
 Co-developed-by: Nattan Ferreira <nattanferreira58@gmail.com>
 Signed-off-by: Nattan Ferreira <nattanferreira58@gmail.com>