### PR TITLE
Add a unique suffix to kw environments

### DIFF
--- a/src/kw_env.sh
+++ b/src/kw_env.sh
@@ -194,6 +194,7 @@ function create_new_env()
   local local_kw_build_config="${local_kw_configs}/build.config"
   local local_kw_deploy_config="${local_kw_configs}/deploy.config"
   local env_name=${options_values['CREATE']}
+  local encoded_pwd=$(get_encoded_pwd)
   local cache_build_path="$KW_CACHE_DIR"
   local current_env_name
   local output
@@ -237,18 +238,18 @@ function create_new_env()
   done
 
   # Handle build and config folder
-  cmd="mkdir -p ${cache_build_path}/${ENV_DIR}/${env_name}"
+  cmd="mkdir --parents ${cache_build_path}/${ENV_DIR}/${encoded_pwd}/${env_name}"
   cmd_manager "$flag" "$cmd"
 
   current_env_name=$(get_current_env_name)
   ret="$?"
   # If we already have an env, we should copy the config file from it.
   if [[ "$ret" == 0 ]]; then
-    cmd="cp ${cache_build_path}/${ENV_DIR}/${current_env_name}/.config ${cache_build_path}/${ENV_DIR}/${env_name}/.config"
+    cmd="cp ${cache_build_path}/${ENV_DIR}/${encoded_pwd}/${current_env_name}/.config ${cache_build_path}/${ENV_DIR}/${encoded_pwd}/${env_name}/.config"
     cmd_manager "$flag" "$cmd"
     return
   elif [[ -f "${PWD}/.config" ]]; then
-    cmd="cp ${PWD}/.config ${cache_build_path}/${ENV_DIR}/${env_name}"
+    cmd="cp ${PWD}/.config ${cache_build_path}/${ENV_DIR}/${encoded_pwd}/${env_name}"
     cmd_manager "$flag" "$cmd"
     return
   fi
@@ -258,10 +259,10 @@ function create_new_env()
   warning 'It is recommended to use kw kernel-config-manager.'
 
   if [[ -e /proc/config.gz ]]; then
-    cmd="zcat /proc/config.gz > ${cache_build_path}/${ENV_DIR}/${env_name}/.config"
+    cmd="zcat /proc/config.gz > ${cache_build_path}/${ENV_DIR}/${encoded_pwd}/${env_name}/.config"
     cmd_manager "$flag" "$cmd"
   elif [[ -e "/boot/config-$(uname -r)" ]]; then
-    cmd="cp /boot/config-$(uname -r) ${cache_build_path}/${ENV_DIR}/${env_name}/.config"
+    cmd="cp /boot/config-$(uname -r) ${cache_build_path}/${ENV_DIR}/${encoded_pwd}/${env_name}/.config"
     cmd_manager "$flag" "$cmd"
   else
     warning 'kw was not able to find any valid config file for the new env'
@@ -276,6 +277,7 @@ function destroy_env()
   local cache_build_path="$KW_CACHE_DIR"
   local current_env
   local env_name=${options_values['DESTROY']}
+  local encoded_pwd=$(get_encoded_pwd)
   local cmd
 
   flag=${flag:-'SILENT'}
@@ -302,7 +304,7 @@ function destroy_env()
     fi
   fi
 
-  cmd="rm -rf ${local_kw_configs:?}/${ENV_DIR}/${env_name} && rm -rf ${cache_build_path:?}/${ENV_DIR}/${env_name}"
+  cmd="rm --recursive --force ${local_kw_configs:?}/${ENV_DIR}/${env_name} && rm -rf ${cache_build_path:?}/${ENV_DIR}/${encoded_pwd}/${env_name}"
   cmd_manager "$flag" "$cmd"
   success "The \"${env_name}\" environment has been destroyed."
 }
@@ -344,14 +346,14 @@ function list_env_available_envs()
   if [[ -f "${local_kw_configs}/${ENV_CURRENT_FILE}" ]]; then
     current_env=$(< "${local_kw_configs}/${ENV_CURRENT_FILE}")
     say 'Current env:'
-    printf ' -> %s: %s\n\n' "$current_env" "${KW_CACHE_DIR}/${ENV_DIR}/${current_env}"
+    printf ' -> %s: %s\n\n' "$current_env" "${KW_CACHE_DIR}/${ENV_DIR}/$(get_encoded_pwd)/${current_env}"
   fi
 
   warning 'Other kw environments:'
   # For the below loop, we want to split the array
   # shellcheck disable=SC2068
   for env in ${all_envs[@]}; do
-    printf ' * %s: %s\n' "$env" "${KW_CACHE_DIR}/${ENV_DIR}/${env}"
+    printf ' * %s: %s\n' "$env" "${KW_CACHE_DIR}/${ENV_DIR}/$(get_encoded_pwd)/${env}"
   done
 }
 

--- a/src/lib/kwlib.sh
+++ b/src/lib/kwlib.sh
@@ -695,6 +695,17 @@ function get_current_env_name()
   return "$ret"
 }
 
