### PR TITLE
Feature: Add a uninstall-all / -U option to remove all KW installed 

### DIFF
--- a/documentation/man/features/kw-deploy.rst
+++ b/documentation/man/features/kw-deploy.rst
@@ -11,7 +11,7 @@ SYNOPSIS
                       [-r | \--reboot] [\--no-reboot]
                       [-m | \--modules] [-s | \--ls-line]
                       [-l | \--list] [-a | \--list-all]
-                      [(-u | \--uninstall) [<kernel-name>[,...]]] [-f \--force]
+                      [(-u | \--uninstall) [<kernel-name>[,...]]] [(-U | \--uninstall-all)] [-f \--force]
                       [\--alert=(s | v | (sv | vs) | n)]
                       [-p | \--create-package]
                       [(-F | \--from-package) <kw-package-path>]
@@ -90,6 +90,10 @@ OPTIONS
   multiple kernels it is necessary to separate them with comma. A regex pattern
   can also be passed as input, prefixed with 'regex:'. If no kernel name is
   provided, remove the first kernel managed by kw it encounters.
+
+-U, \--uninstall-all:
+  Remove all kernels installed by kw. Before proceeding, a confirmation
+  prompt lists every kernel to be removed and waits for user approval.
 
 -f, \--force:
   Remove kernels even if they were not installed by kw (only valid with
@@ -173,3 +177,13 @@ Below are examples of how to use `kw deploy --uninstall`:
 4) Removes the first kernel managed by kw:
 
   kw deploy --uninstall
+
+Below are examples of how to use `kw deploy --uninstall-all`:
+
+5) Remove all kw-managed kernels
+
+  kw deploy --uninstall-all
+
+6) Remove all kw-managed kernels and reboot
+
+  kw deploy --uninstall-all --reboot

--- a/src/bash_autocomplete.sh
+++ b/src/bash_autocomplete.sh
@@ -26,7 +26,7 @@ function _kw_autocomplete()
   kw_options['b']="${kw_options['build']}"
 
   kw_options['deploy']='--remote --local --reboot --no-reboot --modules --list
-                        --list-all --ls-line --setup --uninstall --verbose
+                        --list-all --ls-line --setup --uninstall --uninstall-all --verbose
                         --force --create-package --from-package --boot-into-new-kernel-once'
   kw_options['d']="${kw_options['deploy']}"
 

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -37,8 +37,8 @@ declare REMOTE_INTERACE_CMD_PREFIX
 declare LOCAL_TO_DEPLOY_DIR
 declare LOCAL_REMOTE_DIR
 
-all_long_options='remote:,local,reboot,no-reboot,modules,list,ls-line,uninstall::,list-all,force,setup,verbose,create-package,from-package:,boot-into-new-kernel-once'
-all_short_options='r,m,l,s,u::,a,f,v,p,F:,n'
+all_long_options='remote:,local,reboot,no-reboot,modules,list,ls-line,uninstall::,list-all,force,setup,verbose,create-package,from-package:,boot-into-new-kernel-once,uninstall-all'
+all_short_options='r,m,l,s,u::,a,f,v,p,F:,n,U'
 
 deploy_unprocess_param=''
 
@@ -74,6 +74,7 @@ function deploy_main()
   local single_line=0
   local uninstall=''
   local uninstall_remove_first=''
+  local uninstall_all=''
   local start=0
   local end=0
   local runtime=0
@@ -89,7 +90,9 @@ function deploy_main()
   local cache_to_deploy_path
   local boot_into_new_kernel_once
   local force
-  local encoded_pwd=$(get_encoded_pwd)
+  local encoded_pwd
+
+  encoded_pwd=$(get_encoded_pwd)
 
   # Drop build_and_deploy flag
   shift
@@ -136,6 +139,7 @@ function deploy_main()
   list="${options_values['LS']}"
   uninstall="${options_values['UNINSTALL']}"
   uninstall_remove_first="${options_values['UNINSTALL_REMOVE_FIRST']}"
