### PR TITLE
lib: introduce git helper library and migrate build.sh checks

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -2,6 +2,7 @@ include "${KW_LIB_DIR}/lib/kwlib.sh"
 include "${KW_LIB_DIR}/lib/kwio.sh"
 include "${KW_LIB_DIR}/lib/kw_config_loader.sh"
 include "${KW_LIB_DIR}/transition_functions.sh"
+include "${KW_LIB_DIR}/lib/git.sh"
 
 declare -gA options_values
 
@@ -140,32 +141,20 @@ function build_kernel_main()
 
   if [[ -n "$from_sha_arg" ]]; then
     # Check if there is a rebase in process.
-    if [[ -d .git/rebase-merge ]]; then
-      warning 'ERROR: Abort the repository rebase before continuing with build from sha (use "git rebase --abort")!'
-      return 125 # ECANCELED
-    elif [[ -f .git/MERGE_HEAD ]]; then
-      warning 'ERROR: Abort the repository merge before continuing with build from sha (use "git rebase --abort")!'
-      return 125 # ECANCELED
-    elif [[ -f .git/BISECT_LOG ]]; then
-      warning 'ERROR: Stop the repository bisect before continuing with build from sha (use "git bisect reset")!'
-      return 125 # ECANCELED
-    elif [[ -d .git/rebase-apply ]]; then
-      printf 'ERROR: Abort the repository patch apply before continuing with build from sha (use "git am --abort")!'
+    kw_git_is_repo_safe
+    if [[ "$?" != 0 ]]; then
       return 125 # ECANCELED
     fi
 
     # Check if given SHA represents real commit
-    cmd_manager 'SILENT' "git cat-file -e ${from_sha_arg}^{commit} 2> /dev/null"
+    kw_git_is_valid_commit "$from_sha_arg"
     if [[ "$?" != 0 ]]; then
-      complain "ERROR: The given SHA (${from_sha_arg}) does not represent a valid commit sha."
       return 22 # EINVAL
     fi
 
     # Check if given SHA is in working tree.
-    sha_base=$(git rev-parse --verify "$from_sha_arg")
-    merge_base=$(git merge-base "$from_sha_arg" HEAD)
-    if [[ "$sha_base" != "$merge_base" ]]; then
-      complain "ERROR: Given SHA (${from_sha_arg}) is invalid. Check if it is an ancestor of the branch head."
+    kw_git_is_ancestor "$from_sha_arg" HEAD
+    if [[ "$?" != 0 ]]; then
       return 22 # EINVAL
     fi
 

--- a/src/lib/git.sh
+++ b/src/lib/git.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-2.0
+#
+# Git helper functions for kworkflow
+
+# This function checks if the repository is in a safe state to perform operations
+# like rebase, merge, etc.
+# Return:
+# 0 if safe, 125 (ECANCELED) otherwise.
+kw_git_is_repo_safe()
+{
+  if [[ -d .git/rebase-merge ]]; then
+    warning 'ERROR: Abort the repository rebase before continuing with build from sha (use "git rebase --abort")!'
+    return 125 # ECANCELED
+  elif [[ -f .git/MERGE_HEAD ]]; then
+    warning 'ERROR: Abort the repository merge before continuing with build from sha (use "git rebase --abort")!'
+    return 125 # ECANCELED
+  elif [[ -f .git/BISECT_LOG ]]; then
+    warning 'ERROR: Stop the repository bisect before continuing with build from sha (use "git bisect reset")!'
+    return 125 # ECANCELED
+  elif [[ -d .git/rebase-apply ]]; then
+    printf 'ERROR: Abort the repository patch apply before continuing with build from sha (use "git am --abort")!'
+    return 125 # ECANCELED
+  fi
+}
+
+# Check if given SHA represents real commit
+# @from_sha_arg: The SHA to be checked
+# Return:
+# 0 if valid, 22 (EINVAL) otherwise.
+kw_git_is_valid_commit()
+{
+  local from_sha_arg="$1"
+  cmd_manager 'SILENT' "git cat-file -e ${from_sha_arg}^{commit} 2> /dev/null"
+  if [[ "$?" != 0 ]]; then
+    complain "ERROR: The given SHA (${from_sha_arg}) does not represent a valid commit sha."
+    return 22 # EINVAL
+  fi
+}
+
+# Check if given SHA is in working tree and ancestor of HEAD.
+# @from_sha_arg: The SHA to be checked
+# @head: The head reference (usually HEAD)
+# Return:
+# 0 if valid, 22 (EINVAL) otherwise.
+kw_git_is_ancestor()
+{
+  local from_sha_arg="$1"
+  local head="$2"
+  local sha_base
+  local merge_base
+
+  sha_base=$(git rev-parse --verify "$from_sha_arg")
+  merge_base=$(git merge-base "$from_sha_arg" "$head")
+  if [[ "$sha_base" != "$merge_base" ]]; then
+    complain "ERROR: Given SHA (${from_sha_arg}) is invalid. Check if it is an ancestor of the branch head."
+    return 22 # EINVAL
+  fi
+}

--- a/tests/unit/lib/git_test.sh
+++ b/tests/unit/lib/git_test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+include './src/lib/git.sh'
+include './tests/unit/utils.sh'
+
+setUp()
+{
+  mk_fake_kernel_root "$SHUNIT_TMPDIR"
+  cd "$SHUNIT_TMPDIR" || {
+    fail "($LINENO) It was not possible to move into temporary directory"
+    return
+  }
+}
+
+tearDown()
+{
+  cd "$original_dir" || {
+    fail "($LINENO) It was not possible to move back to original directory"
+    return
+  }
+}
+
+oneTimeSetUp()
+{
+  original_dir="$PWD"
+}
+
+function test_kw_git_is_repo_safe_no_git_dir()
+{
+  local ret
+
+  # Clean state - no git operations in progress
+  [[ -d '.git/rebase-merge' ]] && rm --recursive '.git/rebase-merge'
+  [[ -f '.git/MERGE_HEAD' ]] && rm '.git/MERGE_HEAD'
+  [[ -f '.git/BISECT_LOG' ]] && rm '.git/BISECT_LOG'
+  [[ -d '.git/rebase-apply' ]] && rm --recursive '.git/rebase-apply'
+
+  kw_git_is_repo_safe
+  ret="$?"
+
+  assertEquals "($LINENO) kw_git_is_repo_safe should return 0" 0 "$ret"
+}
+
+invoke_shunit


### PR DESCRIPTION
 Summary

This PR introduces a shared Git helper library and migrates existing git-related checks from `src/build.sh` into it.

The goal is to reduce duplicated git logic, improve maintainability, and enable unit testing of git-related behavior.

---

 Scope

- Adds a new shared library: `src/lib/git.sh`
- Moves existing git safety checks (rebase, merge, bisect, patch-apply) from `src/build.sh` into the library
- Updates `src/build.sh` to use the new helper functions
- Adds initial unit test scaffolding for the git library

---

## Behavior Preservation

- Logic is copied **verbatim** from `src/build.sh`
- Error messages, return codes, and control flow are unchanged
- No functional or behavioral changes are introduced

---

## Out of Scope

- No refactoring or simplification of existing logic
- No new git helpers beyond migrated functionality
- No changes to user-facing behavior

---

## Verification

### Automated
- `make test`
- Unit tests under `tests/unit/lib/`

### Manual
- Verified that `kw build` still blocks execution during:
  - active rebase
  - active merge
  - active bisect
  - active patch apply

---

## Follow-up Work

- Incrementally migrate additional git-related logic to the shared library
- Expand unit test coverage for `src/lib/git.sh`
