### PR TITLE
Add a unique suffix to kw environments

### DIFF
--- a/src/kw_env.sh
+++ b/src/kw_env.sh
@@ -109,7 +109,7 @@ function validate_env_before_switch()
 function use_target_env()
 {
   local target_env="${options_values['USE']}"
-  local encoded_target_env=$(get_env_name_encoded_with_pwd "$target_env")
+  local encoded_target_env=$(encode_env_name_with_pwd "$target_env")
   local local_kw_configs="${PWD}/.kw"
   local tmp_trash
   local cmd
@@ -197,7 +197,7 @@ function create_new_env()
   local local_kw_build_config="${local_kw_configs}/build.config"
   local local_kw_deploy_config="${local_kw_configs}/deploy.config"
   local env_name=${options_values['CREATE']}
-  local encoded_env_name=$(get_env_name_encoded_with_pwd "$env_name")
+  local encoded_env_name=$(encode_env_name_with_pwd "$env_name")
   local cache_build_path="$KW_CACHE_DIR"
   local current_env_name
   local output
@@ -280,7 +280,7 @@ function destroy_env()
   local cache_build_path="$KW_CACHE_DIR"
   local current_env
   local env_name=${options_values['DESTROY']}
-  local encoded_env_name=$(get_env_name_encoded_with_pwd "$env_name")
+  local encoded_env_name=$(encode_env_name_with_pwd "$env_name")
   local cmd
 
   flag=${flag:-'SILENT'}

--- a/src/lib/kwlib.sh
+++ b/src/lib/kwlib.sh
@@ -695,6 +695,25 @@ function get_current_env_name()
   return "$ret"
 }
 
+# This function returns "${current_env}-base64(${PWD})".
+#
+# @env_name: The name of the environment to encode
+#
+# Return:
+# Returns 0 and prints ${current_env}-base64(${PWD}) if env_name is provided.
+# Returns 1 if env_name is not provided.
+get_env_name_encoded_with_pwd() {
+  local env_name="$1"
+
+  if [[ -z "$env_name" ]]; then
+    return 1
+  fi
+
+  local encoded_pwd=$(printf '%s' "$PWD" | base64)
+
+  printf '%s-%s' "$env_name" "$encoded_pwd"
+}
+
 # A common task is to remove files/directories. This function is a predicate
 # to check if a given path is safe to remove (e.g. is not the '/')
 #

--- a/src/lib/kwlib.sh
+++ b/src/lib/kwlib.sh
@@ -714,6 +714,25 @@ get_env_name_encoded_with_pwd() {
   printf '%s-%s' "$env_name" "$encoded_pwd"
 }
 
+# Extracts the environment name from a string of the format "env_name-base64(PWD)".
+# Assumes env_name may contain hyphens.
+#
+# @encoded: The encoded string (e.g., "my-env-L2hvbWUvYXBvbG8y")
+#
+# Return:
+# Returns 0 if successful, 1 if input is empty or malformed.
+# Prints the env_name (everything before the last hyphen) if successful.
+decode_env_name_with_pwd() {
+  local encoded_env_name="$1"
+
+  if [[ -z "$encoded_env_name" || "$encoded_env_name" != *-* ]]; then
+    return 1
+  fi
+
+  local env_name="${encoded_env_name%-*}"
+  printf '%s' "$env_name"
+}
+
 # A common task is to remove files/directories. This function is a predicate
 # to check if a given path is safe to remove (e.g. is not the '/')
 #

--- a/src/lib/kwlib.sh
+++ b/src/lib/kwlib.sh
@@ -702,7 +702,7 @@ function get_current_env_name()
 # Return:
 # Returns 0 and prints ${current_env}-base64(${PWD}) if env_name is provided.
 # Returns 1 if env_name is not provided.