+  uninstall_all="${options_values['UNINSTALL_ALL']}"
   force="${options_values['FORCE']}"
   setup="${options_values['SETUP']}"
   boot_into_new_kernel_once="${options_values['BOOT_INTO_NEW_KERNEL_ONCE']}"
@@ -163,6 +167,11 @@ function deploy_main()
     fi
 
     return "$?"
+  fi
+
+  if [[ -n "$uninstall_all" ]]; then
+    options_values['UNINSTALL']='__kw_uninstall_all__'
+    uninstall='__kw_uninstall_all__'
   fi
 
   # Uninstall option
@@ -1469,8 +1478,8 @@ function parse_deploy_options()
   local after_options
   local long_options='list,ls-line,uninstall::'
   long_options+=',list-all,setup,verbose,from-package:'
-  long_options+=',boot-into-new-kernel-once'
-  local short_options='r,m,l,s,u::,a,f,v,p,F:,n'
+  long_options+=',boot-into-new-kernel-once,uninstall-all'
+  local short_options='r,m,l,s,u::,a,f,v,p,F:,n,U'
   local ret_options
 
   all_options="$(kw_parse "$all_short_options" "$all_long_options" "$@")"
@@ -1546,6 +1555,11 @@ function parse_deploy_options()
         options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=1
         shift 2
         ;;
