### PR TITLE
src: lib: kw_db: Create default database on first use

### DIFF
--- a/kw
+++ b/kw
@@ -24,6 +24,7 @@ if [[ -f "$KW_SYSTEM_WIDE_INSTALLATION" ]]; then
   KW_LIB_DIR='/usr/share/kw'
   KW_SOUND_DIR='/usr/share/sounds/kw'
   KW_DOC_DIR='/usr/share/doc/kw/html/'
+  KW_DB_DIR='/usr/share/kw/database'
   KW_ETC_DIR='/etc/kw'
 else
   KW_LIB_DIR="${KW_LIB_DIR:-"${HOME}/.local/lib"}/${KWORKFLOW}"

--- a/src/lib/kw_db.sh
+++ b/src/lib/kw_db.sh
@@ -32,6 +32,51 @@ function execute_sql_script()
   sqlite3 -init "$KW_DB_DIR/pre_cmd.sql" "$db_path" < "$sql_path"
 }
 
+# This function creates the default user database when it is missing.
+#
+# Return:
+# 0 if the database exists or was created
+# 1 if the database directory could not be created
+# 2 if the database SQL file is missing
+# non-zero from execute_sql_script if database creation fails
+function ensure_default_database_exists()
+{
+  local db_path
+  local sql_path="${KW_DB_DIR}/kwdb.sql"
+
+  db_path="$(join_path "$KW_DATA_DIR" "$DB_NAME")"
+
+  [[ -f "$db_path" ]] && return 0
+
+  if [[ ! -f "$sql_path" ]]; then
+    complain "Could not find the file: ${sql_path}"
+    return 2 # ENOENT
+  fi
+
+  mkdir --parents "$KW_DATA_DIR"
+  if [[ "$?" != 0 ]]; then
+    complain "Could not create database directory: ${KW_DATA_DIR}"
+    return 1 # EPERM
+  fi
+
+  execute_sql_script "$sql_path" "$DB_NAME" "$KW_DATA_DIR" > /dev/null
+}
+
+# This function checks if the given database target is kw's default database.
+#
+# @db:        Name of the database file
+# @db_folder: Path to the folder that contains @db
+#
+# Return:
+# 0 if the target is the default database; non-zero otherwise
+function is_default_database_target()
+{
+  local db="$1"
+  local db_folder="$2"
+
+  [[ "$db" == "$DB_NAME" && "$db_folder" == "$KW_DATA_DIR" ]]
+}
+
 # This function reads and executes a SQL script in the database
 #
 # @sql_cmd:   SQL command to be executed on @db
@@ -49,6 +94,10 @@ function execute_command_db()
   local db_path
 
   db_path="$(join_path "$db_folder" "$db")"
+
+  if [[ ! -f "$db_path" ]] && is_default_database_target "$db" "$db_folder"; then
+    ensure_default_database_exists
+  fi
 
   if [[ ! -f "$db_path" ]]; then
     complain 'Database does not exist'
@@ -81,6 +130,10 @@ function insert_into()
   local cmd
 
   db_path="$(join_path "$db_folder" "$db")"
+
+  if [[ ! -f "$db_path" ]] && is_default_database_target "$db" "$db_folder"; then
+    ensure_default_database_exists
+  fi
 
   if [[ ! -f "$db_path" ]]; then
     complain 'Database does not exist'
@@ -124,6 +177,10 @@ function replace_into()
 
   db_path="$(join_path "$db_folder" "$db")"
 
+  if [[ ! -f "$db_path" ]] && is_default_database_target "$db" "$db_folder"; then
+    ensure_default_database_exists
+  fi
+
   if [[ ! -f "$db_path" ]]; then
     complain 'Database does not exist'
     return 2 # ENOENT
@@ -163,6 +220,10 @@ function remove_from()
   local db_path
 
   db_path="$(join_path "${db_folder}" "$db")"
+
+  if [[ ! -f "$db_path" ]] && is_default_database_target "$db" "$db_folder"; then
+    ensure_default_database_exists
+  fi
 
   if [[ ! -f "${db_path}" ]]; then
     complain 'Database does not exist'
