### PR TITLE
tests: unit: kw_db: Fix flaky kw_db_test and isolate DB state per test

### DIFF
--- a/tests/unit/lib/kw_db_test.sh
+++ b/tests/unit/lib/kw_db_test.sh
@@ -244,64 +244,64 @@ function test_select_from()
   # valid
   output=$(select_from 'pomodoro' "$entries" '' '')
   ret="$?"
-  expected=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT * FROM "pomodoro" ;')
+  expected=$(sqlite3 "${KW_DATA_DIR}/kw.db" -batch 'SELECT * FROM "pomodoro" ;')
   assert_equals_helper 'No error expected' "$LINENO" 0 "$ret"
   assert_equals_helper 'Wrong output' "$LINENO" "$expected" "$output"
 
   entries=$(concatenate_with_commas '"start_date"' '"start_time"' '"description"')
-  condition_array=(['start_time']='2021-11-18')
+  condition_array=(['start_date']='2021-11-18')
   output=$(select_from 'pomodoro' "$entries" '' 'condition_array')
   ret="$?"
-  expected=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT "start_date","start_time","description" FROM "pomodoro" WHERE start_time = '2021-11-18' ;')
+  expected=$(sqlite3 "${KW_DATA_DIR}/kw.db" -batch "SELECT \"start_date\",\"start_time\",\"description\" FROM \"pomodoro\" WHERE start_date = '2021-11-18' ;")
   assert_equals_helper 'No error expected' "$LINENO" 0 "$ret"
   assert_equals_helper 'Wrong output' "$LINENO" "$expected" "$output"
 
-  condition_array=(['start_time,=']='2021-11-18')
+  condition_array=(['start_date,=']='2021-11-18')
   output=$(select_from 'pomodoro' "$entries" '' 'condition_array')
   ret="$?"
-  expected=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT "start_date","start_time","description" FROM "pomodoro" WHERE start_time = '2021-11-18' ;')
+  expected=$(sqlite3 "${KW_DATA_DIR}/kw.db" -batch "SELECT \"start_date\",\"start_time\",\"description\" FROM \"pomodoro\" WHERE start_date = '2021-11-18' ;")
   assert_equals_helper 'No error expected' "$LINENO" 0 "$ret"
   assert_equals_helper 'Wrong output' "$LINENO" "$expected" "$output"
 
-  condition_array=(['start_time,<']='2021-11-18')
+  condition_array=(['start_date,<']='2021-11-18')
   output=$(select_from 'pomodoro' "$entries" '' 'condition_array')
   ret="$?"
-  expected=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT "start_date","start_time","description" FROM "pomodoro" WHERE start_time < '2021-11-18' ;')
+  expected=$(sqlite3 "${KW_DATA_DIR}/kw.db" -batch "SELECT \"start_date\",\"start_time\",\"description\" FROM \"pomodoro\" WHERE start_date < '2021-11-18' ;")
   assert_equals_helper 'No error expected' "$LINENO" 0 "$ret"
   assert_equals_helper 'Wrong output' "$LINENO" "$expected" "$output"
 
-  condition_array=(['start_time,<=']='2021-11-18')
+  condition_array=(['start_date,<=']='2021-11-18')
   output=$(select_from 'pomodoro' "$entries" '' 'condition_array')
   ret="$?"
-  expected=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT "start_date","start_time","description" FROM "pomodoro" WHERE start_time <= '2021-11-18' ;')
+  expected=$(sqlite3 "${KW_DATA_DIR}/kw.db" -batch "SELECT \"start_date\",\"start_time\",\"description\" FROM \"pomodoro\" WHERE start_date <= '2021-11-18' ;")
   assert_equals_helper 'No error expected' "$LINENO" 0 "$ret"
   assert_equals_helper 'Wrong output' "$LINENO" "$expected" "$output"
 
-  condition_array=(['start_time,>']='2021-11-18')
+  condition_array=(['start_date,>']='2021-11-18')
   output=$(select_from 'pomodoro' "$entries" '' 'condition_array')
   ret="$?"
-  expected=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT "start_date","start_time","description" FROM "pomodoro" WHERE start_time > '2021-11-18' ;')
+  expected=$(sqlite3 "${KW_DATA_DIR}/kw.db" -batch "SELECT \"start_date\",\"start_time\",\"description\" FROM \"pomodoro\" WHERE start_date > '2021-11-18' ;")
   assert_equals_helper 'No error expected' "$LINENO" 0 "$ret"
   assert_equals_helper 'Wrong output' "$LINENO" "$expected" "$output"
 
-  condition_array=(['start_time,>=']='2021-11-18')
+  condition_array=(['start_date,>=']='2021-11-18')
   output=$(select_from 'pomodoro' "$entries" '' 'condition_array')
   ret="$?"