+      --uninstall-all | -U)
+        options_values['UNINSTALL_ALL']=1
+        options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=1
+        shift
+        ;;
       --) # End of options, beginning of arguments
         # The uninstall command already handled parameters after --
         after_options=${options##*'--'}
@@ -1588,6 +1602,7 @@ function deploy_help()
     '  deploy - installs kernel and modules:' \
     '  deploy (--setup) - set up target machine for deploy' \
     '  deploy (--uninstall | -u) [(--force | -f)] [<kernel-name>,...] - uninstall kernels' \
+    '  deploy (--uninstall-all | -U) - uninstall all kernels' \
     '  deploy (--list | -l) - list kernels' \
     '  deploy (--ls-line | -s) - list kernels separeted by commas' \
     '  deploy (--list-all | -a) - list all available kernels' \

--- a/src/deploy.sh
+++ b/src/deploy.sh
@@ -174,23 +174,6 @@ function deploy_main()
     uninstall='__kw_uninstall_all__'
   fi
 
-  # Uninstall option
-  if [[ -n "$uninstall" || -n "$uninstall_remove_first" ]]; then
-    start=$(date +%s)
-    run_kernel_uninstall "$target" "$reboot" "$uninstall" "$force" "$flag"
-    ret="$?"
-    end=$(date +%s)
-    runtime=$((end - start))
-
-    if [[ "$ret" == 0 ]]; then
-      statistics_manager 'uninstall' "$start" "$runtime" '' "$flag"
-    else
-      statistics_manager 'uninstall' "$start" "$runtime" 'failure' "$flag"
-    fi
-
-    return "$?"
-  fi
-
   prepare_host_deploy_dir
 
   # We don't want to run the setup if the user request the package creation
@@ -219,6 +202,23 @@ function deploy_main()
     fi
 
     collect_target_info_for_deploy "$target" "$flag"
+  fi
+
+  # Uninstall option
+  if [[ -n "$uninstall" || -n "$uninstall_remove_first" ]]; then
+    start=$(date +%s)
+    run_kernel_uninstall "$target" "$reboot" "$uninstall" "$force" "$flag"
+    ret="$?"
+    end=$(date +%s)
+    runtime=$((end - start))
+
+    if [[ "$ret" == 0 ]]; then
+      statistics_manager 'uninstall' "$start" "$runtime" '' "$flag"
+    else
+      statistics_manager 'uninstall' "$start" "$runtime" 'failure' "$flag"
+    fi
+
+    return "$?"
   fi
 
   # NOTE: If we deploy a new kernel image that does not match with the modules,

--- a/src/plugins/kernel_install/uninstall.sh
+++ b/src/plugins/kernel_install/uninstall.sh
@@ -51,17 +51,35 @@ function kernel_uninstall()
   process_installed_kernels '' "$prefix" 'kw_managed_kernels' "$target"
   total_kernels_managed_by_kw="$?"
 
-  IFS=', ' read -r -a kernel_names_array <<< "$kernel_list_string_or_regex"
-
-  if [[ "$kernel_list_string_or_regex" != "''" ]]; then
-    kernel_to_be_removed_based_on_user_input 'kernel_names_array' 'all_installed_kernels' 'kernel_to_remove'
-    ret="$?"
-  # If user does not provide any input, remove the first kernel managed by kw
-  else
-    kernel_to_remove[0]="${kw_managed_kernels[0]}"
+  if [[ "$kernel_list_string_or_regex" == '__kw_uninstall_all__' ]]; then
     if [[ "$total_kernels_managed_by_kw" -eq 0 ]]; then
       printf '%s\n' 'There is no kernel managed by kw.'
-      return 0 # There is no kernel managed by kw, in this case ignore -u with no parameter
+      return 0
+    fi
+    printf '%s\n' 'The following kernels installed with kw will be removed:'
+    for kernel in "${kw_managed_kernels[@]}"; do
+      printf '  %s\n' "$kernel"
+    done
+    printf 'Uninstalling %s kw deployed kernels. Continue? [y/N] ' "$total_kernels_managed_by_kw"
+    read -r reply
+    printf '\n'
+    if [[ ! "$reply" =~ ^[Yy]$ ]]; then
+      printf '%s\n' 'Aborting...'
+      return 0
+    fi
+    kernel_to_remove=("${kw_managed_kernels[@]}")
+  else
+    IFS=', ' read -r -a kernel_names_array <<< "$kernel_list_string_or_regex"
+
+    if [[ "$kernel_list_string_or_regex" != "''" ]]; then
+      kernel_to_be_removed_based_on_user_input 'kernel_names_array' 'all_installed_kernels' 'kernel_to_remove'
+      ret="$?"
+    else
+      kernel_to_remove[0]="${kw_managed_kernels[0]}"
+      if [[ "$total_kernels_managed_by_kw" -eq 0 ]]; then
+        printf '%s\n' 'There is no kernel managed by kw.'
+        return 0 # There is no kernel managed by kw, in this case ignore -u with no parameter
+      fi
     fi
   fi
 

--- a/tests/unit/deploy_test.sh
+++ b/tests/unit/deploy_test.sh
@@ -678,6 +678,19 @@ function test_kernel_uninstall()
   assert_equals_helper 'Regex option' "$LINENO" "$run_kernel_uninstall_cmd" "$output"
 }
 