@@ -212,6 +273,10 @@ function select_from()
   local query
 
   db_path="$(join_path "$db_folder" "$db")"
+
+  if [[ ! -f "$db_path" ]] && is_default_database_target "$db" "$db_folder"; then
+    ensure_default_database_exists
+  fi
 
   if [[ ! -f "$db_path" ]]; then
     complain 'Database does not exist'
@@ -267,6 +332,10 @@ function update_into()
   local query
 
   db_path="$(join_path "$db_folder" "$db")"
+
+  if [[ ! -f "$db_path" ]] && is_default_database_target "$db" "$db_folder"; then
+    ensure_default_database_exists
+  fi
 
   if [[ ! -f "$db_path" ]]; then
     complain 'Database does not exist'

--- a/tests/unit/lib/kw_db_test.sh
+++ b/tests/unit/lib/kw_db_test.sh
@@ -26,7 +26,7 @@ function oneTimeTearDown()
 function setUp()
 {
   # Ensure each test starts from a clean, deterministic db state
-  rm -f "${KW_DATA_DIR}/kw.db"
+  rm --force "${KW_DATA_DIR}/kw.db"
   execute_sql_script "${DB_FILES}/init.sql" > /dev/null 2>&1
   execute_sql_script "${DB_FILES}/insert.sql" > /dev/null 2>&1
 }
@@ -38,7 +38,7 @@ function test_execute_sql_script()
   local ret
 
   # This test validates db creation messaging, start from no db file
-  rm -f "${KW_DATA_DIR}/kw.db"
+  rm --force "${KW_DATA_DIR}/kw.db"
 
   output=$(execute_sql_script 'wrong/path/invalid_script.sql')
   ret="$?"
@@ -71,6 +71,44 @@ function test_execute_sql_script()
 
   output=$(sqlite3 "$KW_DATA_DIR/kw.db" -batch 'SELECT count(rowid) FROM statistics;')
   assert_equals_helper 'Expected 4 statistic entries' "$LINENO" 4 "$output"
+}
+
+function test_default_database_is_created_on_insert()
+{
+  local columns='("label_name","status","date","time","elapsed_time_in_secs")'
+  local rows="('build','success','2026-05-16','12:00:00','1')"
+  local output
+  local ret
+
+  rm --force "${KW_DATA_DIR}/kw.db"
+
+  output=$(insert_into '"statistics_report"' "$columns" "$rows")
+  ret="$?"
+
+  assert_equals_helper 'Default database should be created on demand' "$LINENO" 0 "$ret"
+  assertTrue "($LINENO) DB file should be created" '[[ -f "${KW_DATA_DIR}/kw.db" ]]'
+
+  output=$(sqlite3 "${KW_DATA_DIR}/kw.db" -batch 'SELECT count(*) FROM "statistics_report" ;')
+  assert_equals_helper 'Expected one statistics entry' "$LINENO" 1 "$output"
+}
+
+function test_insert_into_non_default_database_is_not_created()
+{
+  local columns='("label_name","status","date","time","elapsed_time_in_secs")'
+  local rows="('build','success','2026-05-16','12:00:00','1')"
+  local output
+  local expected
+  local ret
+
+  rm --force "${KW_DATA_DIR}/custom.db"
+
+  output=$(insert_into '"statistics_report"' "$columns" "$rows" 'custom.db')
+  ret="$?"
+  expected='Database does not exist'
+
+  assert_equals_helper 'Non-default database should not be created on demand' "$LINENO" 2 "$ret"
+  assert_equals_helper 'Expected old missing database error' "$LINENO" "$expected" "$output"
+  assertFalse "($LINENO) Custom DB file should not be created" '[[ -f "${KW_DATA_DIR}/custom.db" ]]'
 }
 
 function test_format_values_db()


### PR DESCRIPTION
Create the default per-user `kw.db` when the database helpers access the default database and the file is missing.

This fixes packaged installations where setup.sh is not run per user, so commands such as kw build can record statistics without ending with `"Database does not exist"`.

Explicit non-default database paths still report `ENOENT` as before.