-get_env_name_encoded_with_pwd() {
+encode_env_name_with_pwd() {
   local env_name="$1"
 
   if [[ -z "$env_name" ]]; then

--- a/tests/unit/kw_env_test.sh
+++ b/tests/unit/kw_env_test.sh
@@ -52,16 +52,16 @@ function test_create_new_env_create_multiple_envs_from_current_configs()
 
   # Other checks
   # 1. Do we have the env folder?
-  new_env_name=$(find ".kw/${ENV_DIR}" -type d -name 'xpto')
-  assertEquals "($LINENO) We did not find the new folder name" ".kw/${ENV_DIR}/xpto" "$new_env_name"
+  new_env_name=$(find ".kw/${ENV_DIR}" -type d -name $(get_env_name_encoded_with_pwd 'xpto'))
+  assertEquals "($LINENO) We did not find the new folder name" ".kw/${ENV_DIR}/$(get_env_name_encoded_with_pwd 'xpto')" "$new_env_name"
 
-  new_env_name=$(find ".kw/${ENV_DIR}" -type d -name 'abc')
-  assertEquals "($LINENO) We did not find the new folder name" ".kw/${ENV_DIR}/abc" "$new_env_name"
+  new_env_name=$(find ".kw/${ENV_DIR}" -type d -name $(get_env_name_encoded_with_pwd 'abc'))
+  assertEquals "($LINENO) We did not find the new folder name" ".kw/${ENV_DIR}/$(get_env_name_encoded_with_pwd 'abc')" "$new_env_name"
 
   # 2. Check for config files
   for config in "${config_file_list[@]}"; do
-    assertTrue "${LINENO}: ${config} config not find " '[[ -f .kw/${ENV_DIR}/xpto/${config}.config ]]'
-    assertTrue "${LINENO}: ${config} config not find " '[[ -f .kw/${ENV_DIR}/abc/${config}.config ]]'
+    assertTrue "${LINENO}: ${config} config not find " '[[ -f .kw/${ENV_DIR}/$(get_env_name_encoded_with_pwd "xpto")/${config}.config ]]'
+    assertTrue "${LINENO}: ${config} config not find " '[[ -f .kw/${ENV_DIR}/$(get_env_name_encoded_with_pwd "abc")/${config}.config ]]'
   done
 }
 
@@ -84,7 +84,7 @@ function test_create_new_env_missing_config()
 
   options_values['CREATE']='xlr8'
   create_new_env > /dev/null
-  assertTrue "${LINENO}: missing config not created" '[[ -e .kw/${ENV_DIR}/xlr8/remote.config ]]'
+  assertTrue "${LINENO}: missing config not created" '[[ -e .kw/${ENV_DIR}/$(get_env_name_encoded_with_pwd "xlr8")/remote.config ]]'
 
   rm ./remote.config
 }
@@ -113,8 +113,8 @@ function test_show_available_envs()
 
   local expected=(
     'Other kw environments:'
-    "* farofa: ${KW_CACHE_DIR}/${ENV_DIR}/farofa"
-    "* tapioca: ${KW_CACHE_DIR}/${ENV_DIR}/tapioca"
+    "* farofa: ${KW_CACHE_DIR}/${ENV_DIR}/$(get_env_name_encoded_with_pwd 'farofa')"
+    "* tapioca: ${KW_CACHE_DIR}/${ENV_DIR}/$(get_env_name_encoded_with_pwd 'tapioca')"
   )
 
   output=$(list_env_available_envs)
@@ -164,7 +164,7 @@ function test_use_target_env()
   use_target_env
 
   real_path=$(readlink "${PWD}/.kw/build.config")
-  expected_path="${PWD}/.kw/${ENV_DIR}/farofa/build.config"
+  expected_path="${PWD}/.kw/${ENV_DIR}/$(get_env_name_encoded_with_pwd 'farofa')/build.config"
 
   assertEquals "($LINENO) It looks like that the env did not switch" "$expected_path" "$real_path"
 
@@ -173,7 +173,7 @@ function test_use_target_env()
   use_target_env
 
   real_path=$(readlink "${PWD}/.kw/build.config")