+function test_kernel_uninstall_all_remote()
+{
+  local deploy_remote_cmd="$DEPLOY_REMOTE_PREFIX"
+  local run_kernel_uninstall_cmd="${CONFIG_SSH} ${CONFIG_REMOTE}"
+
+  deploy_remote_cmd+=" --uninstall-kernels 'debian' '0' 'remote' '__kw_uninstall_all__' 'TEST_MODE' ''"
+
+  run_kernel_uninstall_cmd+=" sudo \"${deploy_remote_cmd}\""
+
+  output=$(run_kernel_uninstall 3 0 '__kw_uninstall_all__' '' 'TEST_MODE')
+  assert_equals_helper 'Uninstall-all sends sentinel to remote' "$LINENO" "$run_kernel_uninstall_cmd" "$output"
+}
+
 function test_cleanup()
 {
   local output=''
@@ -832,6 +845,19 @@ function test_parse_deploy_options()
   declare -gA options_values
   parse_deploy_options 'TEST_MODE'
   assert_equals_helper 'Could not set deploy TEST_MODE' "(${LINENO})" 'TEST_MODE' "${options_values['TEST_MODE']}"
+
+  unset options_values
+  declare -gA options_values
+  parse_deploy_options --uninstall-all
+  assert_equals_helper 'Could not set deploy UNINSTALL_ALL' "(${LINENO})" '1' "${options_values['UNINSTALL_ALL']}"
+
+  unset options_values
+  declare -gA options_values
+  parse_deploy_options -U
+  assert_equals_helper 'Could not set deploy UNINSTALL_ALL with -U' "(${LINENO})" '1' "${options_values['UNINSTALL_ALL']}"
+
+  parse_deploy_options --uninstall-all
+  assertTrue "(${LINENO}) - Should allow outside kernel tree" "[[ -n ${options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']} ]]"
 
   # test invalid options
   parse_deploy_options --an-invalid-option
@@ -1275,6 +1301,10 @@ function test_run_commands_outside_kernel_tree()
   options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=''
   parse_deploy_options --uninstall 'some_kernel'
   assertTrue "(${LINENO}) - Should uninstall outside kernel tree" "[[ -n ${options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']} ]]"
+
+  options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']=''
+  parse_deploy_options --uninstall-all
+  assertTrue "(${LINENO}) - Should uninstall-all outside kernel tree" "[[ -n ${options_values['CAN_RUN_OUTSIDE_KERNEL_TREE']} ]]"
 
   cd "$original" || {
     fail "(${LINENO}) It was not possible to move back from temp directory"

--- a/tests/unit/plugins/kernel_install/uninstall_test.sh
+++ b/tests/unit/plugins/kernel_install/uninstall_test.sh
@@ -875,4 +875,148 @@ function test_remove_systemd_kernel_files()
   assert_equals_helper 'Wrong kernel-install remove command' "$LINENO" "$expected_cmd" "$output"
 }
 
+function test_kernel_uninstall_all_with_sentinel()
+{
+  local kernel_name_1='5.5.0-rc2-VKMS+'
+  local kernel_name_2='5.6.0-rc2-AMDGPU+'
+  local mkinitcpio_d_path_1="etc/mkinitcpio.d/${kernel_name_1}.preset"
+  local mkinitcpio_d_path_2="etc/mkinitcpio.d/${kernel_name_2}.preset"
+  local boot_files_1
+  local boot_files_2
+  local output
+  local index
+
+  cd "$SHUNIT_TMPDIR" || {
+    fail "(${LINENO}) It was not possible to move to temporary directory"
+    return
+  }
+
+  # Composing expected command sequence
+  local -a cmd_sequence=(
+    "mkdir --parents ${REMOTE_KW_DEPLOY}"
+    "touch '${INSTALLED_KERNELS_PATH}'"
+    'The following kernels installed with kw will be removed:'
+    "${kernel_name_1}"
+    "${kernel_name_2}"
+    "Uninstalling 2 kw deployed kernels. Continue? [y/N]"
+    "Removing: ${kernel_name_1}"
+  )
+
+  index=${#cmd_sequence[@]}
+
+  mapfile -t boot_files_1 < <(find "${TARGET_PATH}/boot/" -name "*${kernel_name_1}*" | sort --dictionary)
+  for file in "${boot_files_1[@]}"; do
+    cmd_sequence["$((index++))"]="Removing: ${file}"
+    cmd_sequence["$((index++))"]="rm ${file}"
+  done
+
+  cmd_sequence["$((index++))"]="Can't find ${TARGET_PATH}/${mkinitcpio_d_path_1}"
+  cmd_sequence["$((index++))"]="Can't find ${TARGET_PATH}/var/lib/initramfs-tools/${kernel_name_1}"
+  cmd_sequence["$((index++))"]="Can't find ${TARGET_PATH}/lib/modules/${kernel_name_1}"
+  cmd_sequence["$((index++))"]="sed --in-place '/${kernel_name_1}/d' '$INSTALLED_KERNELS_PATH'"
+
+  cmd_sequence["$((index++))"]="Removing: ${kernel_name_2}"
+
+  mapfile -t boot_files_2 < <(find "${TARGET_PATH}/boot/" -name "*${kernel_name_2}*" | sort --dictionary)
+  for file in "${boot_files_2[@]}"; do
+    cmd_sequence["$((index++))"]="Removing: ${file}"
+    cmd_sequence["$((index++))"]="rm ${file}"
+  done
+
+  cmd_sequence["$((index++))"]="Can't find ${TARGET_PATH}/${mkinitcpio_d_path_2}"
+  cmd_sequence["$((index++))"]="Can't find ${TARGET_PATH}/var/lib/initramfs-tools/${kernel_name_2}"
+  cmd_sequence["$((index++))"]="Can't find ${TARGET_PATH}/lib/modules/${kernel_name_2}"
+  cmd_sequence["$((index++))"]="sed --in-place '/${kernel_name_2}/d' '$INSTALLED_KERNELS_PATH'"
+  cmd_sequence["$((index++))"]="update-grub"
+
+  # Check
+  output="$(
+    reply='y'
+
+    function read()
+    {
+      :
+    }
+
+    function does_the_system_uses_systemd()
+    {
+      return 95
+    }
+
+    function is_filesystem_writable()
+    {
+      return 0
+    }
+
+    function migrate_old_kernel_list()
+    {
+      return 0
+    }
+
+    function process_installed_kernels()
+    {
+      local all_kernels="$1"
+      local prefix="$2"
+      local -n _mock_kernels="$3"
+
+      _mock_kernels[0]="$kernel_name_1"
+      _mock_kernels[1]="$kernel_name_2"
+      return 2
+    }
+
+    kernel_uninstall 'debian' 0 'remote' '__kw_uninstall_all__' 'TEST_MODE' '' "$SHUNIT_TMPDIR"
+  )"
+
+  compare_command_sequence '' "$LINENO" 'cmd_sequence' "$output"
+
+  cd "$TEST_ROOT_PATH" || {
+    fail "(${LINENO}) It was not possible to move back from temp directory"
+    return
+  }
+}
+
+function test_kernel_uninstall_all_sentinel_empty_list()
+{
+  local output
+
+  cd "$SHUNIT_TMPDIR" || {
+    fail "(${LINENO}) It was not possible to move to temporary directory"
+    return
+  }
+
+  local -a cmd_sequence=(
+    "mkdir --parents ${REMOTE_KW_DEPLOY}"
+    "touch '${INSTALLED_KERNELS_PATH}'"
+    'There is no kernel managed by kw.'
+  )
+
+  output="$(
+    function migrate_old_kernel_list()
+    {
+      return 0
+    }
+
+    function is_filesystem_writable()
+    {
+      return 0
+    }
+
+    function process_installed_kernels()
+    {
+      local all_kernels="$1"
+      local prefix="$2"
+      local -n _mock_registry="$3"
+    }
+
+    kernel_uninstall 'debian' 0 'remote' '__kw_uninstall_all__' 'TEST_MODE' '' "$SHUNIT_TMPDIR"
+  )"
+
+  compare_command_sequence '' "$LINENO" 'cmd_sequence' "$output"
+
+  cd "$TEST_ROOT_PATH" || {
+    fail "(${LINENO}) It was not possible to move back from temp directory"
+    return
+  }
+}
+
 invoke_shunit


### PR DESCRIPTION
I had over 10 kernels installed to my test machine once.
This PR adds an option to clean them all up :)

Besides the feature, I had to change the plugin-setup to happen before uninstalling, because kw would not update the plugin in my test machine.

Example:
```
kw d --remote notebook --uninstall-all
...
The following kernels installed with kw will be removed:
  7.1.0rcpassos-09396-ga0b17e9f6cee
  7.2.0-rc5rcpassos-00048-gfc02acf6ac0c
  7.2.0-rc5rcpassos-dirty
Uninstalling 23 kw deployed kernels. Continue? [y/N]
```

After running it:
```
kw d --remote notebook -U
There is no kernel managed by kw.
-> Execution time: 00:00:00
```