### PR TITLE
Make bd accept some of the deploy options

### DIFF
--- a/documentation/man/features/kw-bd.rst
+++ b/documentation/man/features/kw-bd.rst
@@ -13,12 +13,20 @@ DESCRIPTION
 ===========
 
 Kw bd is expected to run inside a kernel tree. It executes the build, and if
-there are no errors, it proceeds with deploying the new kernel.
+there are no errors, it proceeds with deploying the new kernel. It is crucial
+to highlight that kw bd supports the following deploy options:
 
-Currently, all arguments invoked along with kw bd will be redirected to kw
-deploy.
+* \--remote <remote>:<port>
+* \--local
+* -r, \--reboot
+* \--no-reboot
+* -m, \--modules
+* -f, \--force
+* -p, \--create-package
+* \--verbose
+* -n, \--boot-into-new-kernel-once
 
-See the kw build and kw deploy man pages for more information.
+See the kw deploy man pages for more information.
 
 .. note::
   This command must be run inside of a kernel tree.
@@ -32,4 +40,4 @@ For simply executing build and deploy use::
 
 If you want to build and deploy the kernel with --create-package option use::
 
-	kw bd --create-package
+	kw bd --reboot

--- a/src/build_and_deploy.sh
+++ b/src/build_and_deploy.sh
@@ -42,28 +42,10 @@ function build_and_deploy_main()
 
 function parse_build_and_deploy_options()
 {
-  local long_options=''
-  local short_options=''
-
-  options="$(kw_parse "$short_options" "$long_options" "$@")"
-  if [[ "$?" != 0 ]]; then
-    options_values['ERROR']="$(kw_parse_get_errors 'kw bd' "$short_options" \
-      "$long_options" "$@")"
+  shared_parse_deploy_options "$@"
+  if [[ "$?" == 22 ]]; then
     return 22 # EINVAL
   fi
-
-  eval "set -- ${options}"
-
-  while [[ "$#" -gt 0 ]]; do
-    case "$1" in
-      --)
-        shift
-        ;;
-      *)
-        shift
-        ;;
-    esac
-  done
 }
 
 function build_and_deploy_help()
@@ -75,4 +57,5 @@ function build_and_deploy_help()
   fi
   printf '%s\n' 'kw bd:' \
     '  bd - build and deploy kernel and modules:'
+  deploy_shared_help 'bd'
 }

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -1560,6 +1560,18 @@ function parse_deploy_options()
   done
 }
 
+function deploy_shared_help()
+{
+  local feature_name="$1"
+
+  printf '%s\n' "  ${feature_name} (--create-package | -p) - Create kw package" \
+    "  ${feature_name} (--reboot | -r) - reboot machine after deploy" \
+    "  ${feature_name} (--no-reboot) - do not reboot machine after deploy" \
+    "  ${feature_name} (--boot-into-new-kernel-once | -n) - Next boot into the new kernel" \
+    "  ${feature_name} (--remote <remote>:<port> | --local) - choose target" \
+    "  ${feature_name} (--verbose | -v) - show a detailed output"
+}
+
 function deploy_help()
 {
   if [[ "$1" == --help ]]; then
@@ -1569,19 +1581,13 @@ function deploy_help()
   fi
   printf '%s\n' 'kw deploy:' \
     '  deploy - installs kernel and modules:' \
-    '  deploy (--remote <remote>:<port> | --local) - choose target' \
-    '  deploy (--reboot | -r) - reboot machine after deploy' \
-    '  deploy (--no-reboot) - do not reboot machine after deploy' \
-    '  deploy (--boot-into-new-kernel-once | -n) - Next boot into the new kernel' \
-    '  deploy (--verbose | -v) - show a detailed output' \
     '  deploy (--setup) - set up target machine for deploy' \
-    '  deploy (--modules | -m) - install only modules' \
     '  deploy (--uninstall | -u) [(--force | -f)] [<kernel-name>,...] - uninstall kernels' \
     '  deploy (--list | -l) - list kernels' \
     '  deploy (--ls-line | -s) - list kernels separeted by commas' \
     '  deploy (--list-all | -a) - list all available kernels' \
-    '  deploy (--create-package | -p) - Create kw package' \
     '  deploy (--from-package | -F) - Deploy from kw package'
+  deploy_shared_help 'deploy'
 }
 
 load_build_config

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -35,6 +35,11 @@ declare REMOTE_INTERACE_CMD_PREFIX
 declare LOCAL_TO_DEPLOY_DIR
 declare LOCAL_REMOTE_DIR
 