+# This function returns ${PWD}, base64-encoded.
+#
+# Return:
+# Returns 0 and prints ${PWD}, base64-encoded
+function get_encoded_pwd()
+{
+  printf '%s' "$PWD" | base64 --wrap=0
+
+  return 0
+}
+
 # A common task is to remove files/directories. This function is a predicate
 # to check if a given path is safe to remove (e.g. is not the '/')
 #

--- a/tests/unit/kw_env_test.sh
+++ b/tests/unit/kw_env_test.sh
@@ -346,4 +346,95 @@ function test_create_and_destroy_env()
   assertFalse "($LINENO) We didn't expect to find this folder in .cache (${KW_CACHE_DIR}/MACHINE_E) since the env was destroyed." '[[ -d "${KW_CACHE_DIR}/MACHINE_E" ]]'
 }
 
+function test_migrate_old_envs_to_base64()
+{
+  local old_env_path="${KW_CACHE_DIR}/${ENV_DIR}"
+  local encoded_pwd=$(get_encoded_pwd)
+  local new_env_path="${old_env_path}/${encoded_pwd}"
+
+  # Create old-style env structure in cache
+  mkdir --parents "${old_env_path}/env1"
+  mkdir --parents "${old_env_path}/env2"
+  echo "test config 1" > "${old_env_path}/env1/build.config"
+  echo "test config 2" > "${old_env_path}/env2/build.config"
+
+  # Create corresponding local .kw/envs structure
+  mkdir --parents ".kw/${ENV_DIR}/env1"
+  mkdir --parents ".kw/${ENV_DIR}/env2"
+
+  # Verify old structure exists
+  assertTrue "(${LINENO}) Old env1 should exist before migration" '[[ -d "${old_env_path}/env1" ]]'
+  assertTrue "(${LINENO}) Old env2 should exist before migration" '[[ -d "${old_env_path}/env2" ]]'
+  assertFalse "(${LINENO}) New structure should not exist before migration" '[[ -d "${new_env_path}" ]]'
+
+  # Run migration
+  migrate_old_envs_to_base64
+
+  # Verify migration completed successfully
+  assertTrue "(${LINENO}) New base64 directory should be created" '[[ -d "${new_env_path}" ]]'
+  assertTrue "(${LINENO}) env1 should be migrated to new location" '[[ -d "${new_env_path}/env1" ]]'
+  assertTrue "(${LINENO}) env2 should be migrated to new location" '[[ -d "${new_env_path}/env2" ]]'
+  assertTrue "(${LINENO}) env1 config should be preserved" '[[ -f "${new_env_path}/env1/build.config" ]]'
+  assertTrue "(${LINENO}) env2 config should be preserved" '[[ -f "${new_env_path}/env2/build.config" ]]'
+
+  # Verify old structure is removed
+  assertFalse "(${LINENO}) Old env1 should be moved" '[[ -d "${old_env_path}/env1" ]]'
+  assertFalse "(${LINENO}) Old env2 should be moved" '[[ -d "${old_env_path}/env2" ]]'
+
+  # Verify config content is preserved
+  local content1=$(cat "${new_env_path}/env1/build.config")
+  local content2=$(cat "${new_env_path}/env2/build.config")
+  assertEquals "(${LINENO}) env1 config content should be preserved" "test config 1" "$content1"
+  assertEquals "(${LINENO}) env2 config content should be preserved" "test config 2" "$content2"
+}
+
+function test_migrate_old_envs_to_base64_no_local_envs()
+{
+  local old_env_path="${KW_CACHE_DIR}/${ENV_DIR}"
+
+  # Create cache envs but no local .kw/envs directory
+  mkdir --parents "${old_env_path}/env1"
+  # Don't create .kw/envs directory
+
+  # Migration should not run
+  migrate_old_envs_to_base64
+  assertEquals "(${LINENO}) Migration should skip when no local envs directory" 0 "$?"
+
+  # Old structure should remain unchanged
+  assertTrue "(${LINENO}) Old env should remain when migration skipped" '[[ -d "${old_env_path}/env1" ]]'
+}
+
+function test_migrate_old_envs_to_base64_already_migrated()
+{
+  local old_env_path="${KW_CACHE_DIR}/${ENV_DIR}"
+  local encoded_pwd=$(get_encoded_pwd)
+  local new_env_path="${old_env_path}/${encoded_pwd}"
+
+  # Create both old and new structure (simulating already migrated)
+  mkdir --parents "${old_env_path}/env1"
+  mkdir --parents "${new_env_path}/existing_env"
+  mkdir --parents ".kw/${ENV_DIR}/env1"
+
+  # Migration should not run when new structure already exists
+  migrate_old_envs_to_base64
+  assertEquals "(${LINENO}) Migration should skip when already migrated" 0 "$?"
+
+  # Both structures should remain (no changes)
+  assertTrue "(${LINENO}) Old env should remain when already migrated" '[[ -d "${old_env_path}/env1" ]]'
+  assertTrue "(${LINENO}) New structure should remain when already migrated" '[[ -d "${new_env_path}/existing_env" ]]'
+}
+
+function test_migrate_old_envs_to_base64_no_envs_to_migrate()
+{
+  local old_env_path="${KW_CACHE_DIR}/${ENV_DIR}"
+
+  # Create empty directories
+  mkdir --parents "${old_env_path}"
+  mkdir --parents ".kw/${ENV_DIR}"
+
+  # Migration should not run when no envs exist
+  migrate_old_envs_to_base64
+  assertEquals "(${LINENO}) Migration should skip when no envs to migrate" 0 "$?"
+}
+
 invoke_shunit

