### PR TITLE
src: plugins: kernel_install: Fix unsintall in the raspberry pi

### DIFF
--- a/src/plugins/kernel_install/utils.sh
+++ b/src/plugins/kernel_install/utils.sh
@@ -207,7 +207,7 @@ function list_all_kernels()
 
   [[ "$flag" == 'VERBOSE' ]] && printf '%s\n' "$cmd_get_kernels"
 
-  cmd_get_kernels="find ${prefix}/boot/ -name '*linuz*' -printf '%f\n' | sort --dictionary"
+  cmd_get_kernels="find ${prefix}/boot/ -regextype posix-egrep -regex '.*(linuz|kernel).*' -printf '%f\n' | sort --dictionary"
 
   output=$(cmd_manager 'SILENT' "$cmd_get_kernels")
   readarray -t raw_kernel_name_list <<< "$output"


### PR DESCRIPTION
After the code refactoring, the uninstall feature stopped working on the Raspberry Pi because the kernel name adopted by Pi is slightly different from other distros. This commit updates the regex pattern to account for the PI kernel name.