+all_long_options='remote:,local,reboot,no-reboot,modules,list,ls-line,uninstall::,list-all,force,setup,verbose,create-package,from-package:,boot-into-new-kernel-once'
+all_short_options='r,m,l,s,u::,a,f,v,p,F:,n'
+
+deploy_unprocess_param=''
+
 # Hash containing user options
 declare -gA options_values
 
@@ -1322,50 +1327,24 @@ function run_kernel_install()
   esac
 }
 
-# This function gets raw data and based on that fill out the options values to
-# be used in another function.
-#
-# @raw_options String with all user options
-#
-# Return:
-# In case of successful return 0, otherwise, return 22.
-#
-function parse_deploy_options()
+function shared_parse_deploy_options()
 {
-  local enable_collect_param=0
   local remote
   local options
   local after_options
-  local long_options='remote:,local,reboot,no-reboot,modules,list,ls-line,uninstall::'
-  long_options+=',list-all,force,setup,verbose,create-package,from-package:'
-  long_options+=',boot-into-new-kernel-once'
-  local short_options='r,m,l,s,u::,a,f,v,p,F:,n'
+  local long_options='remote:,local,reboot,no-reboot,modules,force,verbose,create-package'
+  long_options+=',boot-into-new-kernel-once,verbose'
+  local short_options='r,m,f,v,p,n'
 
   options="$(kw_parse "$short_options" "$long_options" "$@")"
 
-  if [[ "$?" != 0 ]]; then
-    options_values['ERROR']="$(kw_parse_get_errors 'kw deploy' "$short_options" \
-      "$long_options" "$@")"
-    return 22 # EINVAL
-  fi
-
-  options_values['ENV_PATH_KBUILD_OUTPUT_FLAG']=''
-  options_values['TEST_MODE']='SILENT'
-  options_values['UNINSTALL']=''
   options_values['FORCE']=0
   options_values['MODULES']=0
-  options_values['LS_LINE']=0
-  options_values['LS']=0
   # 0: not specified in cmd options   1: --reboot   2: --no-reboot
   options_values['REBOOT']=0
-  options_values['MENU_CONFIG']='nconfig'
-  options_values['LS_ALL']=''
-  options_values['SETUP']=''
   options_values['VERBOSE']=''
   options_values['CREATE_PACKAGE']=''
-  options_values['FROM_PACKAGE']=''
   options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=''
-  options_values['UNINSTALL_REMOVE_FIRST']=''
   options_values['BOOT_INTO_NEW_KERNEL_ONCE']=1
 
   remote_parameters['REMOTE_IP']=''
@@ -1423,6 +1402,106 @@ function parse_deploy_options()
         options_values['MODULES']=1
         shift
         ;;
+      --verbose | -v)
+        options_values['VERBOSE']=1
+        shift
+        ;;
+      --force | -f)
+        options_values['FORCE']=1
+        shift
+        ;;
+      --create-package | -p)
+        options_values['CREATE_PACKAGE']=1
+        shift
+        ;;
+      --boot-into-new-kernel-once | -n)
+        options_values['BOOT_INTO_NEW_KERNEL_ONCE']=1
+        shift
+        ;;
+      --) # End of options, beginning of arguments
+        # The uninstall command already handled parameters after --
+        after_options=${options##*'--'}
+        after_options=$(str_strip "$after_options")
+        if [[ "$after_options" == "'TEST_MODE'" ]]; then
+          options_values['TEST_MODE']='TEST_MODE'
+        fi
+        shift "${#@}"
+        ;;
+      *)
+        options_values['ERROR']="Unrecognized argument: $1"
+        shift
+        return 22 # EINVAL
+        ;;
+    esac
+  done
+
+  case "${options_values['TARGET']}" in
+    1 | 2 | 3) ;;
+
+    *)
+      options_values['ERROR']="Invalid target value: ${options_values['TARGET']}"
+      return 22 # EINVAL
+      ;;
+  esac
+
+  deploy_unprocess_param="${options##*'--'}"
+}
+
+# This function gets raw data and based on that fill out the options values to
+# be used in another function.
+#
+# @raw_options String with all user options
+#
+# Return:
+# In case of successful return 0, otherwise, return 22.
+#
+function parse_deploy_options()
+{
+  local enable_collect_param=0
+  local remote
+  local options
+  local all_options
+  local after_options
+  local long_options='list,ls-line,uninstall::'
+  long_options+=',list-all,setup,verbose,from-package:'
+  long_options+=',boot-into-new-kernel-once'
+  local short_options='r,m,l,s,u::,a,f,v,p,F:,n'
+  local ret_options
+
+  all_options="$(kw_parse "$all_short_options" "$all_long_options" "$@")"
+  if [[ "$?" != 0 ]]; then
+    options_values['ERROR']="$(kw_parse_get_errors 'kw deploy' "$all_short_options" \
+      "$all_long_options" "$@")"
+    return 22 # EINVAL
+  fi
+
+  options_values['ENV_PATH_KBUILD_OUTPUT_FLAG']=''
+  options_values['TEST_MODE']='SILENT'
+  options_values['UNINSTALL']=''
+  options_values['LS_LINE']=0
+  options_values['LS']=0
+  # 0: not specified in cmd options   1: --reboot   2: --no-reboot
+  options_values['MENU_CONFIG']='nconfig'
+  options_values['LS_ALL']=''
+  options_values['SETUP']=''
+  options_values['FROM_PACKAGE']=''
+  options_values['UNINSTALL_REMOVE_FIRST']=''
+
+  shared_parse_deploy_options "$@"
+  if [[ "$?" == 22 ]]; then
+    return 22
+  fi
+
+  options="$(kw_parse "$short_options" "$long_options" "$@")"
+  # Extracts only the options before the substring --
+  options="${options%"${options##*'--'}"}"
+  # Compose the deploy_unprocess_param from shared_parse_deploy_options in the
+  # missing options
+  options="${options}${deploy_unprocess_param}"
+
+  eval "set -- ${options}"
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
       --list | -l)
         options_values['LS']=1
         options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=1
@@ -1457,26 +1536,10 @@ function parse_deploy_options()
         options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=1
         shift 2
         ;;
-      --verbose | -v)
-        options_values['VERBOSE']=1
-        shift
-        ;;
-      --force | -f)
-        options_values['FORCE']=1
-        shift
-        ;;
-      --create-package | -p)
-        options_values['CREATE_PACKAGE']=1
-        shift
-        ;;
       --from-package | -F)
         options_values['FROM_PACKAGE']+="$2"
         options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=1
         shift 2
