### PR TITLE
Fix eval syntax error when run outside kernel tree

### DIFF
--- a/src/lib/kwio.sh
+++ b/src/lib/kwio.sh
@@ -64,13 +64,13 @@ function colored_print()
     if [ -t 1 ]; then
       printf "$colored_format" "$message"
     else
-      printf '%s' "$message"
+      printf '%s' "$message" || true
     fi
   else
     if [ -t 1 ]; then
       printf "$colored_format\n" "$message"
     else
-      printf '%s\n' "$message"
+      printf '%s\n' "$message" || true
     fi
   fi
 }

--- a/src/plugins/subsystems/drm/drm.sh
+++ b/src/plugins/subsystems/drm/drm.sh
@@ -264,8 +264,8 @@ function gui_control()
 
   case "$target" in
     2) # LOCAL TARGET
-      gui_control_cmd="sudo -- sh -c '${gui_control_cmd}'"
-      bind_control_cmd="sudo -- sh -c '${bind_control_cmd}'"
+      gui_control_cmd="sudo bash -c '${gui_control_cmd}'"
+      bind_control_cmd="sudo bash -c '${bind_control_cmd}'"
       cmd_manager "$flag" "$gui_control_cmd"
       cmd_manager "$flag" "$bind_control_cmd"
       ;;

--- a/src/plugins/subsystems/drm/drm.sh
+++ b/src/plugins/subsystems/drm/drm.sh
@@ -260,7 +260,7 @@ function gui_control()
   fi
 
   gui_control_cmd=${gui_control_cmd:-"${default_command}"}
-  bind_control_cmd="for i in /sys/class/vtconsole/*/bind; do printf '%s\n' $vt_console > \$i; done; sleep 0.5"
+  bind_control_cmd="for i in /sys/class/vtconsole/*/bind; do printf "%s\n" $vt_console > \$i; done; sleep 0.5"
 
   case "$target" in
     2) # LOCAL TARGET

--- a/src/plugins/subsystems/drm/drm.sh
+++ b/src/plugins/subsystems/drm/drm.sh
@@ -260,7 +260,7 @@ function gui_control()
   fi
 
   gui_control_cmd=${gui_control_cmd:-"${default_command}"}
-  bind_control_cmd='for i in /sys/class/vtconsole/*/bind; do printf "%s\n" '$vt_console' > $i; done; sleep 0.5' # is this right?
+  bind_control_cmd="for i in /sys/class/vtconsole/*/bind; do printf '%s\n' $vt_console > \$i; done; sleep 0.5"
 
   case "$target" in
     2) # LOCAL TARGET

--- a/src/plugins/subsystems/drm/drm.sh
+++ b/src/plugins/subsystems/drm/drm.sh
@@ -260,7 +260,7 @@ function gui_control()
   fi
 
   gui_control_cmd=${gui_control_cmd:-"${default_command}"}
-  bind_control_cmd="for i in /sys/class/vtconsole/*/bind; do printf "%s\n" $vt_console > \$i; done; sleep 0.5"
+  bind_control_cmd="for i in /sys/class/vtconsole/*/bind; do printf \"%s\\n\" $vt_console > \$i; done; sleep 0.5"
 
   case "$target" in
     2) # LOCAL TARGET

--- a/tests/unit/drm_plugin_test.sh
+++ b/tests/unit/drm_plugin_test.sh
@@ -346,16 +346,16 @@ function test_gui_control_local()
   configurations[gui_off_after_reboot]="$gui_off_after_reboot_cmd"
 
   declare -a expected_cmd_seq=(
-    "sudo -- sh -c '${gui_on_cmd}'"
-    "sudo -- sh -c '${bind_cmd}'"
+    "sudo bash -c '${gui_on_cmd}'"
+    "sudo bash -c '${bind_cmd}'"
   )
 
   output=$(gui_control 'ON' '2' '' 'TEST_MODE')
   compare_command_sequence '' "$LINENO" 'expected_cmd_seq' "$output"
 
   declare -a expected_cmd_seq=(
-    "sudo -- sh -c '${gui_off_cmd}'"
-    "sudo -- sh -c '${unbind_cmd}'"
+    "sudo bash -c '${gui_off_cmd}'"
+    "sudo bash -c '${unbind_cmd}'"
   )
 
   output=$(gui_control 'OFF' '2' '' 'TEST_MODE')
@@ -363,8 +363,8 @@ function test_gui_control_local()
 
   # Test GUI ON after reboot
   declare -a expected_cmd_seq=(
-    "sudo -- sh -c '${gui_on_after_reboot_cmd}'"
-    "sudo -- sh -c '${bind_cmd}'"
+    "sudo bash -c '${gui_on_after_reboot_cmd}'"
+    "sudo bash -c '${bind_cmd}'"
   )
 
   output=$(gui_control 'ON_AFTER_REBOOT' '2' '' 'TEST_MODE')
@@ -372,8 +372,8 @@ function test_gui_control_local()
 
   # Test GUI OFF after reboot
   declare -a expected_cmd_seq=(
-    "sudo -- sh -c '${gui_off_after_reboot_cmd}'"
-    "sudo -- sh -c '${unbind_cmd}'"
+    "sudo bash -c '${gui_off_after_reboot_cmd}'"
+    "sudo bash -c '${unbind_cmd}'"
   )
 
   output=$(gui_control 'OFF_AFTER_REBOOT' '2' '' 'TEST_MODE')


### PR DESCRIPTION
Fixes #663

When kw drm --gui-[on|off] is executed outside a kernel tree, it produces
eval syntax errors due to improper quoting in the bind_control_cmd variable.

The issue was in line 263 where single quotes inside the command string
were prematurely ending the string, causing the shell to misinterpret the
for loop syntax when passed through eval in cmd_manager.

Changed from single quotes to double quotes and properly escaped the
inner variables to allow correct variable expansion and eval execution."