### PR TITLE
Add deploy setup force flag

### DIFF
--- a/documentation/man/features/kw-deploy.rst
+++ b/documentation/man/features/kw-deploy.rst
@@ -7,7 +7,7 @@ kw-deploy - Deploy kernel
 SYNOPSIS
 ========
 *kw* (*d* | *deploy*) [\--remote <remote>:<port> | \--local]
-                      [\--setup]
+                      [\--setup] [\--force-setup]
                       [-r | \--reboot] [\--no-reboot]
                       [-m | \--modules] [-s | \--ls-line]
                       [-l | \--list] [-a | \--list-all]
@@ -72,6 +72,11 @@ OPTIONS
 \--setup:
   This command runs a basic setup in the target machine, including installing
   packages and preparing the distro for the deploy.
+
+\--force-setup:
+  Force the setup command to run, even if the target machine appears to be
+  already configured. Useful when kw-related files were manually deleted
+  from the remote server.
 
 -m, \--modules:
   Only install/update modules.

--- a/src/_kw
+++ b/src/_kw
@@ -215,9 +215,10 @@ _kw_deploy()
       $force \
       '(-l --list -u --uninstall --setup -p --create-package -F --from-package -r --reboot --no-reboot -m --modules)'{-l,--list}'[list kernels]' \
       '(-s --ls-line -u --uninstall --setup -p --create-package -F --from-package -r --reboot --no-reboot -m --modules)'{-s,--ls-line}'[list kernels separeted by commas]' \
-      '(-l --list -s --ls-line -u --uninstall -p --create-package -F --from-package -r --reboot --no-reboot -m --modules)--setup[set up target machine for deploy]' \
-      '(-p --create-package -l --list -s --ls-line -u --uninstall --setup -F --from-package -r --reboot --no-reboot -m --modules)'{-p,--create-package}'[create kw package]' \
-      '(-F --from-package -l --list -s --ls-line -u --uninstall --setup -p --create-package)'{-F,--from-package}'[deploy from kw package]: : '
+      '(-l --list -s --ls-line -u --uninstall -p --create-package -F --from-package -r --reboot --no-reboot -m --modules --force-setup)--setup[set up target machine for deploy]' \
+      '(-l --list -s --ls-line -u --uninstall -p --create-package -F --from-package -r --reboot --no-reboot -m --modules --setup)--force-setup[force setup target machine for deploy]' \
+      '(-p --create-package -l --list -s --ls-line -u --uninstall --setup --force-setup -F --from-package -r --reboot --no-reboot -m --modules)'{-p,--create-package}'[create kw package]' \
+      '(-F --from-package -l --list -s --ls-line -u --uninstall --setup --force-setup -p --create-package)'{-F,--from-package}'[deploy from kw package]: : '
   fi
 }
 

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -26,7 +26,7 @@ function _kw_autocomplete()
   kw_options['b']="${kw_options['build']}"
 
   kw_options['deploy']='--remote --local --reboot --no-reboot --modules --list
-                        --list-all --ls-line --setup --uninstall --verbose
+                        --list-all --ls-line --setup --force-setup --uninstall --verbose
                         --force --create-package --from-package --boot-into-new-kernel-once'
   kw_options['d']="${kw_options['deploy']}"
 

--- a/src/kw.fish
+++ b/src/kw.fish
@@ -19,7 +19,7 @@ complete -c kw -n "__fish_kw_no_commands" -a "build b" -d "Build Kernel and modu
 complete -c kw -n "__fish_seen_subcommand_from build b" -l help -l info -l menu -l cpu-scaling -l ccache -l llvm -l clean -l full-cleanup -l verbose -l doc -l warnings -l save-log-to -l cflags -l from-sha
 
 complete -c kw -n "__fish_kw_no_commands" -a "deploy d" -d "Deploy kernel and modules"
-complete -c kw -n "__fish_seen_subcommand_from deploy d" -l remote -l local -l reboot -l no-reboot -l modules -l list -l list-all -l ls-line -l setup -l uninstall -l verbose -l force -l create-package -l from-package -l boot-into-new-kernel-once
+complete -c kw -n "__fish_seen_subcommand_from deploy d" -l remote -l local -l reboot -l no-reboot -l modules -l list -l list-all -l ls-line -l setup -l force-setup -l uninstall -l verbose -l force -l create-package -l from-package -l boot-into-new-kernel-once
 
 complete -c kw -n "__fish_kw_no_commands" -a "bd" -d "Build and deploy"
 complete -c kw -n "__fish_seen_subcommand_from bd" -l verbose

--- a/tests/unit/deploy_test.sh
+++ b/tests/unit/deploy_test.sh
@@ -820,6 +820,17 @@ function test_parse_deploy_options()
 
   unset options_values
   declare -gA options_values
+  parse_deploy_options --setup
+  assert_equals_helper 'Could not set deploy SETUP' "(${LINENO})" '1' "${options_values['SETUP']}"
+
+  unset options_values
+  declare -gA options_values
+  parse_deploy_options --force-setup
+  assert_equals_helper 'Could not set deploy SETUP with --force-setup' "(${LINENO})" '1' "${options_values['SETUP']}"
+  assert_equals_helper 'Could not set deploy FORCE_SETUP' "(${LINENO})" '1' "${options_values['FORCE_SETUP']}"
+
+  unset options_values
+  declare -gA options_values
   parse_deploy_options --uninstall 'kernel_xpto'
   assert_equals_helper 'Could not set deploy UNINSTALL' "(${LINENO})" "'kernel_xpto'" "${options_values['UNINSTALL']}"
 


### PR DESCRIPTION
When I run kw deploy --setup, I get the message:
"It looks like you are ready to use kw deploy."
However, I had manually deleted all kw-related files from the remote server, expecting the setup to run again, but it didn’t To work around this, I added a new force-setup command, which successfully re-triggers the remote setup.

Thanks for the feedback in #1210 