-        ;;
-      --boot-into-new-kernel-once | -n)
-        options_values['BOOT_INTO_NEW_KERNEL_ONCE']=1
-        shift
         ;;
       --) # End of options, beginning of arguments
         # The uninstall command already handled parameters after --
@@ -1488,21 +1551,13 @@ function parse_deploy_options()
         shift "${#@}"
         ;;
       *)
-        options_values['ERROR']="Unrecognized argument: $1"
+        # Potential parameters that were processed in the
+        # shared_parse_deploy_options. At this point, kw expects that the
+        # invalid option has already been filtered out.
         shift
-        return 22 # EINVAL
         ;;
     esac
   done
-
-  case "${options_values['TARGET']}" in
-    1 | 2 | 3) ;;
-
-    *)
-      options_values['ERROR']="Invalid target value: ${options_values['TARGET']}"
-      return 22 # EINVAL
-      ;;
-  esac
 }
 
 function deploy_help()

--- a/tests/unit/deploy_test.sh
+++ b/tests/unit/deploy_test.sh
@@ -833,6 +833,10 @@ function test_parse_deploy_options()
   parse_deploy_options 'TEST_MODE'
   assert_equals_helper 'Could not set deploy TEST_MODE' "(${LINENO})" 'TEST_MODE' "${options_values['TEST_MODE']}"
 
+  # test invalid options
+  parse_deploy_options --an-invalid-option
+  assert_equals_helper 'Wrong return value' "(${LINENO})" '22' "$?"
+
   # test integration of options
   unset options_values
   declare -gA options_values


### PR DESCRIPTION
This commit addresses the issue #1208 pointed out by @superm1 and @melissawen .
With this change, kw bd accepts the following deploy options: --reboot, --no-reboot, --create-package, --boot-into-new-kernel-once, --verbose, and --remote.