-  expected_path="${PWD}/.kw/${ENV_DIR}/tapioca/build.config"
+  expected_path="${PWD}/.kw/${ENV_DIR}/$(get_env_name_encoded_with_pwd 'tapioca')/build.config"
 
   assertEquals "($LINENO) It looks like that the env did not switch" "$expected_path" "$real_path"
 }
@@ -323,8 +323,8 @@ function test_destroy_env_checking_the_existence_of_a_directory()
   assertFalse "($LINENO) We didn't expect to find this folder in .cache (${KW_CACHE_DIR}/envs/MACHINE_A) since the env was destroyed." '[[ -d "${KW_CACHE_DIR}/envs/MACHINE_A" ]]'
 
   # MACHINE_B
-  assertTrue "$LINENO: We expected to find this folder(${PWD}/.kw/envs/MACHINE_B)" '[[ -d "${PWD}/.kw/envs/MACHINE_B" ]]'
-  assertTrue "$LINENO: We expected to find this folder(${KW_CACHE_DIR}/envs/MACHINE_B)" '[[ -d "${KW_CACHE_DIR}/envs/MACHINE_B" ]]'
+  assertTrue "$LINENO: We expected to find this folder(${PWD}/.kw/envs/MACHINE_B)" '[[ -d "${PWD}/.kw/envs/$(get_env_name_encoded_with_pwd 'MACHINE_B')" ]]'
+  assertTrue "$LINENO: We expected to find this folder(${KW_CACHE_DIR}/envs/MACHINE_B)" '[[ -d "${KW_CACHE_DIR}/envs/$(get_env_name_encoded_with_pwd 'MACHINE_B')" ]]'
 
   # MACHINE_C
   assertFalse "($LINENO) We didn't expect to find this folder (${PWD}/.kw/envs/MACHINE_C) since the env was destroyed." '[[ -d "${PWD}/.kw/envs/MACHINE_C" ]]'

--- a/tests/unit/kw_env_test.sh
+++ b/tests/unit/kw_env_test.sh
@@ -52,16 +52,16 @@ function test_create_new_env_create_multiple_envs_from_current_configs()
 
   # Other checks
   # 1. Do we have the env folder?
-  new_env_name=$(find ".kw/${ENV_DIR}" -type d -name $(get_env_name_encoded_with_pwd 'xpto'))
-  assertEquals "($LINENO) We did not find the new folder name" ".kw/${ENV_DIR}/$(get_env_name_encoded_with_pwd 'xpto')" "$new_env_name"
+  new_env_name=$(find ".kw/${ENV_DIR}" -type d -name $(encode_env_name_with_pwd 'xpto'))
+  assertEquals "($LINENO) We did not find the new folder name" ".kw/${ENV_DIR}/$(encode_env_name_with_pwd 'xpto')" "$new_env_name"
 
-  new_env_name=$(find ".kw/${ENV_DIR}" -type d -name $(get_env_name_encoded_with_pwd 'abc'))
-  assertEquals "($LINENO) We did not find the new folder name" ".kw/${ENV_DIR}/$(get_env_name_encoded_with_pwd 'abc')" "$new_env_name"
+  new_env_name=$(find ".kw/${ENV_DIR}" -type d -name $(encode_env_name_with_pwd 'abc'))
+  assertEquals "($LINENO) We did not find the new folder name" ".kw/${ENV_DIR}/$(encode_env_name_with_pwd 'abc')" "$new_env_name"
 
   # 2. Check for config files
   for config in "${config_file_list[@]}"; do
-    assertTrue "${LINENO}: ${config} config not find " '[[ -f .kw/${ENV_DIR}/$(get_env_name_encoded_with_pwd "xpto")/${config}.config ]]'
-    assertTrue "${LINENO}: ${config} config not find " '[[ -f .kw/${ENV_DIR}/$(get_env_name_encoded_with_pwd "abc")/${config}.config ]]'
+    assertTrue "${LINENO}: ${config} config not find " '[[ -f .kw/${ENV_DIR}/$(encode_env_name_with_pwd "xpto")/${config}.config ]]'
+    assertTrue "${LINENO}: ${config} config not find " '[[ -f .kw/${ENV_DIR}/$(encode_env_name_with_pwd "abc")/${config}.config ]]'
   done
 }
 