-  expected=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT "start_date","start_time","description" FROM "pomodoro" WHERE start_time >= '2021-11-18' ;')
+  expected=$(sqlite3 "${KW_DATA_DIR}/kw.db" -batch "SELECT \"start_date\",\"start_time\",\"description\" FROM \"pomodoro\" WHERE start_date >= '2021-11-18' ;")
   assert_equals_helper 'No error expected' "$LINENO" 0 "$ret"
   assert_equals_helper 'Wrong output' "$LINENO" "$expected" "$output"
 
-  condition_array=(['start_time,!=']='2021-11-18')
+  condition_array=(['start_date,!=']='2021-11-18')
   output=$(select_from 'pomodoro' "$entries" '' 'condition_array')
   ret="$?"
-  expected=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT "start_date","start_time","description" FROM "pomodoro" WHERE start_time != '2021-11-18' ;')
+  expected=$(sqlite3 "${KW_DATA_DIR}/kw.db" -batch "SELECT \"start_date\",\"start_time\",\"description\" FROM \"pomodoro\" WHERE start_date != '2021-11-18' ;")
   assert_equals_helper 'No error expected' "$LINENO" 0 "$ret"
   assert_equals_helper 'Wrong output' "$LINENO" "$expected" "$output"
 
-  condition_array=(['start_time,<>']='2021-11-18')
+  condition_array=(['start_date,<>']='2021-11-18')
   output=$(select_from 'pomodoro' "$entries" '' 'condition_array')
   ret="$?"
-  expected=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT "start_date","start_time","description" FROM "pomodoro" WHERE start_time <> '2021-11-18' ;')
+  expected=$(sqlite3 "${KW_DATA_DIR}/kw.db" -batch "SELECT \"start_date\",\"start_time\",\"description\" FROM \"pomodoro\" WHERE start_date <> '2021-11-18' ;")
   assert_equals_helper 'No error expected' "$LINENO" 0 "$ret"
   assert_equals_helper 'Wrong output' "$LINENO" "$expected" "$output"
 }

--- a/tests/unit/lib/kw_db_test.sh
+++ b/tests/unit/lib/kw_db_test.sh
@@ -23,11 +23,22 @@ function oneTimeTearDown()
   rm -rf "$FAKE_DATA"
 }
 
+function setUp()
+{
+  # Ensure each test starts from a clean, deterministic db state
+  rm -f "${KW_DATA_DIR}/kw.db"
+  execute_sql_script "${DB_FILES}/init.sql" > /dev/null 2>&1
+  execute_sql_script "${DB_FILES}/insert.sql" > /dev/null 2>&1
+}
+
 function test_execute_sql_script()
 {
   local output
   local expected
   local ret
+
+  # This test validates db creation messaging, start from no db file
+  rm -f "${KW_DATA_DIR}/kw.db"
 
   output=$(execute_sql_script 'wrong/path/invalid_script.sql')
   ret="$?"


### PR DESCRIPTION
Good news!! @rodrigosiqueira, @davidbtadokoro

Remember that flaky DB unit test `kw_db_test.sh` that used to fail sometimes and always left us scratching our heads? hahaha, I hit it again while building kw on Debian today, so I decided to dig in for real. I got a deterministic repro and tracked down what was going on :)

#### How I reproduced:

You can trigger the failure 100% by forcing the process clock close to 20:00 UTC:

```
TZ=UTC faketime '2026-01-10 19:59:41' ./run_tests.sh test tests/unit/lib/kw_db_test.sh
```

**[faketime](https://github.com/wolfcw/libfaketime)** is a tool that fakes the current time for a command (it does this via `LD_PRELOAD`, intercepting libc calls like `time()`, etc). If you also set `TZ=UTC`, the fake wall clock matches what sqlite sees for `time('now')` and `date('now')` (those are UTC unless you explicitly add 'localtime').

#### What was happening:

`test_select_from()` was comparing `pomodoro.start_time` (HH:MM:SS) against a date literal (`'2021-11-18'`). In sqlite that ends up as a lexicographic string comparison, so the result depends on the current hour. The test also inserts rows using `time('now')` and `time('now','+10 minutes')`, so depending on whether you're before/after around 20:00, you can land on different sides of that comparison.

Also, the expected `sqlite3` invocations had broken bash quoting (single quotes inside single quotes), so the SQL argument parsing could vary depending on the environment.


#### What this MR changes

* Fix `test_select_from` to compare against `start_date` (YYYY-MM-DD), and make the expected `sqlite3` SQL properly quoted (passed as a single argument).

* Add per-test isolation, `setUp()` recreates `kw.db` from `init.sql` + `insert.sql` for each `test_*`. `test_execute_sql_script` still deletes the DB first to assert "Creating database"
