### PR TITLE
bug: Fixes "kw deploy --modules" not running.

### DIFF
--- a/src/plugins/kernel_install/kw_remote_proxy_hub.sh
+++ b/src/plugins/kernel_install/kw_remote_proxy_hub.sh
@@ -143,6 +143,7 @@ include "${REMOTE_KW_DEPLOY}/${distro}.sh"
 
 case "$action" in
   'modules')
+    include "${REMOTE_KW_DEPLOY}/install.sh"
     # shellcheck disable=SC2068
     install_modules ${action_parameters[@]}
     ;;


### PR DESCRIPTION
Currently, "kw deploy --modules" fails because it can't find the install_modules functions. It had been moved to "install.sh", but it was not included before running it when using the "--modules" option. This simply includes the file right before running the function.