@@ -84,7 +84,7 @@ function test_create_new_env_missing_config()
 
   options_values['CREATE']='xlr8'
   create_new_env > /dev/null
-  assertTrue "${LINENO}: missing config not created" '[[ -e .kw/${ENV_DIR}/$(get_env_name_encoded_with_pwd "xlr8")/remote.config ]]'
+  assertTrue "${LINENO}: missing config not created" '[[ -e .kw/${ENV_DIR}/$(encode_env_name_with_pwd "xlr8")/remote.config ]]'
 
   rm ./remote.config
 }
@@ -113,8 +113,8 @@ function test_show_available_envs()
 
   local expected=(
     'Other kw environments:'
-    "* farofa: ${KW_CACHE_DIR}/${ENV_DIR}/$(get_env_name_encoded_with_pwd 'farofa')"
-    "* tapioca: ${KW_CACHE_DIR}/${ENV_DIR}/$(get_env_name_encoded_with_pwd 'tapioca')"
+    "* farofa: ${KW_CACHE_DIR}/${ENV_DIR}/$(encode_env_name_with_pwd 'farofa')"
+    "* tapioca: ${KW_CACHE_DIR}/${ENV_DIR}/$(encode_env_name_with_pwd 'tapioca')"
   )
 
   output=$(list_env_available_envs)
@@ -164,7 +164,7 @@ function test_use_target_env()
   use_target_env
 
   real_path=$(readlink "${PWD}/.kw/build.config")
-  expected_path="${PWD}/.kw/${ENV_DIR}/$(get_env_name_encoded_with_pwd 'farofa')/build.config"
+  expected_path="${PWD}/.kw/${ENV_DIR}/$(encode_env_name_with_pwd 'farofa')/build.config"
 
   assertEquals "($LINENO) It looks like that the env did not switch" "$expected_path" "$real_path"
 
@@ -173,7 +173,7 @@ function test_use_target_env()
   use_target_env
 
   real_path=$(readlink "${PWD}/.kw/build.config")
-  expected_path="${PWD}/.kw/${ENV_DIR}/$(get_env_name_encoded_with_pwd 'tapioca')/build.config"
+  expected_path="${PWD}/.kw/${ENV_DIR}/$(encode_env_name_with_pwd 'tapioca')/build.config"
 
   assertEquals "($LINENO) It looks like that the env did not switch" "$expected_path" "$real_path"
 }
@@ -323,8 +323,8 @@ function test_destroy_env_checking_the_existence_of_a_directory()
   assertFalse "($LINENO) We didn't expect to find this folder in .cache (${KW_CACHE_DIR}/envs/MACHINE_A) since the env was destroyed." '[[ -d "${KW_CACHE_DIR}/envs/MACHINE_A" ]]'
 
   # MACHINE_B
-  assertTrue "$LINENO: We expected to find this folder(${PWD}/.kw/envs/MACHINE_B)" '[[ -d "${PWD}/.kw/envs/$(get_env_name_encoded_with_pwd 'MACHINE_B')" ]]'
-  assertTrue "$LINENO: We expected to find this folder(${KW_CACHE_DIR}/envs/MACHINE_B)" '[[ -d "${KW_CACHE_DIR}/envs/$(get_env_name_encoded_with_pwd 'MACHINE_B')" ]]'
+  assertTrue "$LINENO: We expected to find this folder(${PWD}/.kw/envs/MACHINE_B)" '[[ -d "${PWD}/.kw/envs/$(encode_env_name_with_pwd 'MACHINE_B')" ]]'
+  assertTrue "$LINENO: We expected to find this folder(${KW_CACHE_DIR}/envs/MACHINE_B)" '[[ -d "${KW_CACHE_DIR}/envs/$(encode_env_name_with_pwd 'MACHINE_B')" ]]'
 
   # MACHINE_C
   assertFalse "($LINENO) We didn't expect to find this folder (${PWD}/.kw/envs/MACHINE_C) since the env was destroyed." '[[ -d "${PWD}/.kw/envs/MACHINE_C" ]]'

