### PR TITLE
tests: unit: Fix return value of compare_command_sequence for single …

### DIFF
--- a/tests/unit/utils.sh
+++ b/tests/unit/utils.sh
@@ -368,6 +368,8 @@ function mk_fake_kw_env()
 # @line $LINENO variable
 # @expected_res Name of the array variable containing expected strings
 # @result_to_compare A raw output from the string
+# Compare a sequence of commands output
+# Note: For single-line outputs, the use of assertEquals is highly recommended over compare_command_sequence.
 function compare_command_sequence()
 {
   local msg="$1"
@@ -386,7 +388,7 @@ function compare_command_sequence()
           "$KW_COLOR_RED" "$KW_COLOR_NONE" "$KW_COLOR_RED" "${f}" "$KW_COLOR_NONE"
       fi
     fi
-    ((count++))
+    ((++count))
   done <<< "$result_to_compare"
 }
 


### PR DESCRIPTION
…line outputs

The compare_command_sequence function was returning an exit status of 1 for single-line outputs even when the comparison matched. This happened because the postfix increment ((count++)) evaluates to 0 on the first iteration, causing bash to return an error status.

This patch changes the increment to a prefix evaluation ((++count)) to ensure a successful exit status.

Additionally, a comment was added to the function header to explicitly recommend the use of assertEquals over compare_command_sequence for single-line output comparisons.

Fixes #1142