### PR TITLE
etc: Remove ssh option from kworkflow.config

### DIFF
--- a/etc/init_templates/rpi4-and-5-raspbian-64-cross-x86-arm/kworkflow_template.config
+++ b/etc/init_templates/rpi4-and-5-raspbian-64-cross-x86-arm/kworkflow_template.config
@@ -9,17 +9,6 @@
 # Default ssh user
 ssh_user=root
 
-# Default ssh ip
-ssh_ip=localhost
-
-# Default ssh port
-ssh_port=22
-
-# Optional ssh configuration file to be used
-#ssh_configfile=~/.ssh/config
-# Hostname of the target in ssh_configfile
-#hostname=
-
 # Default alert options (You should use vs, s, v or n. See README.md for details
 # on this options)
 alert=n

--- a/etc/init_templates/rpi4-raspbian-32-cross-x86-arm/kworkflow_template.config
+++ b/etc/init_templates/rpi4-raspbian-32-cross-x86-arm/kworkflow_template.config
@@ -2,20 +2,6 @@
 # Note: You can customize the settings in this file but no setting should be
 # removed. Otherwise, KW may not work properly.
 
-# Default ssh user
-ssh_user=root
-
-# Default ssh ip
-ssh_ip=localhost
-
-# Default ssh port
-ssh_port=22
-
-# Optional ssh configuration file to be used
-#ssh_configfile=~/.ssh/config
-# Hostname of the target in ssh_configfile
-#hostname=
-
 # Default alert options (You should use vs, s, v or n. See README.md for details
 # on this options)
 alert=n

--- a/etc/init_templates/x86-64/kworkflow_template.config
+++ b/etc/init_templates/x86-64/kworkflow_template.config
@@ -6,24 +6,6 @@
 #? - USERKW will be replaced by the current user
 #? - SOUNDPATH will be replaced by kw's install path
 
-# Default ssh user
-ssh_user=root
-
-# Default ssh ip
-ssh_ip=localhost
-
-# Default ssh port
-ssh_port=22
-
-# Deploying a kernel to a remote requires part of the kw code in the target
-# machine. The following variable enables users to specify which folder they
-# prefer to use.
-
-# Optional ssh configuration file to be used
-#ssh_configfile=~/.ssh/config
-# Hostname of the target in ssh_configfile
-#hostname=
-
 # Default alert options (You should use vs, s, v or n. See README.md for details
 # on this options)
 alert=n

--- a/etc/kworkflow.config
+++ b/etc/kworkflow.config
@@ -9,12 +9,6 @@
 # Default ssh user
 ssh_user=root
 
-# Default ssh ip
-ssh_ip=localhost
-
-# Default ssh port
-ssh_port=22
-
 # Optional ssh configuration file to be used
 #ssh_configfile=~/.ssh/config
 # Hostname of the target in ssh_configfile

--- a/tests/unit/init_test.sh
+++ b/tests/unit/init_test.sh
@@ -123,22 +123,6 @@ function test_force_unsupported_arch()
   assertEquals "($LINENO):" 'arch=baroque' "$kworkflow_content"
 }
 
-function test_set_remote()
-{
-  local output
-  local kworkflow_content
-
-  output=$(init_main --remote juca@123.456.789.123:2222)
-  kworkflow_content=$(grep ssh_user= "$PATH_TO_KW_CONFIG")
-  assertEquals "($LINENO)" 'ssh_user=juca' "$kworkflow_content"
-
-  kworkflow_content=$(grep ssh_ip= "$PATH_TO_KW_CONFIG")
-  assertEquals "($LINENO)" 'ssh_ip=123.456.789.123' "$kworkflow_content"
-
-  kworkflow_content=$(grep ssh_port= "$PATH_TO_KW_CONFIG")
-  assertEquals "($LINENO)" 'ssh_port=2222' "$kworkflow_content"
-}
-
 function test_try_to_set_wrong_arch()
 {
   local output

--- a/tests/unit/lib/kw_config_loader_test.sh
+++ b/tests/unit/lib/kw_config_loader_test.sh
@@ -135,9 +135,6 @@ function test_parse_configuration_check_parser_values_only_for_kworkflow_config_
 function test_parse_configuration_standard_config()
 {
   declare -A expected_configurations=(
-    [ssh_user]='root'
-    [ssh_ip]='localhost'
-    [ssh_port]='22'
     [alert]='n'
     [sound_alert_command]='paplay SOUNDPATH/bell.wav'
     [visual_alert_command]='notify-send -i checkbox -t 10000 "kw" "Command: \"$COMMAND\" completed!"'


### PR DESCRIPTION
Before kw remote was implemented, the ssh information was stored in the 'kworkflow.config', but this became obsolete. For some reason, we forget to clean up the configuration files. This commit removes the ssh option from the config file.