### PR TITLE
src: lib: kwio: Skip empty alert commands

### DIFF
--- a/src/lib/kwio.sh
+++ b/src/lib/kwio.sh
@@ -18,6 +18,7 @@ function alert_completion()
   local COMMAND=$1
   local ALERT_OPT=$2
   local opts
+  local alert_command
 
   if [[ $# -gt 1 && "$ALERT_OPT" =~ ^--alert= ]]; then
     opts="$(printf '%s\n' "$ALERT_OPT" | sed s/--alert=//)"
@@ -27,19 +28,25 @@ function alert_completion()
 
   while read -rN 1 option; do
     if [ "$option" == 'v' ]; then
-      if command_exists "${notification_config[visual_alert_command]}"; then
-        eval "${notification_config[visual_alert_command]} &"
+      alert_command="${notification_config[visual_alert_command]}"
+      if [[ -z "$alert_command" ]]; then
+        warning 'Visual alert command is not configured.'
+      elif command_exists "$alert_command"; then
+        eval "$alert_command &"
       else
         warning 'The following command set in the visual_alert_command variable could not be run:'
-        warning "${notification_config[visual_alert_command]}"
+        warning "$alert_command"
         warning 'Check if the necessary packages are installed.'
       fi
     elif [ "$option" == 's' ]; then
-      if command_exists "${notification_config[sound_alert_command]}"; then
-        eval "${notification_config[sound_alert_command]} &"
+      alert_command="${notification_config[sound_alert_command]}"
+      if [[ -z "$alert_command" ]]; then
+        warning 'Sound alert command is not configured.'
+      elif command_exists "$alert_command"; then
+        eval "$alert_command &"
       else
         warning 'The following command set in the sound_alert_command variable could not be run:'
-        warning "${notification_config[sound_alert_command]}"
+        warning "$alert_command"
         warning 'Check if the necessary packages are installed.'
       fi
     fi

--- a/tests/unit/lib/kwio_test.sh
+++ b/tests/unit/lib/kwio_test.sh
@@ -126,6 +126,19 @@ function test_alert_completion_sound_alert()
   assertEquals 'Variable s should exist.' "$expected" "$output"
 }
 
+function test_alert_completion_empty_alert_commands()
+{
+  local output
+
+  notification_config['sound_alert_command']=''
+  notification_config['visual_alert_command']=''
+
+  output="$(alert_completion '' '--alert=vs' 2>&1)"
+
+  assert_line_match "$LINENO" 'Visual alert command is not configured.' "$output"
+  assert_line_match "$LINENO" 'Sound alert command is not configured.' "$output"
+}
+
 function test_ask_with_default()
 {
   local output=''


### PR DESCRIPTION
Avoid evaluating an empty notification command when sound or visual alerts are requested but the corresponding command is unset.

This prevents shell syntax errors such as `eval: syntax error near unexpected token '&'` in packaged or partially configured installations while preserving the existing warning path for configured commands that are unavailable.