### PR TITLE
src: plugins: kernel_install: Fix permission issues when touching INSTALLED_KERNELS

### DIFF
--- a/src/plugins/kernel_install/utils.sh
+++ b/src/plugins/kernel_install/utils.sh
@@ -152,7 +152,7 @@ function list_installed_kernels()
   local cmd=''
   local ret=0
 
-  [[ "$target" == 2 || "$target" == 'local' ]] && sudo_cmd='sudo '
+  [[ "$target" == 2 || "$target" == 'local' ]] && sudo_cmd='sudo --preserve-env '
 
   # TODO: Drop me in the future
   migrate_old_kernel_list


### PR DESCRIPTION
Currently, when deploying a kernel locally on Fedora, we get:

touch: cannot touch '/boot/INSTALLED_KERNELS': Permission denied
grep: /boot/INSTALLED_KERNELS: No such file or directory

This happens because the function `list_installed_kernels()` wasn't preserving the environment variables when calling sudo. Address this issue by adding `--preserve-env` to $sudo_cmd.