### PR TITLE
Make kw bd accepts some arguments from kw b and kw d.

### DIFF
--- a/src/build_and_deploy.sh
+++ b/src/build_and_deploy.sh
@@ -17,22 +17,25 @@ function build_and_deploy_main()
     build_and_deploy_help "$1"
     exit 0
   fi
+  ##build and deploy flags
+  build_options=()
+  deploy_options=()
 
   parse_build_and_deploy_options "$@"
   if [[ "$?" -gt 0 ]]; then
-    complain "${options_values['ERROR']}"
+    complain "Invalid option: ${options_values['ERROR']}"
     build_and_deploy_help
     return 22 # EINVAL
   fi
 
-  build_kernel_main
+  build_kernel_main '' "${build_options[@]}"
   if [[ "$?" != 0 ]]; then
     complain 'kernel build failed\n'
     exit 22 # EINVAL
   fi
 
   # parameter 1 indicates that deploy is being called within kw bd context.
-  deploy_main 1 "$@"
+  deploy_main 1 "${deploy_options[@]}"
   if [[ "$?" != 0 ]]; then
     complain 'kernel deploy failed\n'
     exit 22 # EINVAL
@@ -42,25 +45,108 @@ function build_and_deploy_main()
 
 function parse_build_and_deploy_options()
 {
-  local long_options=''
-  local short_options=''
+  #build options
+  local long_options='help,ccache,cpu-scaling:,warnings::,save-log-to:,llvm,verbose,cflags:'
+  local short_options='h,S:,w::,s:'
+
+  # #deploy options
+  long_options+=',remote:,local,reboot,no-reboot,modules,force,setup,verbose,create-package,from-package:,boot-into-new-kernel-once'
+  short_options+=',r,m,f,v,p,F:,n'
 
   options="$(kw_parse "$short_options" "$long_options" "$@")"
   if [[ "$?" != 0 ]]; then
+
     options_values['ERROR']="$(kw_parse_get_errors 'kw bd' "$short_options" \
       "$long_options" "$@")"
     return 22 # EINVAL
   fi
 
-  eval "set -- ${options}"
-
   while [[ "$#" -gt 0 ]]; do
+
     case "$1" in
+      --help | -h)
+        # build_and_deply_help "$1"
+        build_and_deploy_help "$1"
+        exit
+        ;;
+      --cpu-scaling | -S)
+        build_options+=("$1" "$2")
+        shift 2
+        ;;
+      --ccache)
+        build_options+=("$1")
+        shift
+        ;;
+      --llvm)
+        build_options+=("$1")
+        shift
+        ;;
+      --cflags)
+        build_options+=("$1" "$2")
+        shift 2
+        ;;
+      --verbose)
+        build_options+=("$1")
+        deploy_options+=("$1")
+        shift
+        ;;
+      --warnings | -w)
+        # Handling optional parameter
+        if [[ "$2" =~ [0-9]+ ]]; then
+          build_options+=("$1" "$2")
+          shift 2
+        else
+          build_options+=("$1")
+          shift
+        fi
+        ;;
+      --save-log-to | -s)
+        build_options+=("$1" "$2")
+        shift 2
+        #after this line only deploy options
+        ;;
+      --remote)
+        deploy_options+=("$1" "$2")
+        shift 2
+        ;;
+      --local)
+        deploy_options+=("$1")
+        shift
+        ;;
+      --reboot | -r)
+        deploy_options+=("$1")
+        shift
+        ;;
+      --no-reboot)
+        deploy_options+=("$1")
+        shift
+        ;;
+      --modules | -m)
+        deploy_options+=("$1")
+        shift
+        ;;
+      --force | -f)
+        deploy_options+=("$1")
+        shift
+        ;;
+      --create-package | -p)
+        deploy_options+=("$1")
+        shift
+        ;;
+      --from-package | -F)
+        deploy_options+=("$1" "$2")
+        shift 2
+        ;;
+      --boot-into-new-kernel-once | -n)
+        deploy_options+=("$1")
+        shift
+        ;;
       --)
         shift
         ;;
       *)
-        shift
+        options_values['ERROR']="$1" #it is an invalid option
+        return 22                    # EINVAL
         ;;
     esac
   done


### PR DESCRIPTION
Previously, to build and deploy the kernel, users had to use kw bd, but it did not accept the same arguments as kw b and kw d, which was inconsistent and unintuitive.
this refactor ensures that kw bd now accepts alomost all the same arguments from kw b and kw d, providing a more coherent and flexible interface for users.
Closes : #1208

Following this feedback : https://github.com/kworkflow/kworkflow/pull/1215
The following options were not included:

--setup
--uninstall
--list
--ls-line
--list-all

--menu
--info
--doc
--clean
--full-cleanup
--from-sha