--- a/tests/unit/lib/kwlib_test.sh
+++ b/tests/unit/lib/kwlib_test.sh
@@ -917,7 +917,7 @@ function test_get_current_env_name()
   }
 }
 
-function test_get_env_name_encoded_with_pwd()
+function test_encode_env_name_with_pwd()
 {
   local result expected base64_pwd
 
@@ -927,12 +927,12 @@ function test_get_env_name_encoded_with_pwd()
   }
 
   # Test when no argument is passed
-  get_env_name_encoded_with_pwd
+  encode_env_name_with_pwd
   assertEquals "($LINENO) - Should return 1 if no env_name is passed" 1 "$?"
 
   # Test when a valid env_name is passed
   base64_pwd=$(printf '%s' "$PWD" | base64)
-  result=$(get_env_name_encoded_with_pwd "dev")
+  result=$(encode_env_name_with_pwd "dev")
   expected="dev-${base64_pwd}"
   assertEquals "($LINENO) - Should return env_name-base64(PWD)" "$expected" "$result"
 

--- a/tests/unit/lib/kwlib_test.sh
+++ b/tests/unit/lib/kwlib_test.sh
@@ -917,6 +917,60 @@ function test_get_current_env_name()
   }
 }
 
+function test_get_env_name_encoded_with_pwd()
+{
+  local result expected base64_pwd
+
+  cd "${SHUNIT_TMPDIR}" || {
+    fail "($LINENO): It was not possible to move into ${SHUNIT_TMPDIR}"
+    return
+  }
+
+  # Test when no argument is passed
+  get_env_name_encoded_with_pwd
+  assertEquals "($LINENO) - Should return 1 if no env_name is passed" 1 "$?"
+
+  # Test when a valid env_name is passed
+  base64_pwd=$(printf '%s' "$PWD" | base64)
+  result=$(get_env_name_encoded_with_pwd "dev")
+  expected="dev-${base64_pwd}"
+  assertEquals "($LINENO) - Should return env_name-base64(PWD)" "$expected" "$result"
+
+  cd "${ORIGINAL_DIR}" || {
+    fail "($LINENO): It was not possible to move back to original directory"
+    return
+  }
+}
+
+function test_decode_env_name_with_pwd() {
+  local result expected base64_pwd encoded
+
+  cd "${SHUNIT_TMPDIR}" || {
+    fail "($LINENO): It was not possible to move into ${SHUNIT_TMPDIR}"
+    return
+  }
+
+  # Test when no argument is passed
+  decode_env_name_with_pwd
+  assertEquals "($LINENO) - Should return 1 if no encoded string is passed" 1 "$?"
+
+  # Test when there is no hyphen
+  decode_env_name_with_pwd "foobar"
+  assertEquals "($LINENO) - Should return 1 if no hyphen is present" 1 "$?"
+
+  # Test with a valid encoded string
+  base64_pwd=$(printf '%s' "$PWD" | base64)
+  encoded="some-env-name-${base64_pwd}"
+  result=$(decode_env_name_with_pwd "$encoded")
+  expected="some-env-name"
+  assertEquals "($LINENO) - Should return env_name extracted from encoded string" "$expected" "$result"
+
+  cd "${ORIGINAL_DIR}" || {
+    fail "($LINENO): It was not possible to move back to original directory"
+    return
+  }
+}
+
 function test_is_safe_path_to_remove()
 {
   local path


### PR DESCRIPTION
kw currently stores environment data in `${XDG_CACHE_HOME:-"${HOME}/.cache"}/${KWORKFLOW}/${ENV_DIR}/${env_name}`, and allows users to create non-distinct environment names in different work trees. When the new environment name isn't unique, data gets overwritten.

This PR implements a suffix to `env_name`: $PWD, encoded using base64 (available in Arch/Debian/Fedora through `coreutils`, already in `*.dependencies`).

It should fix issue #1185.