--- a/tests/unit/kw_env_test.sh
+++ b/tests/unit/kw_env_test.sh
@@ -113,8 +113,8 @@ function test_show_available_envs()
 
   local expected=(
     'Other kw environments:'
-    "* farofa: ${KW_CACHE_DIR}/${ENV_DIR}/farofa"
-    "* tapioca: ${KW_CACHE_DIR}/${ENV_DIR}/tapioca"
+    "* farofa: ${KW_CACHE_DIR}/${ENV_DIR}/$(get_encoded_pwd)/farofa"
+    "* tapioca: ${KW_CACHE_DIR}/${ENV_DIR}/$(get_encoded_pwd)/tapioca"
   )
 
   output=$(list_env_available_envs)
@@ -323,12 +323,12 @@ function test_destroy_env_checking_the_existence_of_a_directory()
   assertFalse "($LINENO) We didn't expect to find this folder in .cache (${KW_CACHE_DIR}/envs/MACHINE_A) since the env was destroyed." '[[ -d "${KW_CACHE_DIR}/envs/MACHINE_A" ]]'
 
   # MACHINE_B
-  assertTrue "$LINENO: We expected to find this folder(${PWD}/.kw/envs/MACHINE_B)" '[[ -d "${PWD}/.kw/envs/MACHINE_B" ]]'
-  assertTrue "$LINENO: We expected to find this folder(${KW_CACHE_DIR}/envs/MACHINE_B)" '[[ -d "${KW_CACHE_DIR}/envs/MACHINE_B" ]]'
+  assertTrue "$LINENO: We expected to find this folder(${PWD}/.kw/envs/MACHINE_B)" '[[ -d "${PWD}/.kw/envs/$(encode_env_name_with_pwd 'MACHINE_B')" ]]'
+  assertTrue "$LINENO: We expected to find this folder(${KW_CACHE_DIR}/envs/$(get_encoded_pwd)/MACHINE_B)" '[[ -d "${KW_CACHE_DIR}/envs/$(get_encoded_pwd)/MACHINE_B" ]]'
 
   # MACHINE_C
   assertFalse "($LINENO) We didn't expect to find this folder (${PWD}/.kw/envs/MACHINE_C) since the env was destroyed." '[[ -d "${PWD}/.kw/envs/MACHINE_C" ]]'
-  assertFalse "($LINENO) We didn't expect to find this folder in .cache (${KW_CACHE_DIR}/envs/MACHINE_C) since the env was destroyed." '[[ -d "${KW_CACHE_DIR}/envs/MACHINE_C" ]]'
+  assertFalse "($LINENO) We didn't expect to find this folder in .cache (${KW_CACHE_DIR}/envs/$(get_encoded_pwd)/MACHINE_C) since the env was destroyed." '[[ -d "${KW_CACHE_DIR}/envs/$(get_encoded_pwd)/MACHINE_C" ]]'
 }
 
 function test_create_and_destroy_env()

--- a/tests/unit/lib/kwlib_test.sh
+++ b/tests/unit/lib/kwlib_test.sh
@@ -917,6 +917,27 @@ function test_get_current_env_name()
   }
 }
 
+function test_get_encoded_pwd()
+{
+  local result
+  local expected
+  local base64_pwd
+
+  cd "${SHUNIT_TMPDIR}" || {
+    fail "(${LINENO}): It was not possible to move into ${SHUNIT_TMPDIR}"
+    return
+  }
+
+  result=$(get_encoded_pwd)
+  expected="$(printf '%s' "$PWD" | base64 --wrap=0)"
+  assertEquals "(${LINENO}) - Should return base64(PWD)" "$expected" "$result"
+
+  cd "${ORIGINAL_DIR}" || {
+    fail "($LINENO): It was not possible to move back to original directory"
+    return
+  }
+}
+
 function test_is_safe_path_to_remove()
 {
   local path


### PR DESCRIPTION
kw currently stores environment data in `${XDG_CACHE_HOME:-"${HOME}/.cache"}/${KWORKFLOW}/${ENV_DIR}/${env_name}`, and allows users to create non-distinct environment names in different work trees. When the new environment name isn't unique, data gets overwritten.

This PR implements a suffix to `env_name`: `$PWD`, encoded using base64 (available in Arch/Debian/Fedora through `coreutils`, already in `*.dependencies`).

It should fix issue #1185.