### PR TITLE
src: lib: kwlib: Remove '=' from base64

### DIFF
--- a/src/lib/kwlib.sh
+++ b/src/lib/kwlib.sh
@@ -654,7 +654,7 @@ function get_current_env_name()
 # Returns 0 and prints ${PWD}, base64-encoded
 function get_encoded_pwd()
 {
-  printf '%s' "$PWD" | base64 --wrap=0
+  printf '%s' "$PWD" | base64 --wrap=0 | tr --delete '='
 
   return 0
 }

--- a/tests/unit/lib/kwlib_test.sh
+++ b/tests/unit/lib/kwlib_test.sh
@@ -795,7 +795,7 @@ function test_get_encoded_pwd()
   }
 
   result=$(get_encoded_pwd)
-  expected="$(printf '%s' "$PWD" | base64 --wrap=0)"
+  expected="$(printf '%s' "$PWD" | base64 --wrap=0 | tr --delete '=')"
   assertEquals "(${LINENO}) - Should return base64(PWD)" "$expected" "$result"
 
   cd "${ORIGINAL_DIR}" || {


### PR DESCRIPTION
When certain environments are created in specific folders, an '=' character is added to the base64 output, which is not part of the base64 output. Unfortunately, leaving this '=' can cause issues when managing folders. This commit removes the '=' character at the end.